### PR TITLE
docs: elevate all risk metric methodologies to gold-standard detail

### DIFF
--- a/docs/methodologies/metrics/attribution-tracking-error.md
+++ b/docs/methodologies/metrics/attribution-tracking-error.md
@@ -1,58 +1,49 @@
-# Historical Attribution Methodology - Tracking Error Attribution
+# Historical Attribution Methodology - Tracking Error Contribution
 
 ## Metric
-- metric_id: ATTRIBUTION_TRACKING_ERROR
+- metric_id: TRACKING_ERROR_ATTRIBUTION
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/historical-attribution
-- supported_modes: stateless, stateful (partial)
+- supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
-- Portfolio and benchmark exposure histories
+- Portfolio and benchmark returns.
+- Portfolio and benchmark exposure history.
 
 ## Upstream Data Sources
-- Stateless: caller supplies all required series
-- Stateful: pending lotus-core benchmark exposure-history contract
+- Stateless caller datasets.
+- Stateful integrated contracts (including benchmark exposure history).
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_return_t = Rp_t - Rb_t
-- active_weight_{g,t} = w_p,{g,t} - w_b,{g,t}
-- group_matrix = active_weight * active_return
-- total_value = std(active_return)*sqrt(annualization_basis)
-- covariance-based component decomposition as in volatility attribution
+1. `a_t=(Rp_t-Rb_t)/100`.
+2. `aw_{k,t}=w_p_{k,t}-w_b_{k,t}`.
+3. `g_{k,t}=aw_{k,t}*a_t`.
+4. `TE=std(a_t)*sqrt(annualization_basis)`.
+5. `CC_k=cov(g_k,a)/std(a)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_return_t = Rp_t - Rb_t
-4. Apply: active_weight_{g,t} = w_p,{g,t} - w_b,{g,t}
-5. Apply: group_matrix = active_weight * active_return
-6. Apply: total_value = std(active_return)*sqrt(annualization_basis)
-7. Apply: covariance-based component decomposition as in volatility attribution
-8. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align return and exposure series.
+2. Build active return and active weight matrices.
+3. Compute component contributions by group.
+4. Reconcile against total tracking error.
 
 ## Configuration Options
-- attribution_options.attribution_types includes ACTIVE_RISK
-- metrics includes TRACKING_ERROR
-- grouping_dimensions
-- annualization_basis
+- `attribution_options.attribution_types`
+- `attribution_options.metrics`
+- `attribution_options.annualization_basis`
 
 ## Outputs
-- attribution_sets for ACTIVE_RISK/TRACKING_ERROR
-- contributors and reconciliation fields
+- ACTIVE_RISK / TRACKING_ERROR attribution set with contributors and residual.
 
 ## Worked Example
-Given:
-- Active return and active-weight series produce contributor components that reconcile to total tracking error
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Compute active return `a_t=(Rp_t-Rb_t)/100` and active weights `aw_{k,t}`.
+- Build group pseudo-active series `g_{k,t}=aw_{k,t}*a_t`.
+- Component contribution: `CC_k=cov(g_k,a)/std(a)*sqrt(annualization_basis)`.
+- Example TE total `0.045`, contributors `0.030` and `0.013`.
+- Reconciled sum `0.043`, residual `0.002`.

--- a/docs/methodologies/metrics/attribution-volatility.md
+++ b/docs/methodologies/metrics/attribution-volatility.md
@@ -1,63 +1,52 @@
-# Historical Attribution Methodology - Volatility Attribution
+# Historical Attribution Methodology - Volatility Contribution
 
 ## Metric
-- metric_id: ATTRIBUTION_VOLATILITY
+- metric_id: VOLATILITY_ATTRIBUTION
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/historical-attribution
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Portfolio exposure history by grouping dimension
-- Periods and annualization basis
+- Portfolio returns.
+- Exposure history by grouping.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller returns + exposure_history
-- Stateful: lotus-performance returns + lotus-core position-timeseries + enrichment
+- Stateless caller datasets.
+- Stateful integrated data contracts.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- metric_series = portfolio returns (decimal)
-- group_matrix = exposure_weight * metric_series
-- total_value = std(metric_series)*sqrt(annualization_basis)
-- component_i = cov(group_i,metric_series)/std(metric_series)*sqrt(annualization_basis)
-- marginal_i = component_i/avg_weight_i
-- percent_i = component_i/total_value
+1. `m_t=r_t/100`.
+2. `g_{k,t}=w_{k,t}*m_t`.
+3. Total `sigma=std(m_t)*sqrt(annualization_basis)`.
+4. Contribution `CC_k = cov(g_k,m)/std(m)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: metric_series = portfolio returns (decimal)
-4. Apply: group_matrix = exposure_weight * metric_series
-5. Apply: total_value = std(metric_series)*sqrt(annualization_basis)
-6. Apply: component_i = cov(group_i,metric_series)/std(metric_series)*sqrt(annualization_basis)
-7. Apply: marginal_i = component_i/avg_weight_i
-8. Apply: percent_i = component_i/total_value
-9. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Pivot exposure history into date x group matrix.
+2. Build group pseudo-return matrix.
+3. Compute per-group component contributions.
+4. Reconcile sum and residual against total volatility.
 
 ## Configuration Options
-- attribution_options.attribution_types includes TOTAL_RISK
-- metrics includes VOLATILITY
-- grouping_dimensions
-- annualization_basis
-- covariance_method=EMPIRICAL
+- `attribution_options.grouping_dimensions`
+- `attribution_options.metrics`
+- `attribution_options.annualization_basis`
 
 ## Outputs
-- attribution_sets[].total_value
-- reconciled_sum
-- residual
-- contributors[].marginal_contribution/component_contribution/percent_contribution
+- `attribution_sets[].contributors[]`
+- `total_value`
+- `reconciled_sum`
+- `residual`
 
 ## Worked Example
-Given:
-- Components [0.08,0.04] reconcile to total 0.12 => percents 66.7%/33.3%
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Compute metric series `m_t = r_t/100` over aligned dates.
+- For each group k, build pseudo series `g_{k,t}=w_{k,t}*m_t`.
+- Compute each component: `CC_k=cov(g_k,m)/std(m)*sqrt(annualization_basis)`.
+- Example total volatility `0.182`, components `0.110` and `0.070`.
+- Reconciled sum `0.180`, residual `0.002` reported explicitly.

--- a/docs/methodologies/metrics/concentration-hhi.md
+++ b/docs/methodologies/metrics/concentration-hhi.md
@@ -8,44 +8,42 @@
 - supported_modes: stateless, stateful, simulation
 
 ## Inputs
-- Current and projected position values
+- Current and proposed position values.
+- Top-N option for ancillary fields.
 
 ## Upstream Data Sources
-- Stateless: caller positions
-- Stateful: lotus-core core-snapshot positions_baseline
-- Simulation: lotus-core simulation session + changes + simulated snapshot
+- Stateless caller payload.
+- Stateful/simulation snapshots from lotus-core.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- w_i = |v_i|/Σ|v|
-- HHI = Σ(w_i^2)*10000
+1. Build absolute exposure denominator for each state: `V = sum_i |v_i|`.
+2. Compute position weights: `w_i = |v_i| / V`.
+3. Compute concentration score: `HHI = sum_i(w_i^2) * 10000`.
+4. Compute transition delta: `HHI_delta = HHI_proposed - HHI_current`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: w_i = |v_i|/Σ|v|
-4. Apply: HHI = Σ(w_i^2)*10000
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Extract usable numeric value per position (`market_value_base`; fallback `quantity`).
+2. Build baseline and proposed absolute-value vectors.
+3. Normalize each vector into weights using absolute total denominator.
+4. Square-and-sum weights and scale by 10,000 for current and proposed states.
+5. Emit rounded current/proposed/delta values in risk proxy payload.
 
 ## Configuration Options
