### PR TITLE
docs: add complete metric methodology pack and master index

### DIFF
--- a/docs/methodologies/metrics-index.md
+++ b/docs/methodologies/metrics-index.md
@@ -1,0 +1,70 @@
+# Lotus-Risk Metrics Methodology Index
+
+This index provides one methodology document per Lotus-Risk metric with formulas, inputs/sources, outputs, configuration, supported modes, and worked examples.
+
+## Methodology Standards
+- Unit convention:
+  - `risk/calculate` request returns are percentage points (`1.0` means `1%`).
+  - `rolling` and `attribution` internals normalize returns to decimal before formula application.
+  - concentration values use weights in decimal and HHI scaled to `0..10000`.
+- Determinism:
+  - each metric doc reflects current implementation behavior in `lotus-risk` `main`.
+  - deterministic error behaviors are documented for data insufficiency and missing dependencies.
+- Domain ownership:
+  - `lotus-risk` computes metrics only.
+  - upstream systems provide canonical inputs:
+    - `lotus-performance`: return series
+    - `lotus-core`: portfolio state, instrument/issuer enrichment, exposure history contracts
+
+## Status Matrix
+- Fully implemented:
+  - all metrics under `risk/calculate`
+  - all metrics under `risk/rolling-metrics`
+  - all metrics under `risk/concentration`
+  - all metrics under `risk/drawdown`
+  - `ATTRIBUTION_VOLATILITY` under `risk/historical-attribution`
+- Partially implemented:
+  - `ATTRIBUTION_TRACKING_ERROR`:
+    - stateless supported
+    - stateful path blocked pending benchmark exposure-history contract from `lotus-core`
+
+## Risk Calculate Metrics (`/analytics/risk/calculate`)
+- [VOLATILITY](./metrics/risk-volatility.md)
+- [DRAWDOWN](./metrics/risk-drawdown.md)
+- [SHARPE](./metrics/risk-sharpe.md)
+- [SORTINO](./metrics/risk-sortino.md)
+- [BETA](./metrics/risk-beta.md)
+- [TRACKING_ERROR](./metrics/risk-tracking-error.md)
+- [INFORMATION_RATIO](./metrics/risk-information-ratio.md)
+- [VAR](./metrics/risk-var.md)
+
+## Rolling Metrics (`/analytics/risk/rolling-metrics`)
+- [ROLLING_VOLATILITY](./metrics/rolling-volatility.md)
+- [ROLLING_SHARPE](./metrics/rolling-sharpe.md)
+- [ROLLING_BETA](./metrics/rolling-beta.md)
+- [ROLLING_TRACKING_ERROR](./metrics/rolling-tracking-error.md)
+- [ROLLING_INFORMATION_RATIO](./metrics/rolling-information-ratio.md)
+- [ROLLING_MAX_DRAWDOWN](./metrics/rolling-max-drawdown.md)
+
+## Concentration Metrics (`/analytics/risk/concentration`)
+- [POSITION_HHI](./metrics/concentration-hhi.md)
+- [TOP_POSITION_WEIGHT](./metrics/concentration-top-position-weight.md)
+- [TOP_N_CUMULATIVE_WEIGHT](./metrics/concentration-top-n-cumulative-weight.md)
+- [ISSUER_HHI](./metrics/concentration-issuer-hhi.md)
+- [TOP_ISSUER_WEIGHT](./metrics/concentration-top-issuer-weight.md)
+
+## Drawdown Analytics Metrics (`/analytics/risk/drawdown`)
+- [MAX_DRAWDOWN](./metrics/drawdown-max-drawdown.md)
+- [TIME_UNDER_WATER_DAYS](./metrics/drawdown-time-under-water.md)
+- [AVERAGE_DRAWDOWN](./metrics/drawdown-average-drawdown.md)
+- [ULCER_INDEX](./metrics/drawdown-ulcer-index.md)
+- [DRAWDOWN_AT_RISK_AND_CDAR](./metrics/drawdown-dar-cdar.md)
+- [RELATIVE_MAX_DRAWDOWN](./metrics/drawdown-relative-max-drawdown.md)
+
+## Historical Attribution Metrics (`/analytics/risk/historical-attribution`)
+- [ATTRIBUTION_VOLATILITY](./metrics/attribution-volatility.md)
+- [ATTRIBUTION_TRACKING_ERROR](./metrics/attribution-tracking-error.md)
+
+## Notes
+- Stateful active tracking-error attribution is currently partial/pending benchmark exposure-history upstream contract.
+- All docs are aligned to current implementation in `main`.

