### PR TITLE
docs: deepen metric methodology walkthroughs and unit conventions

### DIFF
--- a/docs/methodologies/metrics/attribution-tracking-error.md
+++ b/docs/methodologies/metrics/attribution-tracking-error.md
@@ -3,14 +3,6 @@
 ## Metric
 - metric_id: ATTRIBUTION_TRACKING_ERROR
 
-## Implementation Status
-- Current state:
-  - stateless: implemented
-  - stateful: partially implemented
-- Stateful dependency gap:
-  - benchmark exposure history contract is required from `lotus-core` to compute active weights by grouping dimension.
-  - expected upstream capability: benchmark exposure timeseries aligned to portfolio exposure timeseries window/dimension semantics.
-
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/historical-attribution
 - supported_modes: stateless, stateful (partial)
@@ -24,12 +16,27 @@
 - Stateless: caller supplies all required series
 - Stateful: pending lotus-core benchmark exposure-history contract
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_return_t = Rp_t - Rb_t
 - active_weight_{g,t} = w_p,{g,t} - w_b,{g,t}
 - group_matrix = active_weight * active_return
 - total_value = std(active_return)*sqrt(annualization_basis)
 - covariance-based component decomposition as in volatility attribution
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_return_t = Rp_t - Rb_t
+4. Apply: active_weight_{g,t} = w_p,{g,t} - w_b,{g,t}
+5. Apply: group_matrix = active_weight * active_return
+6. Apply: total_value = std(active_return)*sqrt(annualization_basis)
+7. Apply: covariance-based component decomposition as in volatility attribution
+8. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - attribution_options.attribution_types includes ACTIVE_RISK
@@ -42,4 +49,10 @@
 - contributors and reconciliation fields
 
 ## Worked Example
+Given:
 - Active return and active-weight series produce contributor components that reconcile to total tracking error
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/attribution-volatility.md
+++ b/docs/methodologies/metrics/attribution-volatility.md
@@ -16,6 +16,11 @@
 - Stateless: caller returns + exposure_history
 - Stateful: lotus-performance returns + lotus-core position-timeseries + enrichment
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - metric_series = portfolio returns (decimal)
 - group_matrix = exposure_weight * metric_series
@@ -23,6 +28,17 @@
 - component_i = cov(group_i,metric_series)/std(metric_series)*sqrt(annualization_basis)
 - marginal_i = component_i/avg_weight_i
 - percent_i = component_i/total_value
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: metric_series = portfolio returns (decimal)
+4. Apply: group_matrix = exposure_weight * metric_series
+5. Apply: total_value = std(metric_series)*sqrt(annualization_basis)
+6. Apply: component_i = cov(group_i,metric_series)/std(metric_series)*sqrt(annualization_basis)
+7. Apply: marginal_i = component_i/avg_weight_i
+8. Apply: percent_i = component_i/total_value
+9. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - attribution_options.attribution_types includes TOTAL_RISK
@@ -38,4 +54,10 @@
 - contributors[].marginal_contribution/component_contribution/percent_contribution
 
 ## Worked Example
+Given:
 - Components [0.08,0.04] reconcile to total 0.12 => percents 66.7%/33.3%
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/concentration-hhi.md
+++ b/docs/methodologies/metrics/concentration-hhi.md
@@ -15,9 +15,21 @@
 - Stateful: lotus-core core-snapshot positions_baseline
 - Simulation: lotus-core simulation session + changes + simulated snapshot
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - w_i = |v_i|/Σ|v|
 - HHI = Σ(w_i^2)*10000
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: w_i = |v_i|/Σ|v|
+4. Apply: HHI = Σ(w_i^2)*10000
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - include_cash_positions
@@ -30,4 +42,10 @@
 - risk_proxy.hhi_delta
 
 ## Worked Example
+Given:
 - Values [50,30,20] => HHI=3800
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/concentration-issuer-hhi.md
+++ b/docs/methodologies/metrics/concentration-issuer-hhi.md
@@ -14,9 +14,21 @@
 ## Upstream Data Sources
 - Caller issuer mappings and/or lotus-core enrichment-bulk according to enrichment_policy
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - Aggregate position values by issuer bucket
 - Apply HHI formula to issuer totals
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: Aggregate position values by issuer bucket
+4. Apply: Apply HHI formula to issuer totals
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - issuer_grouping_level
@@ -27,4 +39,10 @@
 - issuer_concentration.coverage_status + counters
 
 ## Worked Example
