### PR TITLE
fix: align lotus-risk docker core hostname with canonical query url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ ROUNDING_POLICY_VERSION=v1
 
 # Canonical hostnames remain the in-code defaults for non-containerized and ingress-routed environments.
 # For local Docker runs, lotus-risk keeps canonical upstream hostnames and resolves them via extra_hosts.
-LOTUS_CORE_BASE_URL=http://core-control.dev.lotus
+LOTUS_CORE_BASE_URL=http://core-query.dev.lotus
 LOTUS_CORE_TIMEOUT_SECONDS=10
 LOTUS_PERFORMANCE_BASE_URL=http://performance.dev.lotus
 LOTUS_PERFORMANCE_TIMEOUT_SECONDS=10

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker compose up --build
 
 Local Docker runtime notes:
 - `lotus-risk` keeps canonical upstream hostnames in code defaults for ingress-routed and non-containerized environments.
-- For local Docker Compose runs, `docker-compose.yml` explicitly points `LOTUS_CORE_BASE_URL` to `http://core-control.dev.lotus` and `LOTUS_PERFORMANCE_BASE_URL` to `http://performance.dev.lotus`, with `extra_hosts` mapping those canonical names back to the local host gateway.
+- For local Docker Compose runs, `docker-compose.yml` explicitly points `LOTUS_CORE_BASE_URL` to `http://core-query.dev.lotus` and `LOTUS_PERFORMANCE_BASE_URL` to `http://performance.dev.lotus`, with `extra_hosts` mapping those canonical names back to the local host gateway.
 - Copy `.env.example` to `.env` only when you need to override those local defaults.
 - Stateful lotus-performance integration may complete asynchronously; local defaults use `LOTUS_PERFORMANCE_ASYNC_POLL_INTERVAL_SECONDS=1` and `LOTUS_PERFORMANCE_ASYNC_MAX_POLLS=60`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,10 @@ services:
     env_file:
       - .env
     environment:
-      LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-control.dev.lotus}
+      LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-query.dev.lotus}
       LOTUS_PERFORMANCE_BASE_URL: ${LOTUS_PERFORMANCE_BASE_URL:-http://performance.dev.lotus}
     extra_hosts:
-      - "core-control.dev.lotus:host-gateway"
+      - "core-query.dev.lotus:host-gateway"
       - "performance.dev.lotus:host-gateway"
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8130/health/ready')"]

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -5,20 +5,19 @@ def test_local_docker_compose_sets_explicit_upstream_urls() -> None:
     compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
 
     assert (
-        "LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-control.dev.lotus}"
-        in compose_text
+        "LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-query.dev.lotus}" in compose_text
     )
     assert (
         "LOTUS_PERFORMANCE_BASE_URL: ${LOTUS_PERFORMANCE_BASE_URL:-http://performance.dev.lotus}"
         in compose_text
     )
-    assert '"core-control.dev.lotus:host-gateway"' in compose_text
+    assert '"core-query.dev.lotus:host-gateway"' in compose_text
     assert '"performance.dev.lotus:host-gateway"' in compose_text
 
 
 def test_env_example_documents_local_docker_upstream_defaults() -> None:
     env_example = Path(".env.example").read_text(encoding="utf-8")
 
-    assert "LOTUS_CORE_BASE_URL=http://core-control.dev.lotus" in env_example
+    assert "LOTUS_CORE_BASE_URL=http://core-query.dev.lotus" in env_example
     assert "LOTUS_PERFORMANCE_BASE_URL=http://performance.dev.lotus" in env_example
     assert "Canonical hostnames remain the in-code defaults" in env_example


### PR DESCRIPTION
## Summary
- correct the lotus-core docker hostname to the canonical query URL
- keep lotus-performance on the canonical performance hostname
- align docs and runtime contract tests with the corrected hostname

## Validation
- python -m ruff format --check .
- python -m pytest tests/unit/test_local_docker_runtime_contract.py -q