-- include_cash_positions
-- include_zero_quantity_positions
-- top_n (not used directly in HHI)
+- `concentration_options.top_n`
 
 ## Outputs
-- risk_proxy.hhi_current
-- risk_proxy.hhi_proposed
-- risk_proxy.hhi_delta
+- `risk_proxy.hhi_current`
+- `risk_proxy.hhi_proposed`
+- `risk_proxy.hhi_delta`
 
 ## Worked Example
-Given:
-- Values [50,30,20] => HHI=3800
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Current values `[50, 30, 20]`, absolute total `100`.
+- Current weights `[0.50, 0.30, 0.20]`.
+- Current HHI `=(0.50^2+0.30^2+0.20^2)*10000 = 3800`.
+- Proposed values `[60, 25, 15]` -> weights `[0.60,0.25,0.15]`.
+- Proposed HHI `4450`; delta `+650`.

--- a/docs/methodologies/metrics/concentration-issuer-hhi.md
+++ b/docs/methodologies/metrics/concentration-issuer-hhi.md
@@ -8,41 +8,44 @@
 - supported_modes: stateless, stateful, simulation
 
 ## Inputs
-- Position values
-- Security->issuer mapping
+- Position values and issuer mapping.
+- Issuer grouping and enrichment policy.
 
 ## Upstream Data Sources
-- Caller issuer mappings and/or lotus-core enrichment-bulk according to enrichment_policy
+- Caller mapping and/or lotus-core instrument enrichment.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- Aggregate position values by issuer bucket
-- Apply HHI formula to issuer totals
+1. Resolve issuer key per security (`issuer_id` or `ultimate_parent_issuer_id` by grouping level).
+2. Aggregate position values by issuer bucket: `issuer_value_k = sum_{i in k} v_i`.
+3. Compute issuer weights: `w_k = |issuer_value_k| / sum_j |issuer_value_j|`.
+4. Compute issuer HHI: `ISSUER_HHI = sum_k(w_k^2) * 10000`.
+5. Compute issuer HHI delta between proposed and current states.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: Aggregate position values by issuer bucket
-4. Apply: Apply HHI formula to issuer totals
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Build issuer mapping using configured enrichment policy and grouping level.
+2. Aggregate baseline and proposed positions into issuer buckets.
+3. Compute issuer weights and HHI for each state.
+4. Compute delta and coverage statistics (covered vs total positions).
+5. Emit issuer concentration payload with coverage status and explanatory note if partial.
 
 ## Configuration Options
-- issuer_grouping_level
-- enrichment_policy
+- `issuer_options.grouping_level`
+- `issuer_options.enrichment_policy`
 
 ## Outputs
-- issuer_concentration.hhi_current/proposed/delta
-- issuer_concentration.coverage_status + counters
+- `issuer_concentration.hhi_current`
+- `issuer_concentration.hhi_proposed`
+- `issuer_concentration.hhi_delta`
+- `issuer_concentration.coverage_status`
 
 ## Worked Example
-Given:
-- Issuer totals [70,30] => issuer HHI=5800
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Positions: A=50 (Issuer X), B=30 (Issuer X), C=20 (Issuer Y).
+- Issuer totals: X=80, Y=20; total=100.
+- Issuer weights: X=0.80, Y=0.20.
+- Issuer HHI `=(0.80^2+0.20^2)*10000 = 6800`.
+- If proposed issuer totals become X=70,Y=30 then HHI is `5800`, delta `-1000`.

--- a/docs/methodologies/metrics/concentration-top-issuer-weight.md
+++ b/docs/methodologies/metrics/concentration-top-issuer-weight.md
@@ -8,39 +8,39 @@
 - supported_modes: stateless, stateful, simulation
 
 ## Inputs
-- Issuer aggregated totals
+- Issuer-aggregated valuation buckets.
 
 ## Upstream Data Sources
-- Same as ISSUER_HHI
+- Derived from issuer aggregation pipeline.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- issuer_weight_j = |issuer_total_j|/Σ|issuer_total|
-- Top issuer = max_j(issuer_weight_j)
+1. Aggregate values by issuer bucket.
+2. Compute issuer weights: `w_k = |issuer_value_k| / sum_j |issuer_value_j|`.
+3. Top issuer metric: `TOP_ISSUER = max_k(w_k)`.
+4. Delta: `TOP_ISSUER_delta = TOP_ISSUER_proposed - TOP_ISSUER_current`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: issuer_weight_j = |issuer_total_j|/Σ|issuer_total|
-4. Apply: Top issuer = max_j(issuer_weight_j)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve issuer mapping and aggregate values per issuer.
+2. Normalize issuer totals into weights.
+3. Select maximum issuer weight for each state.
+4. Emit delta and coverage context.
 
 ## Configuration Options
-- issuer_grouping_level
-- enrichment_policy
+- Inherited from issuer mapping options.
 
 ## Outputs
-- issuer_concentration.top_issuer_weight_current/proposed/delta
+- `issuer_concentration.top_issuer_weight_current`
+- `issuer_concentration.top_issuer_weight_proposed`
+- `issuer_concentration.top_issuer_weight_delta`
 
 ## Worked Example
-Given:
-- Issuer totals [70,30] => top issuer weight=0.7
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Issuer totals example: X=80, Y=20.
+- Total issuer value `100` gives weights X=`0.80`, Y=`0.20`.
+- Top issuer weight current = `0.80`.
+- If proposed totals are X=70, Y=30, top issuer weight proposed = `0.70`.
+- Delta = `0.70 - 0.80 = -0.10`.

--- a/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
+++ b/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
@@ -8,42 +8,39 @@
 - supported_modes: stateless, stateful, simulation
 
 ## Inputs
-- Position values
-- top_n
+- Position valuations and top_n.
 
 ## Upstream Data Sources
-- Same data sources as POSITION_HHI
+- Same as position concentration.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- Compute weights
-- Sort descending
-- Sum first N
+1. Compute normalized absolute weights `w_i` from position values.
+2. Sort weights descending: `w_(1) >= w_(2) >= ...`.
+3. Top-N cumulative metric: `TOP_N = sum_{i=1..N} w_(i)`.
+4. Delta: `TOP_N_delta = TOP_N_proposed - TOP_N_current`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: Compute weights
-4. Apply: Sort descending
-5. Apply: Sum first N
-6. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve weights for baseline and proposed states.
+2. Sort each weight vector descending.
+3. Sum first `N` entries using configured `top_n`.
+4. Emit current/proposed/delta plus `top_n` used.
 
 ## Configuration Options
-- top_n
+- `concentration_options.top_n`
 
 ## Outputs
-- single_position_concentration.top_n_cumulative_weight_current/proposed/delta
-- single_position_concentration.top_n
+- `single_position_concentration.top_n_cumulative_weight_current`
+- `...proposed`
+- `...delta`
 
 ## Worked Example
-Given:
-- Weights [0.5,0.3,0.2], top_n=2 => 0.8
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Position values `[50, 30, 20]` -> weights `[0.50, 0.30, 0.20]`.
+- With `top_n=2`, sort descending and sum first 2.
+- Top-2 cumulative weight current = `0.50 + 0.30 = 0.80`.
+- Proposed weights `[0.60,0.25,0.15]` give top-2 cumulative = `0.85`.
+- Delta = `+0.05`.