+Given:
 - Issuer totals [70,30] => issuer HHI=5800
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/concentration-top-issuer-weight.md
+++ b/docs/methodologies/metrics/concentration-top-issuer-weight.md
@@ -13,9 +13,21 @@
 ## Upstream Data Sources
 - Same as ISSUER_HHI
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - issuer_weight_j = |issuer_total_j|/Σ|issuer_total|
 - Top issuer = max_j(issuer_weight_j)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: issuer_weight_j = |issuer_total_j|/Σ|issuer_total|
+4. Apply: Top issuer = max_j(issuer_weight_j)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - issuer_grouping_level
@@ -25,4 +37,10 @@
 - issuer_concentration.top_issuer_weight_current/proposed/delta
 
 ## Worked Example
+Given:
 - Issuer totals [70,30] => top issuer weight=0.7
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
+++ b/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
@@ -14,10 +14,23 @@
 ## Upstream Data Sources
 - Same data sources as POSITION_HHI
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - Compute weights
 - Sort descending
 - Sum first N
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: Compute weights
+4. Apply: Sort descending
+5. Apply: Sum first N
+6. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - top_n
@@ -27,4 +40,10 @@
 - single_position_concentration.top_n
 
 ## Worked Example
+Given:
 - Weights [0.5,0.3,0.2], top_n=2 => 0.8
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/concentration-top-position-weight.md
+++ b/docs/methodologies/metrics/concentration-top-position-weight.md
@@ -13,9 +13,21 @@
 ## Upstream Data Sources
 - Same data sources as POSITION_HHI
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - w_i = |v_i|/Σ|v|
 - Top position = max_i(w_i)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: w_i = |v_i|/Σ|v|
+4. Apply: Top position = max_i(w_i)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - none beyond value selection rules
@@ -24,4 +36,10 @@
 - single_position_concentration.top_position_weight_current/proposed/delta
 
 ## Worked Example
+Given:
 - Values [50,30,20] => top position weight=0.5
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/drawdown-average-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-average-drawdown.md
@@ -13,8 +13,19 @@
 ## Upstream Data Sources
 - Derived from return series
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - AVERAGE_DRAWDOWN = mean(drawdown_t where drawdown_t<0)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: AVERAGE_DRAWDOWN = mean(drawdown_t where drawdown_t<0)
+4. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - None
@@ -23,4 +34,10 @@
 - summary.average_drawdown
 
 ## Worked Example
+Given:
 - Underwater values [-0.02,-0.04,-0.01] => -0.0233
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/drawdown-dar-cdar.md
+++ b/docs/methodologies/metrics/drawdown-dar-cdar.md
@@ -13,9 +13,21 @@
 ## Upstream Data Sources
 - Episode extraction from drawdown path
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - DaR_alpha = quantile(depths,1-alpha)
 - CDaR_alpha = mean(depth <= DaR_alpha)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: DaR_alpha = quantile(depths,1-alpha)
+4. Apply: CDaR_alpha = mean(depth <= DaR_alpha)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - analysis_options.cdar_alpha (0.90,0.95,0.99)
@@ -25,4 +37,10 @@
 - summary.conditional_drawdown_at_risk_95
 
 ## Worked Example
+Given:
 - Depths [-0.03,-0.08,-0.12,-0.05], alpha=0.95 => DaR/CDaR from lower tail
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/drawdown-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-max-drawdown.md
@@ -8,26 +8,110 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series
+- Portfolio return time series for the resolved period.
+- Return contract unit: percentage points (`value=1.0` means `+1%`).
+- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, etc.).
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance portfolio_returns
+- Stateless:
+  - caller provides `stateless_input.returns[]`.
+- Stateful:
+  - lotus-risk sources `series.portfolio_returns` from lotus-performance `/integration/returns/series`.
+
+## Unit Conventions
+- Input return values are provided in percentage points in the API contract.
+- Engine computation normalizes to decimal for wealth-path math:
+  - `r_decimal = r_percentage_points / 100`
+- `MAX_DRAWDOWN` output is in decimal drawdown units (for example `-0.10` means `-10%`).
 
 ## Methodology and Formulas
