### PR TITLE
feat: stateful historical attribution slice B adapter and upstream requirements

### DIFF
--- a/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
+++ b/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
@@ -1,0 +1,251 @@
+# lotus-core and lotus-performance Requirements for Historical Attribution Integration
+
+## Scope
+
+This document defines the upstream contracts required by `lotus-risk` to support:
+
+- `POST /analytics/risk/historical-attribution`
+- `input_mode=stateful` (v1)
+
+This is aligned with RFC-0006 and RFC-0067 governance.
+
+## Ownership Boundaries (Non-Negotiable)
+
+1. `lotus-performance` is the system of record for historical return series:
+- portfolio returns
+- benchmark returns
+
+2. `lotus-core` is the system of record for canonical domain/master data:
+- position history and market values
+- instrument metadata and issuer hierarchy
+- security classification dimensions
+
+3. `lotus-risk` only computes risk attribution. It must not reconstruct master data that belongs to `lotus-core` or return series that belongs to `lotus-performance`.
+
+## Required Upstream Contracts
+
+### A) lotus-performance (Required)
+
+Endpoint:
+
+- `POST /integration/returns/series`
+
+Purpose:
+
+- return aligned historical return series for the requested portfolio scope.
+
+Minimum request contract expected by lotus-risk:
+
+```json
+{
+  "portfolio_id": "PORT_ABC_001",
+  "as_of_date": "2026-02-28",
+  "window": { "mode": "RELATIVE", "period": "SI" },
+  "frequency": "DAILY",
+  "metric_basis": "NET",
+  "reporting_currency": "USD",
+  "series_selection": {
+    "include_portfolio": true,
+    "include_benchmark": true,
+    "include_risk_free": false
+  },
+  "data_policy": {
+    "missing_data_policy": "ALLOW_PARTIAL",
+    "fill_method": "NONE",
+    "calendar_policy": "BUSINESS"
+  },
+  "input_mode": "stateful",
+  "stateful_input": {
+    "consumer_system": "lotus-risk"
+  }
+}
+```
+
+Minimum response contract required:
+
+```json
+{
+  "series": {
+    "portfolio_returns": [
+      { "date": "2026-01-02", "return_value": "0.0015" }
+    ],
+    "benchmark_returns": [
+      { "date": "2026-01-02", "return_value": "0.0011" }
+    ],
+    "risk_free_returns": []
+  },
+  "alignment": {
+    "start_date": "2026-01-02",
+    "end_date": "2026-02-28"
+  },
+  "metadata": {
+    "source_system": "lotus-performance",
+    "contract_version": "v1"
+  }
+}
+```
+
+Required behavior:
+
+1. Portfolio returns must always be present for successful stateful attribution.
+2. Benchmark returns are required when `ACTIVE_RISK` or `TRACKING_ERROR` attribution is requested.
+3. `return_value` must be decimal return (not percentage); lotus-risk converts to internal risk units.
+4. All rows must use ISO date format and deterministic ordering.
+5. Correlation ID must be propagated end-to-end.
+
+### B) lotus-core (Required)
+
+Endpoint 1:
+
+- `POST /integration/portfolios/{portfolio_id}/analytics/position-timeseries`
+
+Purpose:
+
+- return position-by-date exposure base used for attribution grouping and weights.
+
+Minimum request contract expected by lotus-risk:
+
+```json
+{
+  "as_of_date": "2026-02-28",
+  "window": {
+    "start_date": "2026-01-02",
+    "end_date": "2026-02-28"
+  },
+  "frequency": "daily",
+  "dimensions": ["sector", "asset_class"],
+  "reporting_currency": "USD",
+  "consumer_system": "lotus-risk",
+  "page": {
+    "page_size": 5000,
+    "page_token": null
+  }
+}
+```
+
+Minimum response contract required:
+
+```json
+{
+  "rows": [
+    {
+      "valuation_date": "2026-01-02",
+      "security_id": "SEC_AAPL_US",
+      "ending_market_value_reporting_currency": "150000.00",
+      "ending_market_value_portfolio_currency": "150000.00",
+      "dimensions": {
+        "sector": "Information Technology",
+        "asset_class": "Equity"
+      }
+    }
+  ],
+  "page": {
+    "next_page_token": null
+  },
+  "metadata": {
+    "source_system": "lotus-core",
+    "contract_version": "v1"
+  }
+}
+```
+
+Required behavior:
+
+1. `rows[]` must be returned for each available valuation date in window.
+2. At least one of:
+- `ending_market_value_reporting_currency`
+- `ending_market_value_portfolio_currency`
+   must be populated per row.
+3. Stable pagination contract using `page.next_page_token`.
+4. `dimensions` keys must be canonical and stable (`sector`, `asset_class`).
+5. Correlation ID must be propagated end-to-end.
+
+Endpoint 2:
+
+- `POST /integration/instruments/enrichment-bulk`
+
+Purpose:
+
+- map `security_id` to issuer hierarchy for `grouping_dimension=ISSUER`.
+
+Minimum request contract:
+
+```json
+{
+  "security_ids": ["SEC_AAPL_US", "SEC_MSFT_US"]
+}
+```
+
+Minimum response contract:
+
+```json
+{
+  "records": [
+    {
+      "security_id": "SEC_AAPL_US",
+      "issuer_id": "ISSUER_APPLE_INC",
+      "issuer_name": "Apple Inc.",
+      "ultimate_parent_issuer_id": "ISSUER_APPLE_HOLDCO",
+      "ultimate_parent_issuer_name": "Apple HoldCo"
+    }
+  ]
+}
+```
+
+Required behavior:
+
+1. Records may omit unknown securities, but response shape must remain valid.
+2. `issuer_id` and `issuer_name` must be deterministic for a given `security_id`.
+3. Correlation ID must be propagated end-to-end.
+
+## Capability Matrix for Historical Attribution
+
+1. `TOTAL_RISK + VOLATILITY` stateful:
+- needs `portfolio_returns` from lotus-performance
+- needs position timeseries + dimensions from lotus-core
+
+2. `ACTIVE_RISK + TRACKING_ERROR` stateful:
+- needs `portfolio_returns` and `benchmark_returns` from lotus-performance
+- needs portfolio exposure timeseries from lotus-core
+- needs benchmark exposure timeseries contract (currently gap if not yet available)
+
+3. `grouping_dimension=ISSUER`:
+- needs instrument enrichment-bulk from lotus-core
+
+4. `grouping_dimension=POSITION | SECTOR | ASSET_CLASS`:
+- no issuer enrichment required
+
+## Gaps to Resolve (if not already live)
+
+1. Benchmark exposure history contract for active attribution in stateful mode:
+- required to fully support `ACTIVE_RISK` decomposition by grouping dimension.
+
+2. Explicit response metadata in both upstream services:
+- lineage and contract version fields should be stable and documented.
+
+3. OpenAPI completeness:
+- all request/response attributes must include descriptions and realistic examples per RFC-0067.
+
+## Non-Functional Requirements
+
+1. Determinism:
+- same request produces same results and ordering.
+
+2. Performance:
+- support at least 5,000 rows per page in `position-timeseries`.
+
+3. Resilience:
+- standard Lotus error envelope, clear message, correlation ID echo.
+
+4. Governance:
+- canonical snake_case only; no legacy aliases.
+- all attributes must exist in API vocabulary inventory.
+
+## Acceptance Checklist
+
+1. Stateful `TOTAL_RISK` attribution succeeds end-to-end using upstream data only.
+2. Stateful `ACTIVE_RISK` attribution succeeds end-to-end when benchmark exposure history is available.
+3. `ISSUER` grouping succeeds with enrichment-bulk.
+4. Contract tests validate required fields and type/shape guarantees.
+5. Characterization tests lock numerical behavior for stable fixtures.
+6. OpenAPI docs include full descriptions and realistic examples for all attributes.