--- a/docs/methodologies/metrics/attribution-tracking-error.md
+++ b/docs/methodologies/metrics/attribution-tracking-error.md
@@ -1,0 +1,45 @@
+# Historical Attribution Methodology - Tracking Error Attribution
+
+## Metric
+- metric_id: ATTRIBUTION_TRACKING_ERROR
+
+## Implementation Status
+- Current state:
+  - stateless: implemented
+  - stateful: partially implemented
+- Stateful dependency gap:
+  - benchmark exposure history contract is required from `lotus-core` to compute active weights by grouping dimension.
+  - expected upstream capability: benchmark exposure timeseries aligned to portfolio exposure timeseries window/dimension semantics.
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/historical-attribution
+- supported_modes: stateless, stateful (partial)
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+- Portfolio and benchmark exposure histories
+
+## Upstream Data Sources
+- Stateless: caller supplies all required series
+- Stateful: pending lotus-core benchmark exposure-history contract
+
+## Methodology and Formulas
+- active_return_t = Rp_t - Rb_t
+- active_weight_{g,t} = w_p,{g,t} - w_b,{g,t}
+- group_matrix = active_weight * active_return
+- total_value = std(active_return)*sqrt(annualization_basis)
+- covariance-based component decomposition as in volatility attribution
+
+## Configuration Options
+- attribution_options.attribution_types includes ACTIVE_RISK
+- metrics includes TRACKING_ERROR
+- grouping_dimensions
+- annualization_basis
+
+## Outputs
+- attribution_sets for ACTIVE_RISK/TRACKING_ERROR
+- contributors and reconciliation fields
+
+## Worked Example
+- Active return and active-weight series produce contributor components that reconcile to total tracking error

--- a/docs/methodologies/metrics/attribution-volatility.md
+++ b/docs/methodologies/metrics/attribution-volatility.md
@@ -1,0 +1,41 @@
+# Historical Attribution Methodology - Volatility Attribution
+
+## Metric
+- metric_id: ATTRIBUTION_VOLATILITY
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/historical-attribution
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Portfolio exposure history by grouping dimension
+- Periods and annualization basis
+
+## Upstream Data Sources
+- Stateless: caller returns + exposure_history
+- Stateful: lotus-performance returns + lotus-core position-timeseries + enrichment
+
+## Methodology and Formulas
+- metric_series = portfolio returns (decimal)
+- group_matrix = exposure_weight * metric_series
+- total_value = std(metric_series)*sqrt(annualization_basis)
+- component_i = cov(group_i,metric_series)/std(metric_series)*sqrt(annualization_basis)
+- marginal_i = component_i/avg_weight_i
+- percent_i = component_i/total_value
+
+## Configuration Options
+- attribution_options.attribution_types includes TOTAL_RISK
+- metrics includes VOLATILITY
+- grouping_dimensions
+- annualization_basis
+- covariance_method=EMPIRICAL
+
+## Outputs
+- attribution_sets[].total_value
+- reconciled_sum
+- residual
+- contributors[].marginal_contribution/component_contribution/percent_contribution
+
+## Worked Example
+- Components [0.08,0.04] reconcile to total 0.12 => percents 66.7%/33.3%

--- a/docs/methodologies/metrics/concentration-hhi.md
+++ b/docs/methodologies/metrics/concentration-hhi.md
@@ -1,0 +1,33 @@
+# Concentration Methodology - Position HHI
+
+## Metric
+- metric_id: POSITION_HHI
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/concentration
+- supported_modes: stateless, stateful, simulation
+
+## Inputs
+- Current and projected position values
+
+## Upstream Data Sources
+- Stateless: caller positions
+- Stateful: lotus-core core-snapshot positions_baseline
+- Simulation: lotus-core simulation session + changes + simulated snapshot
+
+## Methodology and Formulas
+- w_i = |v_i|/Σ|v|
+- HHI = Σ(w_i^2)*10000
+
+## Configuration Options
+- include_cash_positions
+- include_zero_quantity_positions
+- top_n (not used directly in HHI)
+
+## Outputs
+- risk_proxy.hhi_current
+- risk_proxy.hhi_proposed
+- risk_proxy.hhi_delta
+
+## Worked Example
+- Values [50,30,20] => HHI=3800

