### PR TITLE
Fix docker compose startup parsing and local env noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __pycache__/
 .coverage*
 dist/
 build/
+
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,12 @@ services:
   lotus-risk:
     build: .
     ports:
-      - \"8130:8130\"
+      - "8130:8130"
     env_file:
       - .env
     healthcheck:
-      test: [\"CMD\", \"python\", \"-c\", \"import urllib.request; urllib.request.urlopen('http://localhost:8130/health/ready')\"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8130/health/ready')"]
       interval: 15s
       timeout: 3s
       retries: 10
+


### PR DESCRIPTION
## Summary
- fix invalid escaped quotes in docker-compose.yml for port mapping and healthcheck command
- add .env to .gitignore so local runtime config does not appear as unstaged noise

## Validation
- docker compose config
- docker compose up -d --build previously failed with invalid containerPort; this change resolves parser error