### PR TITLE
style: normalize formatting after RFC-0007 merge

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -347,9 +347,7 @@ async def handle_value_error(request: Request, exc: ValueError) -> Response:
 
 
 @app.exception_handler(UpstreamServiceError)
-async def handle_upstream_service_error(
-    request: Request, exc: UpstreamServiceError
-) -> Response:
+async def handle_upstream_service_error(request: Request, exc: UpstreamServiceError) -> Response:
     details = dict(exc.details)
     details["retryable"] = exc.retryable
     return error_response(

--- a/src/app/ops_runtime.py
+++ b/src/app/ops_runtime.py
@@ -67,8 +67,12 @@ def resolve_dependency_runtime_views(app: FastAPI) -> list[DependencyRuntimeView
                 base_url=dependency.base_url,
                 status=override_status if isinstance(override_status, str) else dependency.status,
                 detail=override_detail if isinstance(override_detail, str) else dependency.detail,
-                category=override.get("category") if isinstance(override.get("category"), str) else None,
-                issue_code=override.get("issue_code") if isinstance(override.get("issue_code"), str) else None,
+                category=override.get("category")
+                if isinstance(override.get("category"), str)
+                else None,
+                issue_code=override.get("issue_code")
+                if isinstance(override.get("issue_code"), str)
+                else None,
             )
         )
     return resolved

--- a/src/app/services/benchmark_exposure_history.py
+++ b/src/app/services/benchmark_exposure_history.py
@@ -63,8 +63,7 @@ def _validate_lineage(response: dict[str, Any]) -> None:
             service="lotus-performance",
             operation="/integration/benchmarks/exposure-context",
             message=(
-                "lotus-performance benchmark exposure context missing "
-                "served_by=lotus-performance"
+                "lotus-performance benchmark exposure context missing served_by=lotus-performance"
             ),
         )
 

--- a/src/app/services/rolling_mode_adapter.py
+++ b/src/app/services/rolling_mode_adapter.py
@@ -100,7 +100,9 @@ async def _get_risk_free_coverage_details(
         details["risk_free_coverage_request_fingerprint"] = request_fingerprint
     sample = coverage.get("missing_dates_sample")
     if isinstance(sample, list) and sample:
-        details["risk_free_missing_dates_sample"] = [value for value in sample if isinstance(value, str)]
+        details["risk_free_missing_dates_sample"] = [
+            value for value in sample if isinstance(value, str)
+        ]
     return details
 
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -172,7 +172,9 @@ def test_health_ready_and_ops_surface_dependency_degradation() -> None:
     assert ops_body["status"] == "degraded"
     assert ops_body["checks"]["ready"] is True
     performance_dependency = next(
-        dependency for dependency in ops_body["dependencies"] if dependency["service"] == "lotus-performance"
+        dependency
+        for dependency in ops_body["dependencies"]
+        if dependency["service"] == "lotus-performance"
     )
     assert performance_dependency["detail"] == "high_latency"
     assert performance_dependency["category"] == "transport"
@@ -216,14 +218,18 @@ def test_health_ready_and_ops_surface_structured_data_gap_metadata() -> None:
 
     assert readiness.status_code == 200
     readiness_dependency = next(
-        dependency for dependency in readiness.json()["dependencies"] if dependency["service"] == "lotus-core"
+        dependency
+        for dependency in readiness.json()["dependencies"]
+        if dependency["service"] == "lotus-core"
     )
     assert readiness_dependency["status"] == "degraded"
     assert readiness_dependency["category"] == "data_gap"
     assert readiness_dependency["issue_code"] == "RISK_FREE_SERIES_EMPTY"
 
     ops_dependency = next(
-        dependency for dependency in ops.json()["dependencies"] if dependency["service"] == "lotus-core"
+        dependency
+        for dependency in ops.json()["dependencies"]
+        if dependency["service"] == "lotus-core"
     )
     assert ops_dependency["detail"] == "risk_free_series_missing_for_usd_ytd"
     assert ops_dependency["category"] == "data_gap"

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -487,7 +487,9 @@ def test_historical_attribution_stateful_active_risk_rejects_bad_benchmark_conte
     assert body["correlation_id"] == "corr-attr-bad-bmk-context"
 
 
-def test_historical_attribution_stateful_active_risk_maps_benchmark_context_500_to_upstream_failure() -> None:
+def test_historical_attribution_stateful_active_risk_maps_benchmark_context_500_to_upstream_failure() -> (
+    None
+):
     class _BenchmarkContextFailurePerformanceClient:
         def __init__(self) -> None:
             self.calls: list[dict[str, object]] = []
@@ -567,4 +569,7 @@ def test_historical_attribution_stateful_active_risk_maps_benchmark_context_500_
     assert body["details"]["service"] == "lotus-performance"
     assert body["details"]["operation"] == "/integration/benchmarks/exposure-context"
     assert body["details"]["upstream_status_code"] == 500
-    assert performance_client.benchmark_exposure_context_calls[0]["correlation_id"] == "corr-attr-bmk-context-500"
+    assert (
+        performance_client.benchmark_exposure_context_calls[0]["correlation_id"]
+        == "corr-attr-bmk-context-500"
+    )

--- a/tests/unit/test_lotus_core_client.py
+++ b/tests/unit/test_lotus_core_client.py
@@ -168,7 +168,9 @@ async def test_client_maps_http_status_error_with_detail(monkeypatch: pytest.Mon
     )
     client = LotusCoreClient(base_url="http://core.local")
 
-    with pytest.raises(UpstreamServiceError, match="rejected request \\(400\\): bad request") as exc_info:
+    with pytest.raises(
+        UpstreamServiceError, match="rejected request \\(400\\): bad request"
+    ) as exc_info:
         await client.get_core_snapshot(
             portfolio_id="DEMO_DPM_EUR_001",
             request_payload={"snapshot_mode": "BASELINE"},

--- a/tests/unit/test_lotus_performance_client.py
+++ b/tests/unit/test_lotus_performance_client.py
@@ -377,7 +377,9 @@ async def test_client_times_out_async_returns_series_when_result_never_completes
 
     client = LotusPerformanceClient(base_url="http://performance.local")
     client._async_max_polls = 2
-    with pytest.raises(UpstreamServiceError, match="did not complete within polling budget") as exc_info:
+    with pytest.raises(
+        UpstreamServiceError, match="did not complete within polling budget"
+    ) as exc_info:
         await client.get_returns_series(
             request_payload={"portfolio_id": "DEMO_DPM_EUR_001"},
             correlation_id="corr-async-timeout",
@@ -429,7 +431,8 @@ async def test_client_maps_benchmark_exposure_context_errors(
     client = LotusPerformanceClient(base_url="http://performance.local")
 
     with pytest.raises(
-        UpstreamServiceError, match="exposure-context failed \\(503\\): benchmark context unavailable"
+        UpstreamServiceError,
+        match="exposure-context failed \\(503\\): benchmark context unavailable",
     ) as exc_info:
         await client.get_benchmark_exposure_context(
             request_payload={"portfolio_id": "DEMO_DPM_EUR_001"},


### PR DESCRIPTION
## Summary
- fix formatting drift that caused the post-merge CI red state after RFC-0007 merge
- no logic changes; formatting-only forward fix on mainline content

## Validation
- python -m pytest -q
- python -m ruff check .
- python -m ruff format --check .