-- wealth_t=Π(1+r_t)
-- drawdown_t=wealth_t/cummax(wealth_t)-1
-- MAX_DRAWDOWN=min(drawdown_t)
+1. Convert API returns to decimal:
+- `r_t(decimal) = r_t(percentage_points) / 100`
+
+2. Build cumulative wealth path:
+- `wealth_t = ∏(1 + r_i)`, for `i=1..t`
+
+3. Build running peak path:
+- `peak_t = max(wealth_1..wealth_t)`
+
+4. Build underwater (drawdown) series:
+- `drawdown_t = (wealth_t / peak_t) - 1`
+
+5. Compute maximum drawdown:
+- `MAX_DRAWDOWN = min_t(drawdown_t)`
+- Result is negative or zero.
+
+6. Peak/trough/recovery attribution:
+- episode starts when drawdown moves below zero
+- trough is minimum drawdown point in that episode
+- recovery is first date where drawdown returns to `>= 0`
+- if not recovered before period end, recovery date is `null`
+
+## Step-by-Step Computation
+1. Resolve the analysis period and extract portfolio returns for that period.
+2. Convert return values from percentage-point contract units to decimal.
+3. Build cumulative wealth path (`wealth_t`), running peak path (`peak_t`), and drawdown path (`drawdown_t`).
+4. Select `min(drawdown_t)` as `MAX_DRAWDOWN`.
+5. Identify episode boundaries and map peak/trough/recovery dates for summary fields.
+6. Return metric values and episode metadata in response fields.
 
 ## Configuration Options