--- a/docs/methodologies/metrics/concentration-issuer-hhi.md
+++ b/docs/methodologies/metrics/concentration-issuer-hhi.md
@@ -1,0 +1,30 @@
+# Concentration Methodology - Issuer HHI
+
+## Metric
+- metric_id: ISSUER_HHI
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/concentration
+- supported_modes: stateless, stateful, simulation
+
+## Inputs
+- Position values
+- Security->issuer mapping
+
+## Upstream Data Sources
+- Caller issuer mappings and/or lotus-core enrichment-bulk according to enrichment_policy
+
+## Methodology and Formulas
+- Aggregate position values by issuer bucket
+- Apply HHI formula to issuer totals
+
+## Configuration Options
+- issuer_grouping_level
+- enrichment_policy
+
+## Outputs
+- issuer_concentration.hhi_current/proposed/delta
+- issuer_concentration.coverage_status + counters
+
+## Worked Example
+- Issuer totals [70,30] => issuer HHI=5800

--- a/docs/methodologies/metrics/concentration-top-issuer-weight.md
+++ b/docs/methodologies/metrics/concentration-top-issuer-weight.md
@@ -1,0 +1,28 @@
+# Concentration Methodology - Top Issuer Weight
+
+## Metric
+- metric_id: TOP_ISSUER_WEIGHT
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/concentration
+- supported_modes: stateless, stateful, simulation
+
+## Inputs
+- Issuer aggregated totals
+
+## Upstream Data Sources
+- Same as ISSUER_HHI
+
+## Methodology and Formulas
+- issuer_weight_j = |issuer_total_j|/Σ|issuer_total|
+- Top issuer = max_j(issuer_weight_j)
+
+## Configuration Options
+- issuer_grouping_level
+- enrichment_policy
+
+## Outputs
+- issuer_concentration.top_issuer_weight_current/proposed/delta
+
+## Worked Example
+- Issuer totals [70,30] => top issuer weight=0.7

--- a/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
+++ b/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
@@ -1,0 +1,30 @@
+# Concentration Methodology - Top-N Cumulative Weight
+
+## Metric
+- metric_id: TOP_N_CUMULATIVE_WEIGHT
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/concentration
+- supported_modes: stateless, stateful, simulation
+
+## Inputs
+- Position values
+- top_n
+
+## Upstream Data Sources
+- Same data sources as POSITION_HHI
+
+## Methodology and Formulas
+- Compute weights
+- Sort descending
+- Sum first N
+
+## Configuration Options
+- top_n
+
+## Outputs
+- single_position_concentration.top_n_cumulative_weight_current/proposed/delta
+- single_position_concentration.top_n
+
+## Worked Example
+- Weights [0.5,0.3,0.2], top_n=2 => 0.8

--- a/docs/methodologies/metrics/concentration-top-position-weight.md
+++ b/docs/methodologies/metrics/concentration-top-position-weight.md
@@ -1,0 +1,27 @@
+# Concentration Methodology - Top Position Weight
+
+## Metric
+- metric_id: TOP_POSITION_WEIGHT
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/concentration
+- supported_modes: stateless, stateful, simulation
+
+## Inputs
+- Position values by state
+
+## Upstream Data Sources
+- Same data sources as POSITION_HHI
+
+## Methodology and Formulas
+- w_i = |v_i|/Σ|v|
+- Top position = max_i(w_i)
+
+## Configuration Options
+- none beyond value selection rules
+
+## Outputs
+- single_position_concentration.top_position_weight_current/proposed/delta
+
+## Worked Example
+- Values [50,30,20] => top position weight=0.5

--- a/docs/methodologies/metrics/drawdown-average-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-average-drawdown.md
@@ -1,0 +1,26 @@
+# Drawdown Methodology - Average Drawdown
+
+## Metric
+- metric_id: AVERAGE_DRAWDOWN
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Underwater drawdown observations
+
+## Upstream Data Sources
+- Derived from return series
+
+## Methodology and Formulas
+- AVERAGE_DRAWDOWN = mean(drawdown_t where drawdown_t<0)
+
+## Configuration Options
+- None
+
+## Outputs
+- summary.average_drawdown
+
+## Worked Example
+- Underwater values [-0.02,-0.04,-0.01] => -0.0233