--- a/docs/rfcs/RFC-0006-historical-risk-attribution-analytics.md
+++ b/docs/rfcs/RFC-0006-historical-risk-attribution-analytics.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- Accepted (Slice A implemented: stateless mode)
+- Accepted (Slice A implemented, Slice B in progress)
 - Owner: lotus-risk
 - Date: 2026-03-01
 
@@ -46,8 +46,8 @@ This RFC defines a quant-rigorous, audit-ready attribution framework and API con
 
 ### Execution Modes
 
-- `stateless`: v1 Slice A
-- `stateful`: v1 Slice B
+- `stateless`: v1 Slice A (implemented)
+- `stateful`: v1 Slice B (partially implemented)
 - `simulation`: deferred
 
 ### Request Envelope (Canonical)
@@ -208,6 +208,34 @@ All formulas operate in decimal units internally. API values follow platform rou
 2. Every request/response attribute requires description and realistic example.
 3. Vocabulary inventory regeneration and validation are mandatory for every schema change.
 4. No legacy aliases permitted in new attribution contract.
+
+## Implementation Progress and Pending Work
+
+### Implemented in lotus-risk
+
+1. Stateful adapter for `POST /analytics/risk/historical-attribution` is implemented for:
+   - `TOTAL_RISK`
+   - `VOLATILITY`
+   - grouping dimensions: `POSITION`, `SECTOR`, `ASSET_CLASS`, `ISSUER`
+2. Stateful adapter now sources:
+   - returns from lotus-performance (`/integration/returns/series`)
+   - position timeseries from lotus-core (`/integration/portfolios/{portfolio_id}/analytics/position-timeseries`)
+   - issuer enrichment from lotus-core (`/integration/instruments/enrichment-bulk`) when required.
+3. Deterministic guardrails are implemented for unsupported stateful combinations in current slice.
+
+### Pending work in lotus-risk
+
+1. Enable stateful `ACTIVE_RISK` and `TRACKING_ERROR` attribution after benchmark exposure-history contract is live.
+2. Add full benchmark-exposure mapping path in the stateful adapter.
+3. Add stateful e2e test coverage for active-risk path once upstream contract is available.
+4. Expand methodology documentation with final active-risk stateful behavior and quality flags.
+
+### Pending upstream dependencies
+
+1. lotus-core:
+   - benchmark exposure-history contract with pagination and canonical dimensions.
+2. lotus-performance:
+   - production-hardened benchmark return-series diagnostics and alignment metadata for attribution use.
 
 ## Open Decisions
 