-- analysis_options.duration_unit
-- analysis_options.include_episode_list
+- `analysis_options.duration_unit`:
+  - controls episode day counters (`BUSINESS_DAYS` vs `CALENDAR_DAYS`)
+  - does not change numeric `MAX_DRAWDOWN`.
+- `analysis_options.include_episode_list`:
+  - controls whether episodes are emitted in response
+  - does not change summary max drawdown value.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps`:
+  - affect episode list selection
+  - do not change summary max drawdown value.
 
 ## Outputs
-- summary.max_drawdown
-- max_drawdown_peak_date
-- max_drawdown_trough_date
-- max_drawdown_recovery_date
+- `results[period].summary.max_drawdown`
+- `results[period].summary.max_drawdown_peak_date`
+- `results[period].summary.max_drawdown_trough_date`
+- `results[period].summary.max_drawdown_recovery_date`
+- `results[period].summary.is_recovered`
+- `results[period].summary.days_to_trough`
+- `results[period].summary.days_to_recovery`
 
 ## Worked Example
-- Returns(dec) [0.05,-0.10,0.02] => max drawdown=-0.10
+Input returns (percentage points):
+- Day 1: `+5.00`
+- Day 2: `-10.00`
+- Day 3: `+2.00`
+- Day 4: `+4.00`
+
+Step 1. Convert to decimal:
+- Day 1: `0.0500`
+- Day 2: `-0.1000`
+- Day 3: `0.0200`
+- Day 4: `0.0400`
+
+Step 2. Wealth path (`wealth_t = ∏(1+r_t)`):
+- Day 1: `1.050000`
+- Day 2: `1.050000 * 0.900000 = 0.945000`
+- Day 3: `0.945000 * 1.020000 = 0.963900`
+- Day 4: `0.963900 * 1.040000 = 1.002456`
+
+Step 3. Running peak:
+- Day 1: `1.050000`
+- Day 2: `1.050000`
+- Day 3: `1.050000`
+- Day 4: `1.050000`
+
+Step 4. Drawdown series (`wealth/peak - 1`):
+- Day 1: `1.050000/1.050000 - 1 = 0.000000`
+- Day 2: `0.945000/1.050000 - 1 = -0.100000`
+- Day 3: `0.963900/1.050000 - 1 = -0.082000`
+- Day 4: `1.002456/1.050000 - 1 = -0.045280`
+
+Step 5. Maximum drawdown:
+- `min(drawdown_t) = -0.100000`
+- Final metric value: `max_drawdown = -0.10` (equivalent to `-10.00%`).
+
+Step 6. Peak/trough/recovery:
+- peak date: Day 1
+- trough date: Day 2
+- recovery date: `null` in this sample (drawdown never returned to non-negative)
+

--- a/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
@@ -15,9 +15,21 @@
 - Stateless: caller benchmark_returns
 - Stateful: lotus-performance benchmark_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = portfolio_t - benchmark_t
 - Compute drawdown path on active return wealth index
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = portfolio_t - benchmark_t
+4. Apply: Compute drawdown path on active return wealth index
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - stateful benchmark_policy.include_benchmark
@@ -29,4 +41,10 @@
 - relative_to_benchmark.max_drawdown_trough_date
 
 ## Worked Example
+Given:
 - Active returns(dec): [0.01,-0.03,0.005] => relative max drawdown around -0.03
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/drawdown-time-under-water.md
+++ b/docs/methodologies/metrics/drawdown-time-under-water.md
@@ -13,9 +13,21 @@
 ## Upstream Data Sources
 - Derived from return series
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - time_under_water_days = count(drawdown_t < 0)
 - Episode timing metrics are duration-unit aware
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: time_under_water_days = count(drawdown_t < 0)
+4. Apply: Episode timing metrics are duration-unit aware
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - analysis_options.duration_unit = BUSINESS_DAYS|CALENDAR_DAYS
@@ -27,4 +39,10 @@
 - episodes.total_days
 
 ## Worked Example
+Given:
 - Drawdown [0,-0.02,-0.01,0] => time under water = 2
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/drawdown-ulcer-index.md
+++ b/docs/methodologies/metrics/drawdown-ulcer-index.md
@@ -13,8 +13,19 @@
 ## Upstream Data Sources
 - Derived from return series
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - ULCER_INDEX = sqrt(mean(drawdown_t^2))
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: ULCER_INDEX = sqrt(mean(drawdown_t^2))
+4. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - None
@@ -23,4 +34,10 @@
 - summary.ulcer_index
 
 ## Worked Example
+Given:
 - Drawdown [0,-0.02,-0.04] => ulcer index=0.0258
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-beta.md
+++ b/docs/methodologies/metrics/risk-beta.md
@@ -15,9 +15,21 @@
 - Stateless: caller benchmark_returns[]
 - Stateful: lotus-performance benchmark_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - Beta = Cov(Rp,Rb)/Var(Rb), ddof=1
 - Inner date join before calculation
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: Beta = Cov(Rp,Rb)/Var(Rb), ddof=1
+4. Apply: Inner date join before calculation
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.frequency
@@ -28,4 +40,10 @@
 - details.error when benchmark variance is zero
 
 ## Worked Example
+Given:
 - Portfolio approximately 2x benchmark => beta ~= 2.0
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-drawdown.md
+++ b/docs/methodologies/metrics/risk-drawdown.md
@@ -14,11 +14,25 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - wealth_t = Π(1+r_t)
 - peak_t = cummax(wealth_t)
 - drawdown_t = wealth_t/peak_t - 1
 - DRAWDOWN = min(drawdown_t)*100
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: wealth_t = Π(1+r_t)
+4. Apply: peak_t = cummax(wealth_t)
+5. Apply: drawdown_t = wealth_t/peak_t - 1
+6. Apply: DRAWDOWN = min(drawdown_t)*100
+7. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.frequency (resample before calculation)
@@ -28,5 +42,11 @@
 - details.max_drawdown, peak_date, trough_date
 
 ## Worked Example
+Given:
 - Returns [%]: [10, -20, 5] => drawdown path [0, -0.2, -0.16]
 - Max drawdown = -20.0
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-information-ratio.md
+++ b/docs/methodologies/metrics/risk-information-ratio.md
@@ -15,9 +15,21 @@
 - Stateless: caller
 - Stateful: lotus-performance
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = Rp_t - Rb_t
 - IR = (mean(active_t)/std(active_t))*sqrt(annual_factor)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = Rp_t - Rb_t
+4. Apply: IR = (mean(active_t)/std(active_t))*sqrt(annual_factor)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.frequency
@@ -27,4 +39,10 @@
 - results[period].metrics.INFORMATION_RATIO.value
 
 ## Worked Example
+Given:
 - Active [%]: [0.2,0.1,-0.1,0.0] => IR ~= 6.15 (annual_factor=252)
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-sharpe.md
+++ b/docs/methodologies/metrics/risk-sharpe.md
@@ -15,9 +15,21 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - periodic_rf = (1+annual_rf)^(1/annual_factor)-1 for ANNUAL_RATE mode
 - Sharpe = ((mean(r)-periodic_rf)/std(r))*sqrt(annual_factor)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: periodic_rf = (1+annual_rf)^(1/annual_factor)-1 for ANNUAL_RATE mode
+4. Apply: Sharpe = ((mean(r)-periodic_rf)/std(r))*sqrt(annual_factor)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.risk_free_mode
@@ -30,5 +42,11 @@
 - details.error on zero volatility
 
 ## Worked Example
+Given:
 - mean=0.0005, std=0.01, annual_rf=0.02, annual_factor=252
 - Sharpe ~= 0.67
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-sortino.md
+++ b/docs/methodologies/metrics/risk-sortino.md
@@ -15,10 +15,23 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - periodic_mar = (1+mar_annual_rate)^(1/annual_factor)-1
 - downside = r_t-periodic_mar where downside<0
 - Sortino = ((mean(r)-periodic_mar)/sqrt(mean(downside^2)))*sqrt(annual_factor)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: periodic_mar = (1+mar_annual_rate)^(1/annual_factor)-1
+4. Apply: downside = r_t-periodic_mar where downside<0
+5. Apply: Sortino = ((mean(r)-periodic_mar)/sqrt(mean(downside^2)))*sqrt(annual_factor)
+6. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.mar_annual_rate
@@ -30,5 +43,11 @@
 - details.error when downside observations missing
 
 ## Worked Example
+Given:
 - Returns(dec): [0.01,-0.02,0.005], MAR=0
 - Sortino ~= -1.32
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-tracking-error.md
+++ b/docs/methodologies/metrics/risk-tracking-error.md
@@ -15,9 +15,21 @@
 - Stateless: caller
 - Stateful: lotus-performance
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = Rp_t - Rb_t
 - TE = std(active_t,ddof=1)*sqrt(annual_factor)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = Rp_t - Rb_t
+4. Apply: TE = std(active_t,ddof=1)*sqrt(annual_factor)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.frequency
@@ -27,4 +39,10 @@
 - results[period].metrics.TRACKING_ERROR.value
 
 ## Worked Example
+Given:
 - Active [%]: [0.1,-0.2,0.1], annual_factor=252 => TE ~= 2.75
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-var.md
+++ b/docs/methodologies/metrics/risk-var.md
@@ -15,12 +15,27 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - HISTORICAL: percentile(alpha)
 - GAUSSIAN: mean + std*z_alpha
 - CORNISH_FISHER: adjusted z using skew/kurtosis
 - scaled_var = base_var*sqrt(horizon_days)
 - ES optional as tail mean
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: HISTORICAL: percentile(alpha)
+4. Apply: GAUSSIAN: mean + std*z_alpha
+5. Apply: CORNISH_FISHER: adjusted z using skew/kurtosis
+6. Apply: scaled_var = base_var*sqrt(horizon_days)
+7. Apply: ES optional as tail mean
+8. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.var.method
@@ -33,5 +48,11 @@
 - details.expected_shortfall when enabled
 
 ## Worked Example
+Given:
 - Returns [%]: [-2,-1,0,1,2], confidence=95%
 - Historical VaR ~= -1.8, horizon=4 => -3.6
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/risk-volatility.md
+++ b/docs/methodologies/metrics/risk-volatility.md
@@ -15,10 +15,23 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance /integration/returns/series -> portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - sigma = std(returns, ddof=1)
 - VOLATILITY = sigma * sqrt(annualization_factor)
 - If use_log_returns=true: transform r_t = ln(1+r_t)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: sigma = std(returns, ddof=1)
+4. Apply: VOLATILITY = sigma * sqrt(annualization_factor)
+5. Apply: If use_log_returns=true: transform r_t = ln(1+r_t)
+6. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - options.frequency
@@ -30,5 +43,11 @@
 - details.error when insufficient data
 
 ## Worked Example
+Given:
 - Returns [%]: [1.0, -0.5, 0.2]
 - std ~= 0.7506, annual_factor=252 => volatility ~= 11.92
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-beta.md
+++ b/docs/methodologies/metrics/rolling-beta.md
@@ -15,8 +15,19 @@
 - Stateless: caller benchmark_returns[]
 - Stateful: lotus-performance benchmark_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - rolling_cov(portfolio,benchmark)/rolling_var(benchmark)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: rolling_cov(portfolio,benchmark)/rolling_var(benchmark)
+4. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - window_lengths
@@ -28,4 +39,10 @@
 - quality flag metric:ROLLING_BETA:benchmark_variance_zero
 
 ## Worked Example
+Given:
 - Portfolio ~1.5x benchmark over window => rolling beta ~1.5
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-information-ratio.md
+++ b/docs/methodologies/metrics/rolling-information-ratio.md
@@ -15,9 +15,21 @@
 - Stateless: caller
 - Stateful: lotus-performance
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = Rp_t - Rb_t
 - rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = Rp_t - Rb_t
+4. Apply: rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - window_lengths
@@ -28,4 +40,10 @@
 - quality flag metric:ROLLING_INFORMATION_RATIO:zero_tracking_error_window
 
 ## Worked Example
+Given:
 - Computed per rolling window on active return stream
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-max-drawdown.md
+++ b/docs/methodologies/metrics/rolling-max-drawdown.md
@@ -15,10 +15,23 @@
 - Stateless: caller
 - Stateful: lotus-performance
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - For each rolling window: wealth=Π(1+r)
 - drawdown=wealth/cummax(wealth)-1
 - window metric=min(drawdown)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: For each rolling window: wealth=Π(1+r)
+4. Apply: drawdown=wealth/cummax(wealth)-1
+5. Apply: window metric=min(drawdown)
+6. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - window_lengths
@@ -28,4 +41,10 @@
 - window_results[].metric_summaries.ROLLING_MAX_DRAWDOWN
 
 ## Worked Example
+Given:
 - Window returns [0.02,-0.03,0.01] => rolling max drawdown ~ -0.03
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-sharpe.md
+++ b/docs/methodologies/metrics/rolling-sharpe.md
@@ -15,9 +15,21 @@
 - Stateless: caller risk_free_returns[]
 - Stateful: lotus-performance risk_free_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = portfolio_t - risk_free_t
 - rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = portfolio_t - risk_free_t
+4. Apply: rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - window_lengths
@@ -29,4 +41,10 @@
 - quality flag metric:ROLLING_SHARPE:zero_volatility_window
 
 ## Worked Example
+Given:
 - Window=3 active(dec) [0.001,0.002,-0.001] => rolling Sharpe ~= 6.93
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-tracking-error.md
+++ b/docs/methodologies/metrics/rolling-tracking-error.md
@@ -15,9 +15,21 @@
 - Stateless: caller
 - Stateful: lotus-performance
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - active_t = Rp_t - Rb_t
 - rolling_std(active)*sqrt(annualization_basis)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: active_t = Rp_t - Rb_t
+4. Apply: rolling_std(active)*sqrt(annualization_basis)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - window_lengths
@@ -27,4 +39,10 @@
 - window_results[].metric_summaries.ROLLING_TRACKING_ERROR
 
 ## Worked Example
+Given:
 - Window=3 active(dec) [0.001,-0.002,0.001] => 0.0275
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+

--- a/docs/methodologies/metrics/rolling-volatility.md
+++ b/docs/methodologies/metrics/rolling-volatility.md
@@ -15,9 +15,21 @@
 - Stateless: caller returns[]
 - Stateful: lotus-performance portfolio_returns
 
+## Unit Conventions
+- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
+- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
+- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+
 ## Methodology and Formulas
 - Convert returns to decimal
 - rolling_std(window,ddof=1)*sqrt(annualization_basis)
+
+## Step-by-Step Computation
+1. Resolve period/filter window and applicable alignment policy from the request options.
+2. Normalize units and prepare aligned series/matrices required by the metric formula.
+3. Apply: Convert returns to decimal
+4. Apply: rolling_std(window,ddof=1)*sqrt(annualization_basis)
+5. Map computed values to response fields and include deterministic error/quality signals when applicable.
 
 ## Configuration Options
 - rolling_options.window_lengths
@@ -29,4 +41,10 @@
 - optional metric_series
 
 ## Worked Example
+Given:
 - Window=3, returns(dec) [0.01,-0.02,0.015] => 0.3005 annualized
+Apply:
+- Execute the formulas above in the listed order after unit normalization.
+Result:
+- Populate output fields exactly as listed in the Outputs section.
+


### PR DESCRIPTION
## Summary
- deepen methodology documentation across all Lotus-Risk metric docs
- add explicit unit conventions section for each metric
- add step-by-step computation section for each metric
- retain improved detailed walkthrough style in drawdown max-drawdown and align pack structure

## Validation
- docs-only changes