--- a/docs/methodologies/metrics/drawdown-dar-cdar.md
+++ b/docs/methodologies/metrics/drawdown-dar-cdar.md
@@ -1,0 +1,28 @@
+# Drawdown Methodology - Drawdown-at-Risk and CDaR
+
+## Metric
+- metric_id: DRAWDOWN_AT_RISK_AND_CDAR
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Episode depth distribution
+
+## Upstream Data Sources
+- Episode extraction from drawdown path
+
+## Methodology and Formulas
+- DaR_alpha = quantile(depths,1-alpha)
+- CDaR_alpha = mean(depth <= DaR_alpha)
+
+## Configuration Options
+- analysis_options.cdar_alpha (0.90,0.95,0.99)
+
+## Outputs
+- summary.drawdown_at_risk_95
+- summary.conditional_drawdown_at_risk_95
+
+## Worked Example
+- Depths [-0.03,-0.08,-0.12,-0.05], alpha=0.95 => DaR/CDaR from lower tail

--- a/docs/methodologies/metrics/drawdown-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-max-drawdown.md
@@ -1,0 +1,33 @@
+# Drawdown Methodology - Maximum Drawdown
+
+## Metric
+- metric_id: MAX_DRAWDOWN
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- wealth_t=Π(1+r_t)
+- drawdown_t=wealth_t/cummax(wealth_t)-1
+- MAX_DRAWDOWN=min(drawdown_t)
+
+## Configuration Options
+- analysis_options.duration_unit
+- analysis_options.include_episode_list
+
+## Outputs
+- summary.max_drawdown
+- max_drawdown_peak_date
+- max_drawdown_trough_date
+- max_drawdown_recovery_date
+
+## Worked Example
+- Returns(dec) [0.05,-0.10,0.02] => max drawdown=-0.10

--- a/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
@@ -1,0 +1,32 @@
+# Drawdown Methodology - Relative Max Drawdown vs Benchmark
+
+## Metric
+- metric_id: RELATIVE_MAX_DRAWDOWN
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller benchmark_returns
+- Stateful: lotus-performance benchmark_returns
+
+## Methodology and Formulas
+- active_t = portfolio_t - benchmark_t
+- Compute drawdown path on active return wealth index
+
+## Configuration Options
+- stateful benchmark_policy.include_benchmark
+- stateful benchmark_policy.missing_benchmark_policy
+
+## Outputs
+- relative_to_benchmark.max_drawdown
+- relative_to_benchmark.max_drawdown_peak_date
+- relative_to_benchmark.max_drawdown_trough_date
+
+## Worked Example
+- Active returns(dec): [0.01,-0.03,0.005] => relative max drawdown around -0.03

--- a/docs/methodologies/metrics/drawdown-time-under-water.md
+++ b/docs/methodologies/metrics/drawdown-time-under-water.md
@@ -1,0 +1,30 @@
+# Drawdown Methodology - Time Under Water
+
+## Metric
+- metric_id: TIME_UNDER_WATER_DAYS
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Drawdown series
+
+## Upstream Data Sources
+- Derived from return series
+
+## Methodology and Formulas
+- time_under_water_days = count(drawdown_t < 0)
+- Episode timing metrics are duration-unit aware
+
+## Configuration Options
+- analysis_options.duration_unit = BUSINESS_DAYS|CALENDAR_DAYS
+
+## Outputs
+- summary.time_under_water_days
+- episodes.days_to_trough
+- episodes.days_to_recovery
+- episodes.total_days
+
+## Worked Example
+- Drawdown [0,-0.02,-0.01,0] => time under water = 2

--- a/docs/methodologies/metrics/drawdown-ulcer-index.md
+++ b/docs/methodologies/metrics/drawdown-ulcer-index.md
@@ -1,0 +1,26 @@
+# Drawdown Methodology - Ulcer Index
+
+## Metric
+- metric_id: ULCER_INDEX
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/drawdown
+- supported_modes: stateless, stateful
+
+## Inputs
+- Full drawdown path
+
+## Upstream Data Sources
+- Derived from return series
+
+## Methodology and Formulas
+- ULCER_INDEX = sqrt(mean(drawdown_t^2))
+
+## Configuration Options
+- None
+
+## Outputs
+- summary.ulcer_index
+
+## Worked Example
+- Drawdown [0,-0.02,-0.04] => ulcer index=0.0258