--- a/src/app/integrations/lotus_core_client.py
+++ b/src/app/integrations/lotus_core_client.py
@@ -85,6 +85,20 @@ class LotusCoreClient:
             correlation_id=correlation_id,
         )
 
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, Any],
+        correlation_id: str | None,
+    ) -> dict[str, Any]:
+        return await self._request_json(
+            "POST",
+            f"/integration/portfolios/{portfolio_id}/analytics/position-timeseries",
+            json_payload=request_payload,
+            correlation_id=correlation_id,
+        )
+
     async def _request_json(
         self,
         method: str,

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -44,6 +44,7 @@ from app.integrations.lotus_performance_client import LotusPerformanceClient
 from app.middleware.correlation import CorrelationIdMiddleware
 from app.services.concentration_engine import calculate_concentration
 from app.services.attribution_engine import calculate_historical_attribution
+from app.services.attribution_mode_adapter import calculate_historical_attribution_stateful
 from app.services.drawdown_engine import calculate_drawdown
 from app.services.drawdown_mode_adapter import calculate_drawdown_stateful
 from app.services.rolling_engine import calculate_rolling_metrics
@@ -373,6 +374,7 @@ async def metrics() -> Response:
 )
 async def analytics_risk_historical_attribution(
     request_payload: HistoricalAttributionRequest,
+    request: Request,
 ) -> HistoricalAttributionResponse:
     if request_payload.input_mode == AttributionInputMode.STATELESS:
         stateless_input = request_payload.stateless_input
@@ -382,9 +384,25 @@ async def analytics_risk_historical_attribution(
             input_mode=AttributionInputMode.STATELESS,
         )
 
+    if request_payload.input_mode == AttributionInputMode.STATEFUL:
+        stateful_input = request_payload.stateful_input
+        assert stateful_input is not None
+        performance_client = getattr(app.state, "lotus_performance_client", None)
+        if performance_client is None:
+            performance_client = LotusPerformanceClient()
+        core_client = getattr(app.state, "lotus_core_client", None)
+        if core_client is None:
+            core_client = LotusCoreClient()
+        return await calculate_historical_attribution_stateful(
+            stateful_input,
+            performance_client=performance_client,
+            core_client=core_client,
+            correlation_id=request.headers.get("X-Correlation-Id"),
+        )
+
     raise ValueError(
         f"input_mode={request_payload.input_mode.value} is not implemented for /analytics/risk/historical-attribution yet. "
-        "Use input_mode=stateless in this slice."
+        "Use input_mode=stateless or input_mode=stateful in this slice."
     )
 
 