--- a/docs/methodologies/metrics/concentration-top-position-weight.md
+++ b/docs/methodologies/metrics/concentration-top-position-weight.md
@@ -8,38 +8,39 @@
 - supported_modes: stateless, stateful, simulation
 
 ## Inputs
-- Position values by state
+- Position valuations.
 
 ## Upstream Data Sources
-- Same data sources as POSITION_HHI
+- Same as concentration HHI path.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- w_i = |v_i|/Σ|v|
-- Top position = max_i(w_i)
+1. Compute absolute denominator: `V = sum_i |v_i|`.
+2. Compute normalized weights: `w_i = |v_i| / V`.
+3. Top position metric: `TOP_1 = max_i(w_i)`.
+4. Delta: `TOP_1_delta = TOP_1_proposed - TOP_1_current`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: w_i = |v_i|/Σ|v|
-4. Apply: Top position = max_i(w_i)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Build baseline and proposed value vectors from input positions.
+2. Normalize vectors to absolute weights.
+3. Select maximum weight in each state.
+4. Compute delta and write response fields.
 
 ## Configuration Options
-- none beyond value selection rules
+- No dedicated option.
 
 ## Outputs
-- single_position_concentration.top_position_weight_current/proposed/delta
+- `single_position_concentration.top_position_weight_current`
+- `...proposed`
+- `...delta`
 
 ## Worked Example
-Given:
-- Values [50,30,20] => top position weight=0.5
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Position values `[50, 30, 20]` -> total `100`.
+- Weights are `[0.50, 0.30, 0.20]`.
+- Top position weight current = `0.50`.
+- Proposed weights `[0.60,0.25,0.15]` -> top position `0.60`.
+- Delta = `+0.10`.

--- a/docs/methodologies/metrics/drawdown-average-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-average-drawdown.md
@@ -8,36 +8,44 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Underwater drawdown observations
+- Drawdown path derived from return series.
 
 ## Upstream Data Sources
-- Derived from return series
+- Derived by drawdown engine.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- AVERAGE_DRAWDOWN = mean(drawdown_t where drawdown_t<0)
+1. Build wealth path from returns:
+`W_t = Π(1 + r_t/100)`.
+2. Build running peak:
+`P_t = max(W_1..W_t)`.
+3. Build drawdown path:
+`DD_t = W_t / P_t - 1`.
+4. Select only underwater points:
+`U = {DD_t | DD_t < 0}`.
+5. Average drawdown:
+`AVG_DD = mean(U)` if `U` is not empty, else `0`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: AVERAGE_DRAWDOWN = mean(drawdown_t where drawdown_t<0)
-4. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve period and compute wealth/running-peak path from return series.
+2. Convert path to drawdown observations (`DD_t`).
+3. Filter drawdown values strictly below zero.
+4. Compute arithmetic mean of filtered values.
+5. If no underwater points exist, return `average_drawdown = 0.0`.
 
 ## Configuration Options
-- None
+- No dedicated metric knob.
 
 ## Outputs
-- summary.average_drawdown
+- `results[period].summary.average_drawdown`
 
 ## Worked Example
-Given:
-- Underwater values [-0.02,-0.04,-0.01] => -0.0233
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Use drawdown path `[0.0000,-0.1000,-0.0820,-0.0453]`.
+- Filter negative values: `[-0.1000,-0.0820,-0.0453]`.
+- Average = `(-0.1000-0.0820-0.0453)/3 = -0.0758`.
+- Output `average_drawdown=-0.0758`.
+- If no negative values exist, output is `0.0`.

--- a/docs/methodologies/metrics/drawdown-dar-cdar.md
+++ b/docs/methodologies/metrics/drawdown-dar-cdar.md
@@ -1,46 +1,53 @@
 # Drawdown Methodology - Drawdown-at-Risk and CDaR
 
 ## Metric
-- metric_id: DRAWDOWN_AT_RISK_AND_CDAR
+- metric_id: DAR_CDAR
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/drawdown
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Episode depth distribution
+- Episode depth distribution.
+- Tail confidence alpha.
 
 ## Upstream Data Sources
-- Episode extraction from drawdown path
+- Derived from drawdown episode extraction.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- DaR_alpha = quantile(depths,1-alpha)
-- CDaR_alpha = mean(depth <= DaR_alpha)
+1. Extract episode depth vector from drawdown episodes:
+`D = [d_1, d_2, ..., d_n]`, where each `d_i <= 0`.
+2. Compute tail probability level:
+`q = 1 - alpha`.
+3. Drawdown-at-Risk:
+`DAR_alpha = quantile(D, q)` (engine uses linear interpolation).
+4. Tail set for conditional measure:
+`T = {d_i in D | d_i <= DAR_alpha}`.
+5. Conditional Drawdown-at-Risk:
+`CDAR_alpha = mean(T)` when `T` is non-empty.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: DaR_alpha = quantile(depths,1-alpha)
-4. Apply: CDaR_alpha = mean(depth <= DaR_alpha)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Build drawdown episodes and collect each episode depth.
+2. Sort/quantile the depth vector at tail level `1-alpha`.
+3. Identify episodes in the worst tail at or below DAR threshold.
+4. Compute average of worst-tail depths for CDaR.
+5. Return both DAR and CDaR in summary response fields.
 
 ## Configuration Options
-- analysis_options.cdar_alpha (0.90,0.95,0.99)
+- `analysis_options.cdar_alpha`
 
 ## Outputs
-- summary.drawdown_at_risk_95
-- summary.conditional_drawdown_at_risk_95
+- `summary.drawdown_at_risk_95`
+- `summary.conditional_drawdown_at_risk_95`
 
 ## Worked Example
-Given:
-- Depths [-0.03,-0.08,-0.12,-0.05], alpha=0.95 => DaR/CDaR from lower tail
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Episode depths example `[-0.04,-0.07,-0.10,-0.02]`.
+- For alpha `0.95`, tail quantile level is `1-alpha = 0.05`.
+- DAR is near lower-tail threshold, approximately `-0.095` to `-0.10` with this sample.
+- Worst-tail set is `[-0.10]` (or includes close values by interpolation rule).
+- CDaR is mean of worst-tail set, approximately `-0.10`.

--- a/docs/methodologies/metrics/drawdown-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-max-drawdown.md
@@ -76,42 +76,8 @@
 - `results[period].summary.days_to_recovery`
 
 ## Worked Example