--- a/docs/methodologies/metrics/risk-beta.md
+++ b/docs/methodologies/metrics/risk-beta.md
@@ -1,0 +1,31 @@
+# Risk Metric Methodology - Beta
+
+## Metric
+- metric_id: BETA
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns (date-aligned)
+
+## Upstream Data Sources
+- Stateless: caller benchmark_returns[]
+- Stateful: lotus-performance benchmark_returns
+
+## Methodology and Formulas
+- Beta = Cov(Rp,Rb)/Var(Rb), ddof=1
+- Inner date join before calculation
+
+## Configuration Options
+- options.frequency
+- options.use_log_returns
+
+## Outputs
+- results[period].metrics.BETA.value
+- details.error when benchmark variance is zero
+
+## Worked Example
+- Portfolio approximately 2x benchmark => beta ~= 2.0

--- a/docs/methodologies/metrics/risk-drawdown.md
+++ b/docs/methodologies/metrics/risk-drawdown.md
@@ -1,0 +1,32 @@
+# Risk Metric Methodology - Drawdown
+
+## Metric
+- metric_id: DRAWDOWN
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series for resolved period
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- wealth_t = Π(1+r_t)
+- peak_t = cummax(wealth_t)
+- drawdown_t = wealth_t/peak_t - 1
+- DRAWDOWN = min(drawdown_t)*100
+
+## Configuration Options
+- options.frequency (resample before calculation)
+
+## Outputs
+- results[period].metrics.DRAWDOWN.value
+- details.max_drawdown, peak_date, trough_date
+
+## Worked Example
+- Returns [%]: [10, -20, 5] => drawdown path [0, -0.2, -0.16]
+- Max drawdown = -20.0

--- a/docs/methodologies/metrics/risk-information-ratio.md
+++ b/docs/methodologies/metrics/risk-information-ratio.md
@@ -1,0 +1,30 @@
+# Risk Metric Methodology - Information Ratio
+
+## Metric
+- metric_id: INFORMATION_RATIO
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance
+
+## Methodology and Formulas
+- active_t = Rp_t - Rb_t
+- IR = (mean(active_t)/std(active_t))*sqrt(annual_factor)
+
+## Configuration Options
+- options.frequency
+- options.annualization_factor
+
+## Outputs
+- results[period].metrics.INFORMATION_RATIO.value
+
+## Worked Example
+- Active [%]: [0.2,0.1,-0.1,0.0] => IR ~= 6.15 (annual_factor=252)

--- a/docs/methodologies/metrics/risk-sharpe.md
+++ b/docs/methodologies/metrics/risk-sharpe.md
@@ -1,0 +1,34 @@
+# Risk Metric Methodology - Sharpe Ratio
+
+## Metric
+- metric_id: SHARPE
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series
+- Risk-free settings
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- periodic_rf = (1+annual_rf)^(1/annual_factor)-1 for ANNUAL_RATE mode
+- Sharpe = ((mean(r)-periodic_rf)/std(r))*sqrt(annual_factor)
+
+## Configuration Options
+- options.risk_free_mode
+- options.risk_free_annual_rate
+- options.frequency
+- options.annualization_factor
+
+## Outputs
+- results[period].metrics.SHARPE.value
+- details.error on zero volatility
+
+## Worked Example
+- mean=0.0005, std=0.01, annual_rf=0.02, annual_factor=252
+- Sharpe ~= 0.67

--- a/docs/methodologies/metrics/risk-sortino.md
+++ b/docs/methodologies/metrics/risk-sortino.md
@@ -1,0 +1,34 @@
+# Risk Metric Methodology - Sortino Ratio
+
+## Metric
+- metric_id: SORTINO
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series
+- MAR annual rate
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- periodic_mar = (1+mar_annual_rate)^(1/annual_factor)-1
+- downside = r_t-periodic_mar where downside<0
+- Sortino = ((mean(r)-periodic_mar)/sqrt(mean(downside^2)))*sqrt(annual_factor)
+
+## Configuration Options
+- options.mar_annual_rate
+- options.frequency
+- options.annualization_factor
+
+## Outputs
+- results[period].metrics.SORTINO.value
+- details.error when downside observations missing
+
+## Worked Example
+- Returns(dec): [0.01,-0.02,0.005], MAR=0
+- Sortino ~= -1.32

