### PR TITLE
Align risk upstream service addressing with RFC-0071

### DIFF
--- a/docs/migrations/from-lotus-core/05_Developer_Guide.md
+++ b/docs/migrations/from-lotus-core/05_Developer_Guide.md
@@ -31,7 +31,7 @@ Execute the following `curl` commands in your Git Bash terminal.
 ```bash
 # Ingest a test portfolio
 curl -X 'POST' \
-  'http://localhost:8200/ingest/portfolios' \
+  'http://core-ingestion.dev.lotus/ingest/portfolios' \
   -H 'Content-Type: application/json' \
   -d '{
   "portfolios": [{"portfolioId": "RISK_DEV_01", "baseCurrency": "USD", "openDate": "2025-01-01", "cifId": "RISK_DEV_CIF", "status": "ACTIVE", "riskExposure":"High", "investmentTimeHorizon":"Long", "portfolioType":"Discretionary", "bookingCenter":"SG"}]
@@ -39,7 +39,7 @@ curl -X 'POST' \
 
 # Ingest an instrument for the portfolio
 curl -X 'POST' \
-  'http://localhost:8200/ingest/instruments' \
+  'http://core-ingestion.dev.lotus/ingest/instruments' \
   -H 'Content-Type: application/json' \
   -d '{
   "instruments": [{"securityId": "RISK_SEC_01", "name": "Risk Dev Stock", "isin": "US_RISK_DEV", "instrumentCurrency": "USD", "productType": "Equity"}]
@@ -47,7 +47,7 @@ curl -X 'POST' \
 
 # Ingest business dates to trigger valuation
 curl -X 'POST' \
-  'http://localhost:8200/ingest/business-dates' \
+  'http://core-ingestion.dev.lotus/ingest/business-dates' \
   -H 'Content-Type: application/json' \
   -d '{
   "business_dates": [{"businessDate": "2025-08-25"}, {"businessDate": "2025-08-26"}, {"businessDate": "2025-08-27"}]
@@ -55,14 +55,14 @@ curl -X 'POST' \
 
 # Ingest a transaction and prices to generate time-series data
 curl -X 'POST' \
-  'http://localhost:8200/ingest/transactions' \
+  'http://core-ingestion.dev.lotus/ingest/transactions' \
   -H 'Content-Type: application/json' \
   -d '{
   "transactions": [{"transaction_id": "RISK_TXN_01", "portfolio_id": "RISK_DEV_01", "security_id": "RISK_SEC_01", "transaction_date": "2025-08-25T10:00:00Z", "transaction_type": "BUY", "quantity": 100, "price": 100, "gross_transaction_amount": 10000, "trade_currency": "USD", "currency": "USD"}]
 }'
 
 curl -X 'POST' \
-  'http://localhost:8200/ingest/market-prices' \
+  'http://core-ingestion.dev.lotus/ingest/market-prices' \
   -H 'Content-Type: application/json' \
   -d '{
   "market_prices": [
@@ -81,7 +81,7 @@ Once the pipeline has run, you can call the endpoint with a valid request body.
 
 ```bash
 curl -X 'POST' \
-  'http://localhost:8201/portfolios/RISK_DEV_01/risk' \
+  'http://risk.dev.lotus/portfolios/RISK_DEV_01/risk' \
   -H 'Content-Type: application/json' \
   -d '{
   "scope": { "as_of_date": "2025-08-27" },

--- a/src/app/integrations/lotus_core_client.py
+++ b/src/app/integrations/lotus_core_client.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import httpx
 
+DEFAULT_LOTUS_CORE_BASE_URL = "http://core-query.dev.lotus"
+
 
 class LotusCoreClient:
     def __init__(
@@ -17,7 +19,7 @@ class LotusCoreClient:
         if configured_base_url is None:
             configured_base_url = os.getenv("LOTUS_CORE_BASE_URL")
         if not configured_base_url:
-            configured_base_url = "http://localhost:8000"
+            configured_base_url = DEFAULT_LOTUS_CORE_BASE_URL
         resolved_base_url = configured_base_url.rstrip("/")
         resolved_timeout = timeout_seconds or float(os.getenv("LOTUS_CORE_TIMEOUT_SECONDS", "10"))
         self._base_url = resolved_base_url

--- a/src/app/integrations/lotus_performance_client.py
+++ b/src/app/integrations/lotus_performance_client.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import httpx
 
+DEFAULT_LOTUS_PERFORMANCE_BASE_URL = "http://performance.dev.lotus"
+
 
 class LotusPerformanceClient:
     def __init__(
@@ -15,7 +17,7 @@ class LotusPerformanceClient:
     ) -> None:
         configured_base_url = base_url or os.getenv("LOTUS_PERFORMANCE_BASE_URL")
         if not configured_base_url:
-            configured_base_url = "http://localhost:8002"
+            configured_base_url = DEFAULT_LOTUS_PERFORMANCE_BASE_URL
         self._base_url = configured_base_url.rstrip("/")
         self._timeout = httpx.Timeout(
             timeout_seconds or float(os.getenv("LOTUS_PERFORMANCE_TIMEOUT_SECONDS", "10"))

--- a/tests/unit/test_lotus_core_client.py
+++ b/tests/unit/test_lotus_core_client.py
@@ -7,7 +7,10 @@ from typing import Any
 import httpx
 import pytest
 
-from app.integrations.lotus_core_client import LotusCoreClient
+from app.integrations.lotus_core_client import (
+    DEFAULT_LOTUS_CORE_BASE_URL,
+    LotusCoreClient,
+)
 
 
 class _FakeAsyncClient:
@@ -185,3 +188,13 @@ def test_extract_error_detail_variants() -> None:
 
     response_dict = _ok_response({"detail": {"message": "nested message"}})
     assert LotusCoreClient._extract_error_detail(response_dict) == "nested message"
+
+
+def test_client_defaults_to_canonical_core_service_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LOTUS_CORE_BASE_URL", raising=False)
+
+    client = LotusCoreClient()
+
+    assert client._base_url == DEFAULT_LOTUS_CORE_BASE_URL

--- a/tests/unit/test_lotus_performance_client.py
+++ b/tests/unit/test_lotus_performance_client.py
@@ -7,7 +7,10 @@ from typing import Any
 import httpx
 import pytest
 
-from app.integrations.lotus_performance_client import LotusPerformanceClient
+from app.integrations.lotus_performance_client import (
+    DEFAULT_LOTUS_PERFORMANCE_BASE_URL,
+    LotusPerformanceClient,
+)
 
 
 class _FakeAsyncClient:
@@ -139,4 +142,4 @@ def test_client_extract_error_detail_variants() -> None:
 def test_client_defaults_base_url_when_env_missing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LOTUS_PERFORMANCE_BASE_URL", raising=False)
     client = LotusPerformanceClient()
-    assert client._base_url == "http://localhost:8002"
+    assert client._base_url == DEFAULT_LOTUS_PERFORMANCE_BASE_URL


### PR DESCRIPTION
## Summary
- replace localhost upstream defaults with canonical core/performance service identities
- update migration/developer guidance to use canonical Lotus service URLs
- add unit coverage for the canonical runtime defaults

## Validation
- python -m pytest tests/unit/test_lotus_core_client.py tests/unit/test_lotus_performance_client.py -q