-Input returns (percentage points):
-- Day 1: `+5.00`
-- Day 2: `-10.00`
-- Day 3: `+2.00`
-- Day 4: `+4.00`
-
-Step 1. Convert to decimal:
-- Day 1: `0.0500`
-- Day 2: `-0.1000`
-- Day 3: `0.0200`
-- Day 4: `0.0400`
-
-Step 2. Wealth path (`wealth_t = ∏(1+r_t)`):
-- Day 1: `1.050000`
-- Day 2: `1.050000 * 0.900000 = 0.945000`
-- Day 3: `0.945000 * 1.020000 = 0.963900`
-- Day 4: `0.963900 * 1.040000 = 1.002456`
-
-Step 3. Running peak:
-- Day 1: `1.050000`
-- Day 2: `1.050000`
-- Day 3: `1.050000`
-- Day 4: `1.050000`
-
-Step 4. Drawdown series (`wealth/peak - 1`):
-- Day 1: `1.050000/1.050000 - 1 = 0.000000`
-- Day 2: `0.945000/1.050000 - 1 = -0.100000`
-- Day 3: `0.963900/1.050000 - 1 = -0.082000`
-- Day 4: `1.002456/1.050000 - 1 = -0.045280`
-
-Step 5. Maximum drawdown:
-- `min(drawdown_t) = -0.100000`
-- Final metric value: `max_drawdown = -0.10` (equivalent to `-10.00%`).
-
-Step 6. Peak/trough/recovery:
-- peak date: Day 1
-- trough date: Day 2
-- recovery date: `null` in this sample (drawdown never returned to non-negative)
-
+- Input returns (percentage points): Day1 `+5.00`, Day2 `-10.00`, Day3 `+2.00`, Day4 `+4.00`.
+- Convert to decimal: `[0.0500, -0.1000, 0.0200, 0.0400]`.
+- Wealth path: `[1.050000, 0.945000, 0.963900, 1.002456]`; running peak stays `[1.050000, 1.050000, 1.050000, 1.050000]`.
+- Drawdown path (`wealth/peak - 1`): `[0.000000, -0.100000, -0.082000, -0.045280]`.
+- Maximum drawdown is `-0.100000` (equivalent to `-10.00%`), with peak Day1 and trough Day2.

--- a/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-relative-max-drawdown.md
@@ -1,4 +1,4 @@
-# Drawdown Methodology - Relative Max Drawdown vs Benchmark
+# Drawdown Methodology - Relative Maximum Drawdown
 
 ## Metric
 - metric_id: RELATIVE_MAX_DRAWDOWN
@@ -8,43 +8,38 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark return series.
 
 ## Upstream Data Sources
-- Stateless: caller benchmark_returns
-- Stateful: lotus-performance benchmark_returns
+- Stateless caller or stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = portfolio_t - benchmark_t
-- Compute drawdown path on active return wealth index
+1. Active return path: `a_t = Rp_t - Rb_t` (pp).
+2. Active wealth path: `AW_t = Π(1 + a_t/100)`.
+3. Active running peak: `AP_t = cummax(AW_t)`.
+4. Active drawdown path: `ADD_t = AW_t / AP_t - 1`.
+5. Relative maximum drawdown: `REL_MAX_DD = min(ADD_t)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = portfolio_t - benchmark_t
-4. Apply: Compute drawdown path on active return wealth index
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align portfolio and benchmark returns on common dates.
+2. Compute active return, wealth, and drawdown paths.
+3. Identify minimum active drawdown value.
+4. Map corresponding peak and trough dates into relative summary fields.
 
 ## Configuration Options
-- stateful benchmark_policy.include_benchmark
-- stateful benchmark_policy.missing_benchmark_policy
+- Benchmark data must be present.
 
 ## Outputs
-- relative_to_benchmark.max_drawdown
-- relative_to_benchmark.max_drawdown_peak_date
-- relative_to_benchmark.max_drawdown_trough_date
+- `results[period].relative_to_benchmark.max_drawdown` and date fields.
 
 ## Worked Example
-Given:
-- Active returns(dec): [0.01,-0.03,0.005] => relative max drawdown around -0.03
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Portfolio pp `[1.0,-2.0,0.5]`, benchmark pp `[0.5,-1.0,0.2]`.
+- Active pp `[0.5,-1.0,0.3]` -> decimal `[0.005,-0.010,0.003]`.
+- Active wealth `[1.005000,0.994950,0.997935]` with peak `1.005000`.
+- Active drawdown `[0.0000,-0.0100,-0.0070]`.
+- Relative max drawdown is `-0.0100` (=-1.00%).

--- a/docs/methodologies/metrics/drawdown-time-under-water.md
+++ b/docs/methodologies/metrics/drawdown-time-under-water.md
@@ -8,41 +8,40 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Drawdown series
+- Drawdown path over period.
 
 ## Upstream Data Sources
-- Derived from return series
+- Derived in drawdown engine.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- time_under_water_days = count(drawdown_t < 0)
-- Episode timing metrics are duration-unit aware
+1. Build wealth and running peak from period returns:
+`W_t = Π(1 + r_t/100)`, `P_t = max(W_1..W_t)`.
+2. Compute drawdown path:
+`DD_t = W_t / P_t - 1`.
+3. Time-under-water count:
+`TUW = Σ I(DD_t < 0)` where `I` is indicator function.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: time_under_water_days = count(drawdown_t < 0)
-4. Apply: Episode timing metrics are duration-unit aware
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve period and compute drawdown path point-by-point.
+2. For each observation date, mark whether portfolio is below prior peak (`DD_t < 0`).
+3. Count all marked observations to get time under water.
+4. Return integer count in summary payload.
+5. This metric measures persistence of drawdown, not its depth.
 
 ## Configuration Options
-- analysis_options.duration_unit = BUSINESS_DAYS|CALENDAR_DAYS
+- No dedicated metric knob.
 
 ## Outputs
-- summary.time_under_water_days
-- episodes.days_to_trough
-- episodes.days_to_recovery
-- episodes.total_days
+- `results[period].summary.time_under_water_days`
 
 ## Worked Example
-Given:
-- Drawdown [0,-0.02,-0.01,0] => time under water = 2
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Drawdown path `[0.0000,-0.1000,-0.0820,-0.0453]`.
+- Count points where drawdown `< 0`.
+- Negative points are 3 observations.
+- Output `time_under_water_days = 3`.
+- Count is path-based and independent of drawdown depth.

--- a/docs/methodologies/metrics/drawdown-ulcer-index.md
+++ b/docs/methodologies/metrics/drawdown-ulcer-index.md
@@ -8,36 +8,44 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Full drawdown path
+- Drawdown path over period.
 
 ## Upstream Data Sources
-- Derived from return series
+- Derived in drawdown engine.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- ULCER_INDEX = sqrt(mean(drawdown_t^2))
+1. Build wealth path:
+`W_t = Π(1 + r_t/100)`.
+2. Build running peak:
+`P_t = max(W_1..W_t)`.
+3. Build drawdown path:
+`DD_t = W_t / P_t - 1`.
+4. Square drawdown observations:
+`SQ_t = DD_t^2`.
+5. Ulcer Index:
+`UI = sqrt(mean(SQ_t))`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: ULCER_INDEX = sqrt(mean(drawdown_t^2))
-4. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Compute period drawdown series from the return path.
+2. Square each drawdown observation so larger drawdowns are penalized more.
+3. Take mean of squared drawdowns over the full period.
+4. Apply square root to restore drawdown scale.
+5. Return ulcer index as a non-negative decimal risk intensity measure.
 
 ## Configuration Options
-- None
+- No dedicated metric knob.
 
 ## Outputs
-- summary.ulcer_index
+- `results[period].summary.ulcer_index`
 
 ## Worked Example
-Given:
-- Drawdown [0,-0.02,-0.04] => ulcer index=0.0258
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Use drawdown path `[0.0000,-0.1000,-0.0820,-0.0453]`.
+- Square values: `[0.000000,0.010000,0.006724,0.002052]`.
+- Mean square = `0.004694`.
+- Ulcer Index = `sqrt(0.004694) = 0.0685`.
+- Output is decimal drawdown intensity.

--- a/docs/methodologies/metrics/risk-beta.md
+++ b/docs/methodologies/metrics/risk-beta.md
@@ -8,42 +8,41 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns (date-aligned)
+- Portfolio and benchmark return series in pp.
 
 ## Upstream Data Sources
-- Stateless: caller benchmark_returns[]
-- Stateful: lotus-performance benchmark_returns
+- Stateless caller provides both.
+- Stateful lotus-performance provides both.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- Beta = Cov(Rp,Rb)/Var(Rb), ddof=1
-- Inner date join before calculation
+1. Align portfolio and benchmark return series on common dates (inner join).
+2. Compute sample covariance `cov(Rp,Rb,ddof=1)`.
+3. Compute sample benchmark variance `var(Rb,ddof=1)`.
+4. Beta definition: `BETA = cov(Rp,Rb) / var(Rb)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: Beta = Cov(Rp,Rb)/Var(Rb), ddof=1
-4. Apply: Inner date join before calculation
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Build aligned period return matrix with portfolio and benchmark columns.
+2. Validate at least two aligned observations.
+3. Compute covariance and benchmark variance.
+4. If benchmark variance is zero, return deterministic metric error.
+5. Otherwise return beta value.
 
 ## Configuration Options