--- a/docs/methodologies/metrics/risk-tracking-error.md
+++ b/docs/methodologies/metrics/risk-tracking-error.md
@@ -1,0 +1,30 @@
+# Risk Metric Methodology - Tracking Error
+
+## Metric
+- metric_id: TRACKING_ERROR
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance
+
+## Methodology and Formulas
+- active_t = Rp_t - Rb_t
+- TE = std(active_t,ddof=1)*sqrt(annual_factor)
+
+## Configuration Options
+- options.frequency
+- options.annualization_factor
+
+## Outputs
+- results[period].metrics.TRACKING_ERROR.value
+
+## Worked Example
+- Active [%]: [0.1,-0.2,0.1], annual_factor=252 => TE ~= 2.75

--- a/docs/methodologies/metrics/risk-var.md
+++ b/docs/methodologies/metrics/risk-var.md
@@ -1,0 +1,37 @@
+# Risk Metric Methodology - Value at Risk
+
+## Metric
+- metric_id: VAR
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series
+- VaR method/confidence/horizon
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- HISTORICAL: percentile(alpha)
+- GAUSSIAN: mean + std*z_alpha
+- CORNISH_FISHER: adjusted z using skew/kurtosis
+- scaled_var = base_var*sqrt(horizon_days)
+- ES optional as tail mean
+
+## Configuration Options
+- options.var.method
+- options.var.confidence
+- options.var.horizon_days
+- options.var.include_expected_shortfall
+
+## Outputs
+- results[period].metrics.VAR.value
+- details.expected_shortfall when enabled
+
+## Worked Example
+- Returns [%]: [-2,-1,0,1,2], confidence=95%
+- Historical VaR ~= -1.8, horizon=4 => -3.6

--- a/docs/methodologies/metrics/risk-volatility.md
+++ b/docs/methodologies/metrics/risk-volatility.md
@@ -1,0 +1,34 @@
+# Risk Metric Methodology - Volatility
+
+## Metric
+- metric_id: VOLATILITY
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/calculate
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio return series for resolved period
+- Annualization basis (frequency or override)
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance /integration/returns/series -> portfolio_returns
+
+## Methodology and Formulas
+- sigma = std(returns, ddof=1)
+- VOLATILITY = sigma * sqrt(annualization_factor)
+- If use_log_returns=true: transform r_t = ln(1+r_t)
+
+## Configuration Options
+- options.frequency
+- options.annualization_factor
+- options.use_log_returns
+
+## Outputs
+- results[period].metrics.VOLATILITY.value
+- details.error when insufficient data
+
+## Worked Example
+- Returns [%]: [1.0, -0.5, 0.2]
+- std ~= 0.7506, annual_factor=252 => volatility ~= 11.92

--- a/docs/methodologies/metrics/rolling-beta.md
+++ b/docs/methodologies/metrics/rolling-beta.md
@@ -1,0 +1,31 @@
+# Rolling Metric Methodology - Rolling Beta
+
+## Metric
+- metric_id: ROLLING_BETA
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller benchmark_returns[]
+- Stateful: lotus-performance benchmark_returns
+
+## Methodology and Formulas
+- rolling_cov(portfolio,benchmark)/rolling_var(benchmark)
+
+## Configuration Options
+- window_lengths
+- min_observations_policy
+- alignment_policy INNER_JOIN
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_BETA
+- quality flag metric:ROLLING_BETA:benchmark_variance_zero
+
+## Worked Example
+- Portfolio ~1.5x benchmark over window => rolling beta ~1.5

--- a/docs/methodologies/metrics/rolling-information-ratio.md
+++ b/docs/methodologies/metrics/rolling-information-ratio.md
@@ -1,0 +1,31 @@
+# Rolling Metric Methodology - Rolling Information Ratio
+
+## Metric
+- metric_id: ROLLING_INFORMATION_RATIO
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance
+
+## Methodology and Formulas
+- active_t = Rp_t - Rb_t
+- rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+
+## Configuration Options
+- window_lengths
+- annualization_basis
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_INFORMATION_RATIO
+- quality flag metric:ROLLING_INFORMATION_RATIO:zero_tracking_error_window
+
+## Worked Example
+- Computed per rolling window on active return stream