--- a/src/app/services/attribution_mode_adapter.py
+++ b/src/app/services/attribution_mode_adapter.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from app.contracts.attribution import (
+    AttributionInputMode,
+    ExposurePoint,
+    GroupingDimension,
+    HistoricalAttributionResponse,
+    HistoricalAttributionStatefulInput,
+    HistoricalAttributionStatelessInput,
+)
+from app.contracts.risk import ReturnPoint, RiskRequestScope
+from app.services.attribution_engine import calculate_historical_attribution
+
+
+class LotusPerformanceClientProtocol(Protocol):
+    async def get_returns_series(
+        self,
+        *,
+        request_payload: dict[str, Any],
+        correlation_id: str | None,
+    ) -> dict[str, Any]: ...
+
+
+class LotusCoreClientProtocol(Protocol):
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, Any],
+        correlation_id: str | None,
+    ) -> dict[str, Any]: ...
+
+    async def get_instrument_enrichment(
+        self,
+        *,
+        security_ids: list[str],
+        correlation_id: str | None,
+    ) -> dict[str, Any]: ...
+
+
+def _decimal_return_to_percentage_points(value: Any) -> float:
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"Invalid return value from lotus-performance: {value}") from exc
+    return float(decimal_value * Decimal("100"))
+
+
+def _to_return_points(series: Any) -> list[ReturnPoint]:
+    if not isinstance(series, list):
+        return []
+    result: list[ReturnPoint] = []
+    for row in series:
+        if not isinstance(row, dict):
+            continue
+        raw_date = row.get("date")
+        if not isinstance(raw_date, str):
+            continue
+        result.append(
+            ReturnPoint(
+                date=date.fromisoformat(raw_date),
+                value=_decimal_return_to_percentage_points(row.get("return_value")),
+            )
+        )
+    return result
+
+
+def _build_stateful_returns_request(stateful: HistoricalAttributionStatefulInput) -> dict[str, Any]:
+    return {
+        "portfolio_id": stateful.portfolio_id,
+        "as_of_date": stateful.as_of_date.isoformat(),
+        "window": {"mode": "RELATIVE", "period": "SI"},
+        "frequency": "DAILY",
+        "metric_basis": stateful.net_or_gross,
+        "reporting_currency": stateful.reporting_currency,
+        "series_selection": {
+            "include_portfolio": True,
+            "include_benchmark": False,
+            "include_risk_free": False,
+        },
+        "data_policy": {
+            "missing_data_policy": "ALLOW_PARTIAL",
+            "fill_method": "NONE",
+            "calendar_policy": "BUSINESS",
+        },
+        "input_mode": "stateful",
+        "stateful_input": {"consumer_system": "lotus-risk"},
+    }
+
+
+def _group_key_and_label(
+    *,
+    row: dict[str, Any],
+    grouping_dimension: GroupingDimension,
+    issuer_map: dict[str, tuple[str, str | None]],
+) -> tuple[str, str | None]:
+    security_id_raw = row.get("security_id")
+    security_id = str(security_id_raw) if security_id_raw else "UNKNOWN_SECURITY"
+    dimensions_raw = row.get("dimensions")
+    dimensions = dimensions_raw if isinstance(dimensions_raw, dict) else {}
+
+    if grouping_dimension == "POSITION":
+        return security_id, security_id
+    if grouping_dimension == "SECTOR":
+        sector = dimensions.get("sector")
+        label = str(sector) if sector else "UNKNOWN"
+        return f"SECTOR_{label}", label
+    if grouping_dimension == "ASSET_CLASS":
+        asset_class = dimensions.get("asset_class")
+        label = str(asset_class) if asset_class else "UNKNOWN"
+        return f"ASSET_CLASS_{label}", label
+    if grouping_dimension == "ISSUER":
+        issuer_id, issuer_name = issuer_map.get(security_id, (f"ISSUER_{security_id}", None))
+        return issuer_id, issuer_name
+    raise ValueError(f"Unsupported stateful grouping_dimension={grouping_dimension}")
+
+
+def _as_decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(
+            f"Invalid market value from lotus-core position-timeseries: {value}"
+        ) from exc
+
+
+def _build_exposure_points(
+    *,
+    rows: list[dict[str, Any]],
+    grouping_dimensions: list[GroupingDimension],
+    issuer_map: dict[str, tuple[str, str | None]],
+) -> list[ExposurePoint]:
+    grouped_values: dict[tuple[date, GroupingDimension, str], Decimal] = {}
+    totals_by_date: dict[date, Decimal] = {}
+    labels: dict[tuple[GroupingDimension, str], str | None] = {}
+
+    for row in rows:
+        valuation_date = row.get("valuation_date")
+        if not isinstance(valuation_date, str):
+            continue
+        obs_date = date.fromisoformat(valuation_date)
+        ending_reporting = row.get("ending_market_value_reporting_currency")
+        ending_portfolio = row.get("ending_market_value_portfolio_currency")
+        market_value = _as_decimal(
+            ending_reporting if ending_reporting is not None else ending_portfolio
+        )
+        totals_by_date[obs_date] = totals_by_date.get(obs_date, Decimal("0")) + market_value
+
+        for grouping_dimension in grouping_dimensions:
+            group_key, group_label = _group_key_and_label(
+                row=row,
+                grouping_dimension=grouping_dimension,
+                issuer_map=issuer_map,
+            )
+            labels[(grouping_dimension, group_key)] = group_label
+            key = (obs_date, grouping_dimension, group_key)
+            grouped_values[key] = grouped_values.get(key, Decimal("0")) + market_value
+
+    points: list[ExposurePoint] = []
+    for (obs_date, grouping_dimension, group_key), value in grouped_values.items():
+        total = totals_by_date.get(obs_date, Decimal("0"))
+        if total == 0:
+            continue
+        points.append(
+            ExposurePoint(
+                date=obs_date,
+                grouping_dimension=grouping_dimension,
+                group_key=group_key,
+                group_label=labels.get((grouping_dimension, group_key)),
+                weight=float(value / total),
+            )
+        )
+    points.sort(key=lambda item: (item.date, item.grouping_dimension, item.group_key))
+    return points
+
+
+async def _fetch_position_timeseries_rows(
+    *,
+    core_client: LotusCoreClientProtocol,
+    portfolio_id: str,
+    as_of_date: date,
+    start_date: date,
+    reporting_currency: str | None,
+    grouping_dimensions: list[GroupingDimension],
+    correlation_id: str | None,
+) -> list[dict[str, Any]]:
+    dimensions: list[str] = []
+    if "SECTOR" in grouping_dimensions:
+        dimensions.append("sector")
+    if "ASSET_CLASS" in grouping_dimensions:
+        dimensions.append("asset_class")
+
+    page_token: str | None = None
+    rows: list[dict[str, Any]] = []
+    while True:
+        payload: dict[str, Any] = {
+            "as_of_date": as_of_date.isoformat(),
+            "window": {
+                "start_date": start_date.isoformat(),
+                "end_date": as_of_date.isoformat(),
+            },
+            "frequency": "daily",
+            "dimensions": dimensions,
+            "consumer_system": "lotus-risk",
+            "page": {"page_size": 5000, "page_token": page_token},
+        }
+        if reporting_currency:
+            payload["reporting_currency"] = reporting_currency
+
+        response = await core_client.get_position_analytics_timeseries(
+            portfolio_id=portfolio_id,
+            request_payload=payload,
+            correlation_id=correlation_id,
+        )
+        batch = response.get("rows")
+        if not isinstance(batch, list):
+            raise ValueError("lotus-core position-timeseries payload missing 'rows' list")
+        for row in batch:
+            if isinstance(row, dict):
+                rows.append(row)
+
+        page = response.get("page")
+        next_page_token = page.get("next_page_token") if isinstance(page, dict) else None
+        if not isinstance(next_page_token, str) or not next_page_token:
+            break
+        page_token = next_page_token
+    return rows
+
+
+async def _build_issuer_map(
+    *,
+    core_client: LotusCoreClientProtocol,
+    rows: list[dict[str, Any]],
+    correlation_id: str | None,
+) -> dict[str, tuple[str, str | None]]:
+    security_ids = sorted(
+        {
+            str(row.get("security_id"))
+            for row in rows
+            if isinstance(row, dict) and row.get("security_id")
+        }
+    )
+    if not security_ids:
+        return {}
+    response = await core_client.get_instrument_enrichment(
+        security_ids=security_ids,
+        correlation_id=correlation_id,
+    )
+    records = response.get("records")
+    if not isinstance(records, list):
+        raise ValueError("lotus-core enrichment payload missing 'records' list")
+    issuer_map: dict[str, tuple[str, str | None]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        security_id_raw = record.get("security_id")
+        if not security_id_raw:
+            continue
+        security_id = str(security_id_raw)
+        issuer_id_raw = record.get("issuer_id")
+        issuer_name_raw = record.get("issuer_name")
+        issuer_id = str(issuer_id_raw) if issuer_id_raw else f"ISSUER_{security_id}"
+        issuer_name = str(issuer_name_raw) if issuer_name_raw else None
+        issuer_map[security_id] = (issuer_id, issuer_name)
+    return issuer_map
+
+
+async def calculate_historical_attribution_stateful(
+    stateful: HistoricalAttributionStatefulInput,
+    *,
+    performance_client: LotusPerformanceClientProtocol,
+    core_client: LotusCoreClientProtocol,
+    correlation_id: str | None,
+) -> HistoricalAttributionResponse:
+    options = stateful.attribution_options
+    requested_groupings = options.grouping_dimensions
+    if "CUSTOM" in requested_groupings:
+        raise ValueError(
+            "stateful historical-attribution does not support grouping_dimension=CUSTOM"
+        )
+
+    requires_active = (
+        "ACTIVE_RISK" in options.attribution_types or "TRACKING_ERROR" in options.metrics
+    )
+    if requires_active:
+        raise ValueError(
+            "stateful ACTIVE_RISK/TRACKING_ERROR attribution is blocked until benchmark exposure history contract is available"
+        )
+
+    returns_response = await performance_client.get_returns_series(
+        request_payload=_build_stateful_returns_request(stateful),
+        correlation_id=correlation_id,
+    )
+    series = returns_response.get("series")
+    if not isinstance(series, dict):
+        raise ValueError("lotus-performance returns-series payload missing 'series' object")
+
+    portfolio_returns = _to_return_points(series.get("portfolio_returns"))
+    if not portfolio_returns:
+        raise ValueError("lotus-performance returns-series returned no portfolio returns")
+    start_date = min(point.date for point in portfolio_returns)
+
+    rows = await _fetch_position_timeseries_rows(
+        core_client=core_client,
+        portfolio_id=stateful.portfolio_id,
+        as_of_date=stateful.as_of_date,
+        start_date=start_date,
+        reporting_currency=stateful.reporting_currency,
+        grouping_dimensions=requested_groupings,
+        correlation_id=correlation_id,
+    )
+    if not rows:
+        raise ValueError("lotus-core position-timeseries returned no rows")
+
+    issuer_map = (
+        await _build_issuer_map(
+            core_client=core_client,
+            rows=rows,
+            correlation_id=correlation_id,
+        )
+        if "ISSUER" in requested_groupings
+        else {}
+    )
+    exposure_history = _build_exposure_points(
+        rows=rows,
+        grouping_dimensions=requested_groupings,
+        issuer_map=issuer_map,
+    )
+    if not exposure_history:
+        raise ValueError("unable to build exposure history from lotus-core position-timeseries")
+
+    stateless_input = HistoricalAttributionStatelessInput(
+        scope=RiskRequestScope(
+            as_of_date=stateful.as_of_date,
+            reporting_currency=stateful.reporting_currency,
+            net_or_gross=stateful.net_or_gross,
+        ),
+        periods=stateful.periods,
+        returns=portfolio_returns,
+        benchmark_returns=[],
+        exposure_history=exposure_history,
+        benchmark_exposure_history=[],
+        attribution_options=options,
+    )
+    return calculate_historical_attribution(
+        stateless_input,
+        input_mode=AttributionInputMode.STATEFUL,
+    )

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -193,7 +193,100 @@ def test_historical_attribution_stateless_happy_path() -> None:
     assert len(ytd["attribution_sets"]) == 4
 
 
-def test_historical_attribution_stateful_rejected_in_slice_a() -> None:
+def test_historical_attribution_stateful_total_risk_happy_path() -> None:
+    class _FakeLotusPerformanceClient:
+        async def get_returns_series(
+            self,
+            *,
+            request_payload: dict[str, object],
+            correlation_id: str | None,
+        ) -> dict[str, object]:
+            assert request_payload["input_mode"] == "stateful"
+            assert request_payload["stateful_input"] == {"consumer_system": "lotus-risk"}
+            return {
+                "series": {
+                    "portfolio_returns": [
+                        {"date": "2026-01-02", "return_value": "0.0100"},
+                        {"date": "2026-01-03", "return_value": "-0.0050"},
+                        {"date": "2026-01-04", "return_value": "0.0040"},
+                    ]
+                }
+            }
+
+    class _FakeLotusCoreClient:
+        async def get_position_analytics_timeseries(
+            self,
+            *,
+            portfolio_id: str,
+            request_payload: dict[str, object],
+            correlation_id: str | None,
+        ) -> dict[str, object]:
+            return {
+                "rows": [
+                    {
+                        "security_id": "SEC_A",
+                        "valuation_date": "2026-01-02",
+                        "dimensions": {"sector": "TECH", "asset_class": "EQUITY"},
+                        "ending_market_value_portfolio_currency": "60",
+                    },
+                    {
+                        "security_id": "SEC_B",
+                        "valuation_date": "2026-01-02",
+                        "dimensions": {"sector": "HEALTH", "asset_class": "EQUITY"},
+                        "ending_market_value_portfolio_currency": "40",
+                    },
+                    {
+                        "security_id": "SEC_A",
+                        "valuation_date": "2026-01-03",
+                        "dimensions": {"sector": "TECH", "asset_class": "EQUITY"},
+                        "ending_market_value_portfolio_currency": "65",
+                    },
+                    {
+                        "security_id": "SEC_B",
+                        "valuation_date": "2026-01-03",
+                        "dimensions": {"sector": "HEALTH", "asset_class": "EQUITY"},
+                        "ending_market_value_portfolio_currency": "35",
+                    },
+                ],
+                "page": {"next_page_token": None},
+            }
+
+        async def get_instrument_enrichment(
+            self,
+            *,
+            security_ids: list[str],
+            correlation_id: str | None,
+        ) -> dict[str, object]:
+            return {"records": []}
+
+    client = TestClient(app)
+    app.state.lotus_performance_client = _FakeLotusPerformanceClient()
+    app.state.lotus_core_client = _FakeLotusCoreClient()
+    response = client.post(
+        "/analytics/risk/historical-attribution",
+        json={
+            "input_mode": "stateful",
+            "stateful_input": {
+                "portfolio_id": "DEMO_DPM_EUR_001",
+                "as_of_date": "2026-01-04",
+                "periods": [{"type": "YTD", "name": "YTD"}],
+                "attribution_options": {
+                    "attribution_types": ["TOTAL_RISK"],
+                    "metrics": ["VOLATILITY"],
+                    "grouping_dimensions": ["SECTOR"],
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_mode"] == "stateful"
+    assert body["results"]["YTD"]["error"] is None
+
+
+def test_historical_attribution_stateful_rejects_active_risk_until_benchmark_exposure_contract() -> (
+    None
+):
     client = TestClient(app)
     response = client.post(
         "/analytics/risk/historical-attribution",
@@ -201,12 +294,17 @@ def test_historical_attribution_stateful_rejected_in_slice_a() -> None:
             "input_mode": "stateful",
             "stateful_input": {
                 "portfolio_id": "DEMO_DPM_EUR_001",
-                "as_of_date": "2026-02-28",
+                "as_of_date": "2026-01-04",
                 "periods": [{"type": "YTD", "name": "YTD"}],
+                "attribution_options": {
+                    "attribution_types": ["ACTIVE_RISK"],
+                    "metrics": ["TRACKING_ERROR"],
+                    "grouping_dimensions": ["SECTOR"],
+                },
             },
         },
     )
     assert response.status_code == 400
     error = response.json()["error"]
     assert error["code"] == "INVALID_INPUT"
-    assert "not implemented" in error["message"]
+    assert "benchmark exposure history contract" in error["message"]

--- a/tests/unit/test_attribution_mode_adapter.py
+++ b/tests/unit/test_attribution_mode_adapter.py
@@ -1,0 +1,422 @@
+import asyncio
+from datetime import date
+
+import pytest
+
+from app.contracts.attribution import HistoricalAttributionStatefulInput
+from app.services import attribution_mode_adapter as adapter
+from app.services.attribution_mode_adapter import calculate_historical_attribution_stateful
+
+
+class _StubPerformanceClient:
+    def __init__(self) -> None:
+        self.payload: dict[str, object] | None = None
+
+    async def get_returns_series(
+        self,
+        *,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        self.payload = request_payload
+        return {
+            "series": {
+                "portfolio_returns": [
+                    {"date": "2026-01-02", "return_value": "0.0100"},
+                    {"date": "2026-01-03", "return_value": "-0.0050"},
+                    {"date": "2026-01-04", "return_value": "0.0040"},
+                ]
+            }
+        }
+
+
+class _StubCoreClient:
+    def __init__(self) -> None:
+        self.position_payloads: list[dict[str, object]] = []
+        self.enrichment_calls: list[list[str]] = []
+
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        self.position_payloads.append(request_payload)
+        page = request_payload.get("page")
+        page_token = page.get("page_token") if isinstance(page, dict) else None
+        if page_token:
+            return {
+                "rows": [
+                    {
+                        "security_id": "SEC_B",
+                        "valuation_date": "2026-01-03",
+                        "dimensions": {"sector": "HEALTH", "asset_class": "EQUITY"},
+                        "ending_market_value_portfolio_currency": "40",
+                    }
+                ],
+                "page": {"next_page_token": None},
+            }
+        return {
+            "rows": [
+                {
+                    "security_id": "SEC_A",
+                    "valuation_date": "2026-01-02",
+                    "dimensions": {"sector": "TECH", "asset_class": "EQUITY"},
+                    "ending_market_value_portfolio_currency": "60",
+                },
+                {
+                    "security_id": "SEC_B",
+                    "valuation_date": "2026-01-02",
+                    "dimensions": {"sector": "HEALTH", "asset_class": "EQUITY"},
+                    "ending_market_value_portfolio_currency": "40",
+                },
+            ],
+            "page": {"next_page_token": "NEXT_1"},
+        }
+
+    async def get_instrument_enrichment(
+        self,
+        *,
+        security_ids: list[str],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        self.enrichment_calls.append(security_ids)
+        return {
+            "records": [
+                {"security_id": "SEC_A", "issuer_id": "ISSUER_A", "issuer_name": "Issuer A"},
+                {"security_id": "SEC_B", "issuer_id": "ISSUER_B", "issuer_name": "Issuer B"},
+            ]
+        }
+
+
+class _StubCoreClientBadRows(_StubCoreClient):
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {"rows": "bad"}
+
+
+class _StubCoreClientNoRows(_StubCoreClient):
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {"rows": [], "page": {"next_page_token": None}}
+
+
+class _StubCoreClientInvalidExposure(_StubCoreClient):
+    async def get_position_analytics_timeseries(
+        self,
+        *,
+        portfolio_id: str,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {
+            "rows": [
+                {
+                    "security_id": "SEC_A",
+                    "valuation_date": None,
+                    "dimensions": {"sector": "TECH"},
+                    "ending_market_value_portfolio_currency": "100",
+                }
+            ],
+            "page": {"next_page_token": None},
+        }
+
+
+class _StubCoreClientBadRecords(_StubCoreClient):
+    async def get_instrument_enrichment(
+        self,
+        *,
+        security_ids: list[str],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {"records": "bad"}
+
+
+class _StubPerformanceClientMissingSeries(_StubPerformanceClient):
+    async def get_returns_series(
+        self,
+        *,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {}
+
+
+class _StubPerformanceClientEmptyReturns(_StubPerformanceClient):
+    async def get_returns_series(
+        self,
+        *,
+        request_payload: dict[str, object],
+        correlation_id: str | None,
+    ) -> dict[str, object]:
+        return {"series": {"portfolio_returns": []}}
+
+
+def _stateful_input(
+    *, grouping_dimensions: list[str], attribution_types: list[str]
+) -> HistoricalAttributionStatefulInput:
+    return HistoricalAttributionStatefulInput.model_validate(
+        {
+            "portfolio_id": "DEMO_DPM_EUR_001",
+            "as_of_date": "2026-01-04",
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "attribution_options": {
+                "attribution_types": attribution_types,
+                "metrics": ["VOLATILITY"],
+                "grouping_dimensions": grouping_dimensions,
+            },
+        }
+    )
+
+
+def test_stateful_attribution_total_risk_happy_path() -> None:
+    perf = _StubPerformanceClient()
+    core = _StubCoreClient()
+    response = asyncio.run(
+        calculate_historical_attribution_stateful(
+            _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+            performance_client=perf,
+            core_client=core,
+            correlation_id="corr-attr",
+        )
+    )
+    assert perf.payload is not None
+    assert perf.payload["input_mode"] == "stateful"
+    assert perf.payload["stateful_input"] == {"consumer_system": "lotus-risk"}
+    assert len(core.position_payloads) == 2
+    first_payload = core.position_payloads[0]
+    assert first_payload["dimensions"] == ["sector"]
+    assert response.input_mode.value == "stateful"
+    assert response.results["YTD"].error is None
+
+
+def test_stateful_attribution_asset_class_and_reporting_currency() -> None:
+    perf = _StubPerformanceClient()
+    core = _StubCoreClient()
+    payload = _stateful_input(grouping_dimensions=["ASSET_CLASS"], attribution_types=["TOTAL_RISK"])
+    payload.reporting_currency = "USD"
+    response = asyncio.run(
+        calculate_historical_attribution_stateful(
+            payload,
+            performance_client=perf,
+            core_client=core,
+            correlation_id="corr-attr",
+        )
+    )
+    assert response.results["YTD"].error is None
+    assert core.position_payloads[0]["dimensions"] == ["asset_class"]
+    assert core.position_payloads[0]["reporting_currency"] == "USD"
+
+
+def test_stateful_attribution_issuer_grouping_uses_enrichment() -> None:
+    perf = _StubPerformanceClient()
+    core = _StubCoreClient()
+    response = asyncio.run(
+        calculate_historical_attribution_stateful(
+            _stateful_input(grouping_dimensions=["ISSUER"], attribution_types=["TOTAL_RISK"]),
+            performance_client=perf,
+            core_client=core,
+            correlation_id="corr-attr",
+        )
+    )
+    assert len(core.enrichment_calls) == 1
+    assert set(core.enrichment_calls[0]) == {"SEC_A", "SEC_B"}
+    assert response.results["YTD"].error is None
+
+
+def test_stateful_attribution_issuer_grouping_rejects_bad_enrichment_shape() -> None:
+    with pytest.raises(ValueError, match="enrichment payload missing 'records' list"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["ISSUER"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClientBadRecords(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_active_risk_without_benchmark_exposure_contract() -> None:
+    with pytest.raises(ValueError, match="benchmark exposure history contract"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["ACTIVE_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClient(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_custom_grouping() -> None:
+    with pytest.raises(ValueError, match="grouping_dimension=CUSTOM"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["CUSTOM"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClient(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_missing_series_object() -> None:
+    with pytest.raises(ValueError, match="payload missing 'series' object"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClientMissingSeries(),
+                core_client=_StubCoreClient(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_empty_portfolio_returns() -> None:
+    with pytest.raises(ValueError, match="returned no portfolio returns"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClientEmptyReturns(),
+                core_client=_StubCoreClient(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_missing_rows_list() -> None:
+    with pytest.raises(ValueError, match="payload missing 'rows' list"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClientBadRows(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_empty_rows() -> None:
+    with pytest.raises(ValueError, match="returned no rows"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClientNoRows(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_stateful_attribution_rejects_empty_exposure_history() -> None:
+    with pytest.raises(ValueError, match="unable to build exposure history"):
+        asyncio.run(
+            calculate_historical_attribution_stateful(
+                _stateful_input(grouping_dimensions=["SECTOR"], attribution_types=["TOTAL_RISK"]),
+                performance_client=_StubPerformanceClient(),
+                core_client=_StubCoreClientInvalidExposure(),
+                correlation_id="corr-attr",
+            )
+        )
+
+
+def test_helper_branch_coverage_for_conversion_and_grouping() -> None:
+    assert adapter._to_return_points("bad") == []
+    assert adapter._to_return_points(
+        [1, {"date": None}, {"date": "2026-01-02", "return_value": "0.01"}]
+    )[0].date == date(2026, 1, 2)
+    with pytest.raises(ValueError, match="Invalid return value"):
+        adapter._decimal_return_to_percentage_points("nan%")
+    with pytest.raises(ValueError, match="Invalid market value"):
+        adapter._as_decimal("invalid")
+
+    row = {"security_id": "SEC_X", "dimensions": {}}
+    assert adapter._group_key_and_label(row=row, grouping_dimension="POSITION", issuer_map={}) == (
+        "SEC_X",
+        "SEC_X",
+    )
+    assert adapter._group_key_and_label(
+        row=row, grouping_dimension="ASSET_CLASS", issuer_map={}
+    ) == ("ASSET_CLASS_UNKNOWN", "UNKNOWN")
+    assert adapter._group_key_and_label(row=row, grouping_dimension="ISSUER", issuer_map={}) == (
+        "ISSUER_SEC_X",
+        None,
+    )
+    with pytest.raises(ValueError, match="Unsupported stateful grouping_dimension"):
+        adapter._group_key_and_label(
+            row=row,
+            grouping_dimension="UNKNOWN",  # type: ignore[arg-type]
+            issuer_map={},
+        )
+
+
+def test_build_exposure_points_skips_zero_total_rows() -> None:
+    points = adapter._build_exposure_points(
+        rows=[
+            {
+                "security_id": "SEC_ZERO",
+                "valuation_date": "2026-01-02",
+                "dimensions": {"sector": "TECH"},
+                "ending_market_value_portfolio_currency": "0",
+            }
+        ],
+        grouping_dimensions=["SECTOR"],
+        issuer_map={},
+    )
+    assert points == []
+
+
+def test_build_issuer_map_handles_empty_and_partial_rows() -> None:
+    core = _StubCoreClient()
+    empty_map = asyncio.run(
+        adapter._build_issuer_map(
+            core_client=core, rows=[{"security_id": None}], correlation_id="corr"
+        )
+    )
+    assert empty_map == {}
+
+    mixed_map = asyncio.run(
+        adapter._build_issuer_map(
+            core_client=core,
+            rows=[{"security_id": "SEC_A"}],
+            correlation_id="corr",
+        )
+    )
+    assert mixed_map["SEC_A"] == ("ISSUER_A", "Issuer A")
+
+
+def test_build_issuer_map_skips_non_dict_and_missing_security_id_records() -> None:
+    class _StubCoreClientWithBadRecords(_StubCoreClient):
+        async def get_instrument_enrichment(
+            self,
+            *,
+            security_ids: list[str],
+            correlation_id: str | None,
+        ) -> dict[str, object]:
+            return {
+                "records": [
+                    "bad_record",
+                    {"issuer_id": "ISSUER_ONLY"},
+                    {"security_id": "SEC_A", "issuer_id": "ISSUER_A"},
+                ]
+            }
+
+    issuer_map = asyncio.run(
+        adapter._build_issuer_map(
+            core_client=_StubCoreClientWithBadRecords(),
+            rows=[{"security_id": "SEC_A"}],
+            correlation_id="corr",
+        )
+    )
+    assert issuer_map == {"SEC_A": ("ISSUER_A", None)}

--- a/tests/unit/test_lotus_core_client.py
+++ b/tests/unit/test_lotus_core_client.py
@@ -103,10 +103,21 @@ async def test_client_supports_add_changes_and_snapshot_routes(
         security_ids=["SEC_A", "SEC_B"],
         correlation_id=None,
     )
+    position_timeseries_response = await client.get_position_analytics_timeseries(
+        portfolio_id="DEMO_DPM_EUR_001",
+        request_payload={"as_of_date": "2026-02-28"},
+        correlation_id=None,
+    )
 
     assert add_response == {"ok": True}
     assert snapshot_response == {"ok": True}
     assert enrichment_response == {"ok": True}
+    assert position_timeseries_response == {"ok": True}
+    assert _FakeAsyncClient.last_request is not None
+    assert (
+        _FakeAsyncClient.last_request["url"]
+        == "http://core.local/integration/portfolios/DEMO_DPM_EUR_001/analytics/position-timeseries"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- implement stateful mode path for `/analytics/risk/historical-attribution` using lotus-performance returns and lotus-core position/enrichment inputs
- add `attribution_mode_adapter` with deterministic guardrails for unsupported active-risk stateful path until benchmark-exposure contract is available
- extend lotus-core client with position-timeseries integration method
- add integration + unit characterization coverage for adapter and endpoint behavior
- add dependency requirement spec for lotus-core/lotus-performance and update RFC-0006 with implemented vs pending work

## Validation
- `uv run make ci`