-- options.frequency
-- options.use_log_returns
+- `options.frequency`
+- `options.use_log_returns`
 
 ## Outputs
-- results[period].metrics.BETA.value
-- details.error when benchmark variance is zero
+- `results[period].metrics.BETA.value`
+- `...details.error`
 
 ## Worked Example
-Given:
-- Portfolio approximately 2x benchmark => beta ~= 2.0
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Portfolio pp `[1.0,-1.0,2.0]`, benchmark pp `[0.5,-0.5,1.0]`.
+- Covariance and variance computed on aligned dates with ddof=1.
+- Since portfolio is exactly 2x benchmark each date, `cov(Rp,Rb)=2*var(Rb)`.
+- Beta `= cov/var = 2.0`.
+- If benchmark variance is zero, response emits `details.error`.

--- a/docs/methodologies/metrics/risk-drawdown.md
+++ b/docs/methodologies/metrics/risk-drawdown.md
@@ -8,45 +8,41 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series for resolved period
+- Portfolio return observations in pp for the selected period.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance portfolio_returns
+- Stateless caller returns.
+- Stateful lotus-performance returns.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- wealth_t = Π(1+r_t)
-- peak_t = cummax(wealth_t)
-- drawdown_t = wealth_t/peak_t - 1
-- DRAWDOWN = min(drawdown_t)*100
+1. `W_t = Π(1+r_t/100)`.
+2. `P_t = cummax(W_t)`.
+3. `DD_t = W_t/P_t - 1`.
+4. Reported value: `min(DD_t) * 100` (pp).
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: wealth_t = Π(1+r_t)
-4. Apply: peak_t = cummax(wealth_t)
-5. Apply: drawdown_t = wealth_t/peak_t - 1
-6. Apply: DRAWDOWN = min(drawdown_t)*100
-7. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Build wealth and running-peak paths.
+2. Compute drawdown series.
+3. Find trough and corresponding prior peak dates.
+4. Return drawdown value and details map.
 
 ## Configuration Options
-- options.frequency (resample before calculation)
+- `options.frequency`
 
 ## Outputs
-- results[period].metrics.DRAWDOWN.value
-- details.max_drawdown, peak_date, trough_date
+- `results[period].metrics.DRAWDOWN.value`
+- `results[period].metrics.DRAWDOWN.details.max_drawdown`
+- `...peak_date`
+- `...trough_date`
 
 ## Worked Example
-Given:
-- Returns [%]: [10, -20, 5] => drawdown path [0, -0.2, -0.16]
-- Max drawdown = -20.0
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Returns pp `[10, -20, 5]`.
+- Wealth path `[1.10, 0.88, 0.924]`; running peak `[1.10, 1.10, 1.10]`.
+- Drawdown decimal path `[0.00, -0.20, -0.16]`.
+- Minimum drawdown is `-0.20`; reported metric value is `-20.0` pp.
+- Peak/trough dates are derived from peak-before-trough logic in details payload.

--- a/docs/methodologies/metrics/risk-information-ratio.md
+++ b/docs/methodologies/metrics/risk-information-ratio.md
@@ -8,41 +8,41 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark returns.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = Rp_t - Rb_t
-- IR = (mean(active_t)/std(active_t))*sqrt(annual_factor)
+1. Active return vector: `a_t = Rp_t - Rb_t`.
+2. Active mean: `mu_a = mean(a_t)`.
+3. Active volatility: `sigma_a = std(a_t, ddof=1)`.
+4. Information ratio: `IR = (mu_a / sigma_a) * sqrt(annualization_factor)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = Rp_t - Rb_t
-4. Apply: IR = (mean(active_t)/std(active_t))*sqrt(annual_factor)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align portfolio and benchmark series.
+2. Compute active return vector and its sample moments.
+3. Validate non-zero `sigma_a`; otherwise emit deterministic error.
+4. Annualize and return information ratio.
 
 ## Configuration Options
-- options.frequency
-- options.annualization_factor
+- `options.frequency`
+- `options.annualization_factor`
 
 ## Outputs
-- results[period].metrics.INFORMATION_RATIO.value
+- `results[period].metrics.INFORMATION_RATIO.value`
+- `...details.error`
 
 ## Worked Example
-Given:
-- Active [%]: [0.2,0.1,-0.1,0.0] => IR ~= 6.15 (annual_factor=252)
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Active pp returns `[0.2,0.1,-0.1,0.0]`.
+- Active mean `0.05`; sample std `0.1291`.
+- Annualization `252`.
+- IR `=(0.05/0.1291)*sqrt(252)=6.146`.
+- If active std is zero, response emits `Tracking error is zero`.

--- a/docs/methodologies/metrics/risk-sharpe.md
+++ b/docs/methodologies/metrics/risk-sharpe.md
@@ -8,45 +8,43 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series
-- Risk-free settings
+- Portfolio return series in pp.
+- Risk-free settings and annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance portfolio_returns
+- Stateless caller returns.
+- Stateful lotus-performance returns.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- periodic_rf = (1+annual_rf)^(1/annual_factor)-1 for ANNUAL_RATE mode
-- Sharpe = ((mean(r)-periodic_rf)/std(r))*sqrt(annual_factor)
+1. `rf_p=(1+rf_annual)^(1/annual_factor)-1` (or 0).
+2. `mu_excess = mean(r_pp)/100 - rf_p`.
+3. `sigma = std(r_pp,ddof=1)/100`.
+4. `SHARPE=(mu_excess/sigma)*sqrt(annual_factor)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: periodic_rf = (1+annual_rf)^(1/annual_factor)-1 for ANNUAL_RATE mode
-4. Apply: Sharpe = ((mean(r)-periodic_rf)/std(r))*sqrt(annual_factor)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve return sample and periodic RF.
+2. Compute excess mean and sample volatility.
+3. Fail on zero volatility.
+4. Annualize ratio and emit metric.
 
 ## Configuration Options
-- options.risk_free_mode
-- options.risk_free_annual_rate
-- options.frequency
-- options.annualization_factor
+- `options.risk_free_mode`
+- `options.risk_free_annual_rate`
+- `options.annualization_factor`
+- `options.use_log_returns`
 
 ## Outputs
-- results[period].metrics.SHARPE.value
-- details.error on zero volatility
+- `results[period].metrics.SHARPE.value`
+- `...details.error`
 
 ## Worked Example