--- a/docs/methodologies/metrics/rolling-max-drawdown.md
+++ b/docs/methodologies/metrics/rolling-max-drawdown.md
@@ -1,0 +1,31 @@
+# Rolling Metric Methodology - Rolling Max Drawdown
+
+## Metric
+- metric_id: ROLLING_MAX_DRAWDOWN
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- window_lengths[]
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance
+
+## Methodology and Formulas
+- For each rolling window: wealth=Π(1+r)
+- drawdown=wealth/cummax(wealth)-1
+- window metric=min(drawdown)
+
+## Configuration Options
+- window_lengths
+- min_observations_policy
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_MAX_DRAWDOWN
+
+## Worked Example
+- Window returns [0.02,-0.03,0.01] => rolling max drawdown ~ -0.03

--- a/docs/methodologies/metrics/rolling-sharpe.md
+++ b/docs/methodologies/metrics/rolling-sharpe.md
@@ -1,0 +1,32 @@
+# Rolling Metric Methodology - Rolling Sharpe
+
+## Metric
+- metric_id: ROLLING_SHARPE
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Risk-free returns
+
+## Upstream Data Sources
+- Stateless: caller risk_free_returns[]
+- Stateful: lotus-performance risk_free_returns
+
+## Methodology and Formulas
+- active_t = portfolio_t - risk_free_t
+- rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+
+## Configuration Options
+- window_lengths
+- annualization_basis
+- alignment_policy INNER_JOIN
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_SHARPE
+- quality flag metric:ROLLING_SHARPE:zero_volatility_window
+
+## Worked Example
+- Window=3 active(dec) [0.001,0.002,-0.001] => rolling Sharpe ~= 6.93

--- a/docs/methodologies/metrics/rolling-tracking-error.md
+++ b/docs/methodologies/metrics/rolling-tracking-error.md
@@ -1,0 +1,30 @@
+# Rolling Metric Methodology - Rolling Tracking Error
+
+## Metric
+- metric_id: ROLLING_TRACKING_ERROR
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- Benchmark returns
+
+## Upstream Data Sources
+- Stateless: caller
+- Stateful: lotus-performance
+
+## Methodology and Formulas
+- active_t = Rp_t - Rb_t
+- rolling_std(active)*sqrt(annualization_basis)
+
+## Configuration Options
+- window_lengths
+- annualization_basis
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_TRACKING_ERROR
+
+## Worked Example
+- Window=3 active(dec) [0.001,-0.002,0.001] => 0.0275

--- a/docs/methodologies/metrics/rolling-volatility.md
+++ b/docs/methodologies/metrics/rolling-volatility.md
@@ -1,0 +1,32 @@
+# Rolling Metric Methodology - Rolling Volatility
+
+## Metric
+- metric_id: ROLLING_VOLATILITY
+
+## Endpoint and Mode Coverage
+- endpoint: /analytics/risk/rolling-metrics
+- supported_modes: stateless, stateful
+
+## Inputs
+- Portfolio returns
+- window_lengths[]
+
+## Upstream Data Sources
+- Stateless: caller returns[]
+- Stateful: lotus-performance portfolio_returns
+
+## Methodology and Formulas
+- Convert returns to decimal
+- rolling_std(window,ddof=1)*sqrt(annualization_basis)
+
+## Configuration Options
+- rolling_options.window_lengths
+- rolling_options.annualization_basis
+- rolling_options.min_observations_policy
+
+## Outputs
+- window_results[].metric_summaries.ROLLING_VOLATILITY
+- optional metric_series
+
+## Worked Example
+- Window=3, returns(dec) [0.01,-0.02,0.015] => 0.3005 annualized


### PR DESCRIPTION
## Summary
- add gold-standard methodology documentation pack for Lotus-Risk metrics
- add master metrics index and one document per metric with inputs, formulas, outputs, configuration, endpoint/mode mapping, upstream sources, and worked examples
- include explicit implementation status matrix and stateful attribution dependency gap notes

## Validation
- docs-only change