-Given:
-- mean=0.0005, std=0.01, annual_rf=0.02, annual_factor=252
-- Sharpe ~= 0.67
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Mean return decimal `0.0005`, std decimal `0.01`.
+- Annual RF `2.0%`, annualization `252` gives periodic RF `0.0000786`.
+- Excess mean `0.0004214`.
+- Sharpe `=(0.0004214/0.01)*sqrt(252)=0.669`.
+- If std is zero, response returns `details.error=Zero volatility`.

--- a/docs/methodologies/metrics/risk-sortino.md
+++ b/docs/methodologies/metrics/risk-sortino.md
@@ -8,46 +8,41 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series
-- MAR annual rate
+- Portfolio return series in pp.
+- Minimum acceptable return annual rate.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance portfolio_returns
+- Stateless caller returns.
+- Stateful lotus-performance returns.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- periodic_mar = (1+mar_annual_rate)^(1/annual_factor)-1
-- downside = r_t-periodic_mar where downside<0
-- Sortino = ((mean(r)-periodic_mar)/sqrt(mean(downside^2)))*sqrt(annual_factor)
+1. Convert MAR annual rate to periodic threshold: `mar_p = (1+mar_annual)^(1/annual_factor)-1`.
+2. Downside excess vector: `d_t = r_t/100 - mar_p` for `d_t < 0`.
+3. Downside deviation: `sigma_down = sqrt(mean(d_t^2))`.
+4. Sortino ratio: `SORTINO = ((mean(r_t)/100 - mar_p) / sigma_down) * sqrt(annual_factor)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: periodic_mar = (1+mar_annual_rate)^(1/annual_factor)-1
-4. Apply: downside = r_t-periodic_mar where downside<0
-5. Apply: Sortino = ((mean(r)-periodic_mar)/sqrt(mean(downside^2)))*sqrt(annual_factor)
-6. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve period returns and periodic MAR threshold.
+2. Build downside-only vector below MAR.
+3. If downside vector is empty, emit `No downside observations` error.
+4. Compute downside deviation and annualized Sortino ratio.
 
 ## Configuration Options
-- options.mar_annual_rate
-- options.frequency
-- options.annualization_factor
+- `options.mar_annual_rate`
+- `options.annualization_factor`
 
 ## Outputs
-- results[period].metrics.SORTINO.value
-- details.error when downside observations missing
+- `results[period].metrics.SORTINO.value`
+- `...details.error`
 
 ## Worked Example
-Given:
-- Returns(dec): [0.01,-0.02,0.005], MAR=0
-- Sortino ~= -1.32
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Decimal returns `[0.0100,-0.0200,0.0050]`, MAR `0`.
+- Downside vector is `[-0.0200]` (only values below MAR).
+- Downside deviation `sqrt(mean(0.0200^2))=0.0200`.
+- Mean return `-0.001667`; Sortino `=(-0.001667/0.0200)*sqrt(252)=-1.323`.
+- If downside set is empty, engine returns `No downside observations`.

--- a/docs/methodologies/metrics/risk-tracking-error.md
+++ b/docs/methodologies/metrics/risk-tracking-error.md
@@ -8,41 +8,39 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark returns.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = Rp_t - Rb_t
-- TE = std(active_t,ddof=1)*sqrt(annual_factor)
+1. Active return vector: `a_t = Rp_t - Rb_t`.
+2. Sample active volatility: `sigma_a = std(a_t, ddof=1)`.
+3. Annualized tracking error: `TE = sigma_a * sqrt(annualization_factor)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = Rp_t - Rb_t
-4. Apply: TE = std(active_t,ddof=1)*sqrt(annual_factor)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align portfolio and benchmark returns by date and period.
+2. Compute active return at each aligned point.
+3. Compute sample standard deviation of active return.
+4. Apply annualization factor and emit metric value.
 
 ## Configuration Options
-- options.frequency
-- options.annualization_factor
+- `options.frequency`
+- `options.annualization_factor`
 
 ## Outputs
-- results[period].metrics.TRACKING_ERROR.value
+- `results[period].metrics.TRACKING_ERROR.value`
 
 ## Worked Example
-Given:
-- Active [%]: [0.1,-0.2,0.1], annual_factor=252 => TE ~= 2.75
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Aligned portfolio and benchmark returns produce active pp `[0.1,-0.2,0.1]`.
+- Active mean is `0`; sample std is `0.1732` pp.
+- Annualization factor `252`.
+- TE = `0.1732*sqrt(252)=2.749` pp.
+- Output field stores annualized TE value.

--- a/docs/methodologies/metrics/risk-var.md
+++ b/docs/methodologies/metrics/risk-var.md
@@ -8,51 +8,45 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series
-- VaR method/confidence/horizon
+- Portfolio return series in pp.
+- VaR method, confidence, horizon, ES flag.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance portfolio_returns
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- HISTORICAL: percentile(alpha)
-- GAUSSIAN: mean + std*z_alpha
-- CORNISH_FISHER: adjusted z using skew/kurtosis
-- scaled_var = base_var*sqrt(horizon_days)
-- ES optional as tail mean
+1. `alpha=1-confidence`.
+2. Historical VaR = percentile(alpha).
+3. Gaussian VaR = mean + std*z(alpha).
+4. Cornish-Fisher VaR = mean + std*z_cf(alpha,skew,kurtosis).
+5. Scale horizon by `sqrt(horizon_days)`.
+6. ES (optional) = mean(return <= VaR).
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: HISTORICAL: percentile(alpha)
-4. Apply: GAUSSIAN: mean + std*z_alpha
-5. Apply: CORNISH_FISHER: adjusted z using skew/kurtosis
-6. Apply: scaled_var = base_var*sqrt(horizon_days)
-7. Apply: ES optional as tail mean
-8. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Compute one-day VaR by configured method.
+2. Apply square-root-of-time scaling.
+3. Optionally compute expected shortfall.
+4. Emit value and details.
 
 ## Configuration Options
-- options.var.method
-- options.var.confidence
-- options.var.horizon_days
-- options.var.include_expected_shortfall
+- `options.var.method`
+- `options.var.confidence`
+- `options.var.horizon_days`
+- `options.var.include_expected_shortfall`
 
 ## Outputs
-- results[period].metrics.VAR.value
-- details.expected_shortfall when enabled
+- `results[period].metrics.VAR.value`
+- `...details.expected_shortfall`
 
 ## Worked Example
-Given:
-- Returns [%]: [-2,-1,0,1,2], confidence=95%
-- Historical VaR ~= -1.8, horizon=4 => -3.6
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Returns pp `[-2,-1,0,1,2]`, confidence `95%`.
+- Historical one-day VaR at 5th percentile is `-1.8` pp.
+- With horizon `4`, scaled VaR `=-1.8*sqrt(4)=-3.6` pp.
+- If ES enabled, tail mean at or below VaR gives one-day ES (here near `-2.0` pp).
+- Scaled ES for 4-day horizon is about `-4.0` pp.

--- a/docs/methodologies/metrics/risk-volatility.md
+++ b/docs/methodologies/metrics/risk-volatility.md
@@ -8,46 +8,42 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series for resolved period
-- Annualization basis (frequency or override)
+- Portfolio return observations for the resolved period (minimum 2).
+- Annualization basis from frequency or explicit override.
+- Optional log-return transform flag.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance /integration/returns/series -> portfolio_returns
+- Stateless: caller `returns[]`.
+- Stateful: lotus-performance return series.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- sigma = std(returns, ddof=1)
-- VOLATILITY = sigma * sqrt(annualization_factor)
-- If use_log_returns=true: transform r_t = ln(1+r_t)
+1. If enabled: `r_t = ln(1+r_t/100)*100`.
+2. `sigma_pp = std(r_t, ddof=1)`.
+3. `VOLATILITY = sigma_pp * sqrt(annualization_factor)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: sigma = std(returns, ddof=1)
-4. Apply: VOLATILITY = sigma * sqrt(annualization_factor)
-5. Apply: If use_log_returns=true: transform r_t = ln(1+r_t)
-6. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve period and filter returns.
+2. Apply configured resampling and optional log transform.
+3. Compute sample standard deviation.
+4. Annualize and return value or `Insufficient data` error.
 
 ## Configuration Options
-- options.frequency
-- options.annualization_factor
-- options.use_log_returns
+- `options.frequency`
+- `options.annualization_factor`
+- `options.use_log_returns`
 
 ## Outputs
-- results[period].metrics.VOLATILITY.value
-- details.error when insufficient data
+- `results[period].metrics.VOLATILITY.value`
+- `results[period].metrics.VOLATILITY.details.error`
 
 ## Worked Example
-Given:
-- Returns [%]: [1.0, -0.5, 0.2]
-- std ~= 0.7506, annual_factor=252 => volatility ~= 11.92
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Returns pp `[1.00, -0.50, 0.20]`.
+- Sample mean `0.2333` and sample std `0.7505` pp.
+- With annualization factor `252`, volatility `=0.7505*sqrt(252)=11.914`.
+- Output `results[period].metrics.VOLATILITY.value = 11.914`.
+- If fewer than 2 observations exist, return `details.error=Insufficient data`.

--- a/docs/methodologies/metrics/rolling-beta.md
+++ b/docs/methodologies/metrics/rolling-beta.md
@@ -8,41 +8,49 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark returns.
+- Window lengths.
 
 ## Upstream Data Sources
-- Stateless: caller benchmark_returns[]
-- Stateful: lotus-performance benchmark_returns
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- rolling_cov(portfolio,benchmark)/rolling_var(benchmark)
+1. Convert both portfolio and benchmark return series from pp to decimal:
+`r_decimal = r_pp / 100`.
+2. For each window end date `t` and window size `W`, define trailing slices:
+`Rp_t(W)` and `Rb_t(W)`.
+3. Compute rolling sample covariance:
+`cov_t = cov(Rp_t(W), Rb_t(W), ddof=1)`.
+4. Compute rolling sample benchmark variance:
+`var_t = var(Rb_t(W), ddof=1)`.
+5. Compute rolling beta:
+`beta_t(W) = cov_t / var_t`.
+6. If `var_t == 0`, output is null for that point and a quality flag is emitted.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: rolling_cov(portfolio,benchmark)/rolling_var(benchmark)
-4. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align portfolio and benchmark returns by date (inner join).
+2. Build rolling covariance and rolling variance vectors for each requested window length.
+3. Divide covariance by variance point-by-point to obtain rolling beta.
+4. Replace infinite values with null and attach `benchmark_variance_zero` quality flags.
+5. Compute window-level summary statistics (`latest`, `average`, percentiles) from non-null points.
 
 ## Configuration Options
-- window_lengths
-- min_observations_policy
-- alignment_policy INNER_JOIN
+- `rolling_options.window_lengths`
+- `rolling_options.min_observations_policy`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_BETA
-- quality flag metric:ROLLING_BETA:benchmark_variance_zero
+- `window_results[].metric_summaries.ROLLING_BETA`
+- `quality_flags`
 
 ## Worked Example
-Given:
-- Portfolio ~1.5x benchmark over window => rolling beta ~1.5
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window data: benchmark decimal `[0.01,-0.02,0.015]` and portfolio `[0.015,-0.03,0.0225]`.
+- Portfolio is exactly 1.5x benchmark at each point.
+- Rolling covariance equals `1.5 * rolling_var(benchmark)`.
+- Rolling beta for that window = `1.5`.
+- Summary fields aggregate all rolling-beta points over the period.

--- a/docs/methodologies/metrics/rolling-information-ratio.md
+++ b/docs/methodologies/metrics/rolling-information-ratio.md
@@ -8,42 +8,43 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark returns.
+- Window lengths.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = Rp_t - Rb_t
-- rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+1. Active return vector: `a_t = r_portfolio_t - r_benchmark_t`.
+2. Rolling active mean: `mu_a_t(W)=mean(a_{t-W+1..t})`.
+3. Rolling active std: `sigma_a_t(W)=std(a_{t-W+1..t},ddof=1)`.
+4. Rolling information ratio: `RIR_t(W)=(mu_a_t/sigma_a_t)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = Rp_t - Rb_t
-4. Apply: rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align series and compute active return stream.
+2. Compute rolling active mean and std per window length.
+3. Compute ratio and annualize by configured basis.
+4. Null zero-std points and emit quality flags.
+5. Return summary distribution and optional full series.
 
 ## Configuration Options
-- window_lengths
-- annualization_basis
+- `rolling_options.window_lengths`
+- `rolling_options.annualization_basis`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_INFORMATION_RATIO
-- quality flag metric:ROLLING_INFORMATION_RATIO:zero_tracking_error_window
+- `window_results[].metric_summaries.ROLLING_INFORMATION_RATIO`
+- `quality_flags`
 
 ## Worked Example
-Given:
-- Computed per rolling window on active return stream
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window=3, active decimal returns `[0.002,0.001,-0.001]`.
+- Rolling mean `0.000667` and sample std `0.001528`.
+- Point IR `=(0.000667/0.001528)*sqrt(252)=6.928`.
+- If rolling std is zero, value is null and quality flag is emitted.
+- Summary aggregates valid window points.

--- a/docs/methodologies/metrics/rolling-max-drawdown.md
+++ b/docs/methodologies/metrics/rolling-max-drawdown.md
@@ -1,4 +1,4 @@
-# Rolling Metric Methodology - Rolling Max Drawdown
+# Rolling Metric Methodology - Rolling Maximum Drawdown
 
 ## Metric
 - metric_id: ROLLING_MAX_DRAWDOWN
@@ -8,43 +8,40 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- window_lengths[]
+- Portfolio return series.
+- Window lengths.
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- For each rolling window: wealth=Π(1+r)
-- drawdown=wealth/cummax(wealth)-1
-- window metric=min(drawdown)
+1. For each trailing window, convert returns to decimal and build wealth path `W_k=Π(1+r_k)`.
+2. Build window running peak `P_k=cummax(W_k)`.
+3. Build window drawdown `DD_k=W_k/P_k-1`.
+4. Rolling max drawdown point: `RMDD_t(W)=min(DD_k)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: For each rolling window: wealth=Π(1+r)
-4. Apply: drawdown=wealth/cummax(wealth)-1
-5. Apply: window metric=min(drawdown)
-6. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. For each date `t`, extract trailing `W`-length window.
+2. Compute wealth, running peak, and drawdown inside that window.
+3. Record minimum drawdown as rolling point.
+4. Repeat for all dates and produce summary stats.
 
 ## Configuration Options
-- window_lengths
-- min_observations_policy
+- `rolling_options.window_lengths`
+- `rolling_options.min_observations_policy`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_MAX_DRAWDOWN
+- `window_results[].metric_summaries.ROLLING_MAX_DRAWDOWN`
 
 ## Worked Example
-Given:
-- Window returns [0.02,-0.03,0.01] => rolling max drawdown ~ -0.03
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window decimal returns `[0.05,-0.10,0.02]`.
+- Window wealth `[1.0500,0.9450,0.9639]` and running peak `[1.0500,1.0500,1.0500]`.
+- Window drawdown `[0.0000,-0.1000,-0.0820]`.
+- Rolling max drawdown point = `-0.1000`.
+- Rolling summary combines all window points for period.

--- a/docs/methodologies/metrics/rolling-sharpe.md
+++ b/docs/methodologies/metrics/rolling-sharpe.md
@@ -8,43 +8,42 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Risk-free returns
+- Portfolio and risk-free return series.
+- Window lengths and annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller risk_free_returns[]
-- Stateful: lotus-performance risk_free_returns
+- Stateless caller.
+- Stateful lotus-performance/core integrations.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = portfolio_t - risk_free_t
-- rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
+1. Excess return vector vs risk-free: `x_t = r_portfolio_t - r_rf_t`.
+2. Rolling mean: `mu_x_t(W)=mean(x_{t-W+1..t})`.
+3. Rolling std: `sigma_x_t(W)=std(x_{t-W+1..t},ddof=1)`.
+4. Rolling Sharpe: `RS_t(W)=(mu_x_t/sigma_x_t)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = portfolio_t - risk_free_t
-4. Apply: rolling_mean(active)/rolling_std(active)*sqrt(annualization_basis)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Inner-align portfolio and risk-free return series.
+2. Compute excess return stream.
+3. Compute rolling mean/std for each window.
+4. Compute annualized Sharpe and flag zero-std windows.
+5. Build summaries and optional metric series.
 
 ## Configuration Options
-- window_lengths
-- annualization_basis
-- alignment_policy INNER_JOIN
+- `rolling_options.window_lengths`
+- `rolling_options.annualization_basis`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_SHARPE
-- quality flag metric:ROLLING_SHARPE:zero_volatility_window
+- `window_results[].metric_summaries.ROLLING_SHARPE`
+- `results[period].quality_flags`
 
 ## Worked Example
-Given:
-- Window=3 active(dec) [0.001,0.002,-0.001] => rolling Sharpe ~= 6.93
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window=3, excess decimal returns `[0.004,0.001,-0.002]`.
+- Rolling mean `0.001000`, sample std `0.003000`.
+- Point Sharpe `=(0.001/0.003)*sqrt(252)=5.291`.
+- If std is zero, point is null and flagged.
+- Summary reports distribution of rolling Sharpe points.

--- a/docs/methodologies/metrics/rolling-tracking-error.md
+++ b/docs/methodologies/metrics/rolling-tracking-error.md
@@ -8,41 +8,40 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- Benchmark returns
+- Portfolio and benchmark returns.
+- Window lengths.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller
-- Stateful: lotus-performance
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- active_t = Rp_t - Rb_t
-- rolling_std(active)*sqrt(annualization_basis)
+1. Active decimal return: `a_t = r_portfolio_t - r_benchmark_t`.
+2. Rolling sample std: `sigma_a_t(W)=std(a_{t-W+1..t},ddof=1)`.
+3. Rolling tracking error: `RTE_t(W)=sigma_a_t(W)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: active_t = Rp_t - Rb_t
-4. Apply: rolling_std(active)*sqrt(annualization_basis)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Align portfolio and benchmark return series in period scope.
+2. Build active return vector.
+3. Compute rolling sample std for each window.
+4. Annualize each point and publish summaries/series.
 
 ## Configuration Options
-- window_lengths
-- annualization_basis
+- `rolling_options.window_lengths`
+- `rolling_options.annualization_basis`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_TRACKING_ERROR
+- `window_results[].metric_summaries.ROLLING_TRACKING_ERROR`
 
 ## Worked Example
-Given:
-- Window=3 active(dec) [0.001,-0.002,0.001] => 0.0275
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window=3, active decimal returns `[0.001,-0.002,0.001]`.
+- Sample std of active returns `0.001732`.
+- Annualized TE point `0.001732*sqrt(252)=0.02749`.
+- Repeat over all windows to produce rolling series.
+- Summary fields are computed from valid rolling points only.

--- a/docs/methodologies/metrics/rolling-volatility.md
+++ b/docs/methodologies/metrics/rolling-volatility.md
@@ -8,43 +8,42 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio returns
-- window_lengths[]
+- Portfolio returns.
+- Window lengths.
+- Annualization basis.
 
 ## Upstream Data Sources
-- Stateless: caller returns[]
-- Stateful: lotus-performance portfolio_returns
+- Stateless caller.
+- Stateful lotus-performance.
 
 ## Unit Conventions
-- Return contracts are usually in percentage-point units unless the endpoint contract states otherwise.
-- Statistical formulas may normalize to decimal returns (r_decimal = r_pp / 100) before computation.
-- Output units follow endpoint schema semantics (for example ratio, decimal drawdown, or HHI scale).
+- Return inputs are percentage points (pp): `1.0` means `+1%`.
+- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
+- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
 
 ## Methodology and Formulas
-- Convert returns to decimal
-- rolling_std(window,ddof=1)*sqrt(annualization_basis)
+1. Convert returns to decimal: `r_t = r_pp/100`.
+2. For each window size `W`, rolling sample std: `sigma_t(W)=std(r_{t-W+1..t},ddof=1)`.
+3. Annualized rolling volatility: `RV_t(W)=sigma_t(W)*sqrt(annualization_basis)`.
 
 ## Step-by-Step Computation
-1. Resolve period/filter window and applicable alignment policy from the request options.
-2. Normalize units and prepare aligned series/matrices required by the metric formula.
-3. Apply: Convert returns to decimal
-4. Apply: rolling_std(window,ddof=1)*sqrt(annualization_basis)
-5. Map computed values to response fields and include deterministic error/quality signals when applicable.
+1. Resolve period and decimal return series.
+2. For each window length, run rolling sample std with configured minimum observations.
+3. Annualize each rolling point.
+4. Build summary statistics and optional point-wise series output.
 
 ## Configuration Options
-- rolling_options.window_lengths
-- rolling_options.annualization_basis
-- rolling_options.min_observations_policy
+- `rolling_options.window_lengths`
+- `rolling_options.annualization_basis`
+- `rolling_options.min_observations_policy`
 
 ## Outputs
-- window_results[].metric_summaries.ROLLING_VOLATILITY
-- optional metric_series
+- `window_results[].metric_summaries.ROLLING_VOLATILITY`
+- `window_results[].metric_series[]`
 
 ## Worked Example
-Given:
-- Window=3, returns(dec) [0.01,-0.02,0.015] => 0.3005 annualized
-Apply:
-- Execute the formulas above in the listed order after unit normalization.
-Result:
-- Populate output fields exactly as listed in the Outputs section.
-
+- Window=3, decimal returns `[0.010,-0.020,0.015]`.
+- Sample std `0.01893`.
+- Annualization basis `252`.
+- Rolling volatility point `0.01893*sqrt(252)=0.3005`.
+- Window summary reports latest/avg/min/max/percentiles across all points.


### PR DESCRIPTION
## Summary
- performed a strict editorial pass across all metric methodology docs
- expanded formulas and step-by-step computation sections for concentration/risk/rolling/drawdown/attribution metrics
- strengthened worked examples with explicit intermediate calculations and output mapping
- kept endpoint/mode/input/source/output sections aligned with current lotus-risk engine behavior

## Scope
- docs only (docs/methodologies/metrics/*.md)
- no runtime code path changes

## Quality checks
- verified all metric docs include methodology, computation steps, and worked examples
- removed generic placeholder example text and replaced with concrete numeric walk-throughs
