### PR TITLE
Normalize lotus-risk formatting for CI

### DIFF
--- a/src/app/contracts/rolling.py
+++ b/src/app/contracts/rolling.py
@@ -400,20 +400,20 @@ class RollingWindowResult(BaseModel):
         description="Rolling metric summaries keyed by metric name.",
         json_schema_extra={
             "example": {
-                    "ROLLING_VOLATILITY": {
-                        "total_point_count": 90,
-                        "computed_point_count": 70,
-                        "coverage_ratio": 0.777778,
-                        "min_observations_required": 21,
-                        "warmup_point_count": 20,
-                        "non_computed_point_count": 20,
-                        "post_warmup_gap_point_count": 0,
-                        "latest_observation_date": "2026-03-31",
-                        "latest": 0.1374,
-                        "average": 0.1221,
-                        "minimum": 0.0913,
-                        "maximum": 0.1662,
-                        "p05": 0.0975,
+                "ROLLING_VOLATILITY": {
+                    "total_point_count": 90,
+                    "computed_point_count": 70,
+                    "coverage_ratio": 0.777778,
+                    "min_observations_required": 21,
+                    "warmup_point_count": 20,
+                    "non_computed_point_count": 20,
+                    "post_warmup_gap_point_count": 0,
+                    "latest_observation_date": "2026-03-31",
+                    "latest": 0.1374,
+                    "average": 0.1221,
+                    "minimum": 0.0913,
+                    "maximum": 0.1662,
+                    "p05": 0.0975,
                     "p50": 0.1218,
                     "p95": 0.1611,
                 }
@@ -461,7 +461,9 @@ class RollingBenchmarkContext(BaseModel):
         description="Whether benchmark return observations aligned with portfolio observations for requested rolling metrics.",
         json_schema_extra={"example": True},
     )
-    reason: Literal["NOT_REQUESTED", "BENCHMARK_UNAVAILABLE", "NO_ALIGNED_OBSERVATIONS", "APPLIED"] = Field(
+    reason: Literal[
+        "NOT_REQUESTED", "BENCHMARK_UNAVAILABLE", "NO_ALIGNED_OBSERVATIONS", "APPLIED"
+    ] = Field(
         description="Deterministic benchmark application outcome for the period.",
         json_schema_extra={"example": "APPLIED"},
     )
@@ -480,7 +482,9 @@ class RollingRiskFreeContext(BaseModel):
         description="Whether risk-free observations aligned with portfolio observations for rolling Sharpe.",
         json_schema_extra={"example": True},
     )
-    reason: Literal["NOT_REQUESTED", "RISK_FREE_UNAVAILABLE", "NO_ALIGNED_OBSERVATIONS", "APPLIED"] = Field(
+    reason: Literal[
+        "NOT_REQUESTED", "RISK_FREE_UNAVAILABLE", "NO_ALIGNED_OBSERVATIONS", "APPLIED"
+    ] = Field(
         description="Deterministic risk-free application outcome for the period.",
         json_schema_extra={"example": "APPLIED"},
     )
@@ -762,28 +766,28 @@ class RollingResponse(BaseModel):
                     "YTD": {
                         "start_date": "2026-01-01",
                         "end_date": "2026-03-31",
-                    "series_count": 90,
-                    "benchmark_series_count": 90,
-                    "aligned_benchmark_series_count": 90,
-                    "window_lengths_requested": [21],
-                    "window_count_requested": 1,
-                    "window_lengths_emitted": [21],
-                    "window_count_emitted": 1,
-                    "benchmark_context": {
-                        "requested": True,
-                        "available": True,
-                        "aligned": True,
-                        "reason": "APPLIED",
-                    },
-                    "risk_free_series_count": 0,
-                    "aligned_risk_free_series_count": 0,
-                    "risk_free_context": {
-                        "requested": False,
-                        "available": False,
-                        "aligned": False,
-                        "reason": "NOT_REQUESTED",
-                    },
-                    "window_results": [
+                        "series_count": 90,
+                        "benchmark_series_count": 90,
+                        "aligned_benchmark_series_count": 90,
+                        "window_lengths_requested": [21],
+                        "window_count_requested": 1,
+                        "window_lengths_emitted": [21],
+                        "window_count_emitted": 1,
+                        "benchmark_context": {
+                            "requested": True,
+                            "available": True,
+                            "aligned": True,
+                            "reason": "APPLIED",
+                        },
+                        "risk_free_series_count": 0,
+                        "aligned_risk_free_series_count": 0,
+                        "risk_free_context": {
+                            "requested": False,
+                            "available": False,
+                            "aligned": False,
+                            "reason": "NOT_REQUESTED",
+                        },
+                        "window_results": [
                             {
                                 "window_length": 21,
                                 "metric_summaries": {

--- a/src/app/services/concentration_engine.py
+++ b/src/app/services/concentration_engine.py
@@ -313,9 +313,7 @@ def _build_response(payload: ConcentrationComputationInput) -> ConcentrationResp
     current_hhi = _compute_hhi(current_values)
     proposed_hhi = _compute_hhi(proposed_values) if proposed_values else current_hhi
 
-    current_top, current_top_n = _single_position_metrics(
-        current_values, top_n=payload.top_n
-    )
+    current_top, current_top_n = _single_position_metrics(current_values, top_n=payload.top_n)
     if proposed_values:
         proposed_top, proposed_top_n = _single_position_metrics(
             proposed_values, top_n=payload.top_n
@@ -325,9 +323,7 @@ def _build_response(payload: ConcentrationComputationInput) -> ConcentrationResp
 
     current_issuer_hhi = _compute_hhi(current_issuer_values)
     proposed_issuer_hhi = (
-        _compute_hhi(proposed_issuer_values)
-        if proposed_issuer_values
-        else current_issuer_hhi
+        _compute_hhi(proposed_issuer_values) if proposed_issuer_values else current_issuer_hhi
     )
 
     current_issuer_top, _ = _single_position_metrics(current_issuer_values, top_n=1)
@@ -432,7 +428,9 @@ def _extract_issuer_map(
             continue
         security_id = _as_str(row.get("security_id"))
         if grouping_level == IssuerGroupingLevel.ULTIMATE_PARENT:
-            issuer_id = _as_str(row.get("ultimate_parent_issuer_id")) or _as_str(row.get("issuer_id"))
+            issuer_id = _as_str(row.get("ultimate_parent_issuer_id")) or _as_str(
+                row.get("issuer_id")
+            )
             issuer_name = _as_str(row.get("ultimate_parent_issuer_name")) or _as_str(
                 row.get("issuer_name")
             )
@@ -861,10 +859,12 @@ async def calculate_concentration(
                             if not security_id:
                                 continue
                             if request.issuer_grouping_level == IssuerGroupingLevel.ULTIMATE_PARENT:
-                                issuer_id = _as_str(record.get("ultimate_parent_issuer_id")) or _as_str(record.get("issuer_id"))
-                                issuer_name = _as_str(record.get("ultimate_parent_issuer_name")) or _as_str(
-                                    record.get("issuer_name")
-                                )
+                                issuer_id = _as_str(
+                                    record.get("ultimate_parent_issuer_id")
+                                ) or _as_str(record.get("issuer_id"))
+                                issuer_name = _as_str(
+                                    record.get("ultimate_parent_issuer_name")
+                                ) or _as_str(record.get("issuer_name"))
                             else:
                                 issuer_id = _as_str(record.get("issuer_id"))
                                 issuer_name = _as_str(record.get("issuer_name"))
@@ -906,9 +906,7 @@ async def calculate_concentration(
             proposed_positions=proposed_positions if proposed_positions else current_positions,
             top_n=stateless_input.top_n,
             current_issuers=current_issuers,
-            proposed_issuers=(
-                proposed_issuers if proposed_issuers else current_issuers
-            ),
+            proposed_issuers=(proposed_issuers if proposed_issuers else current_issuers),
             covered_position_count_current=covered_current,
             covered_position_count_proposed=(
                 covered_proposed if proposed_positions else covered_current

--- a/src/app/services/drawdown_engine.py
+++ b/src/app/services/drawdown_engine.py
@@ -256,9 +256,7 @@ def calculate_drawdown(
                     requested=include_benchmark is True,
                     applied=False,
                     reason=(
-                        "BENCHMARK_UNAVAILABLE"
-                        if include_benchmark is True
-                        else "NOT_REQUESTED"
+                        "BENCHMARK_UNAVAILABLE" if include_benchmark is True else "NOT_REQUESTED"
                     ),
                     aligned_observation_count=0,
                 ),

--- a/src/app/services/risk_engine.py
+++ b/src/app/services/risk_engine.py
@@ -419,9 +419,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                         raise ValueError("Zero volatility")
                     mean_return = _as_number(metric_series.mean() / 100)
                     excess_return = _as_number(mean_return - periodic_rf)
-                    sharpe = (
-                        excess_return / (denominator / 100)
-                    ) * sqrt(annual_factor)
+                    sharpe = (excess_return / (denominator / 100)) * sqrt(annual_factor)
                     metric_map["SHARPE"] = RiskValue(
                         value=_as_number(sharpe),
                         details={
@@ -430,9 +428,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                             "mean_return": mean_return,
                             "periodic_risk_free_rate": periodic_rf,
                             "excess_return": excess_return,
-                            "annualized_excess_return": _as_number(
-                                excess_return * annual_factor
-                            ),
+                            "annualized_excess_return": _as_number(excess_return * annual_factor),
                             "volatility": _as_number(denominator / 100),
                         },
                     )
@@ -451,9 +447,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                     downside_deviation = _as_number(np.sqrt((downside**2).mean()))
                     mean_return = _as_number(metric_series.mean() / 100)
                     excess_return = _as_number(mean_return - periodic_mar)
-                    sortino = (
-                        excess_return / downside_deviation
-                    ) * sqrt(annual_factor)
+                    sortino = (excess_return / downside_deviation) * sqrt(annual_factor)
                     metric_map["SORTINO"] = RiskValue(
                         value=_as_number(sortino),
                         details={
@@ -463,9 +457,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                             "periodic_mar": periodic_mar,
                             "mean_return": mean_return,
                             "excess_return": excess_return,
-                            "annualized_excess_return": _as_number(
-                                excess_return * annual_factor
-                            ),
+                            "annualized_excess_return": _as_number(excess_return * annual_factor),
                             "downside_observation_count": downside_count,
                             "downside_deviation": downside_deviation,
                         },
@@ -523,9 +515,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                     base_var = _calculate_var_by_method(
                         metric_series, request.options.var.method, request.options.var.confidence
                     )
-                    horizon_scale_factor = _as_number(
-                        sqrt(request.options.var.horizon_days)
-                    )
+                    horizon_scale_factor = _as_number(sqrt(request.options.var.horizon_days))
                     scaled_var = _as_number(base_var * horizon_scale_factor)
                     tail_observation_count = int((metric_series <= base_var).sum())
                     details: dict[str, str | float | int | bool | None] = {
@@ -545,9 +535,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                         base_es = _expected_shortfall(metric_series, base_var)
                         details["base_expected_shortfall"] = base_es
                         details["expected_shortfall_observation_count"] = tail_observation_count
-                        details["expected_shortfall"] = _as_number(
-                            base_es * horizon_scale_factor
-                        )
+                        details["expected_shortfall"] = _as_number(base_es * horizon_scale_factor)
                     metric_map["VAR"] = RiskValue(value=scaled_var, details=details)
                 except ValueError as exc:
                     metric_map["VAR"] = _metric_error(str(exc))

--- a/src/app/services/rolling_engine.py
+++ b/src/app/services/rolling_engine.py
@@ -293,7 +293,9 @@ def _risk_free_context(
     )
 
 
-def _request_dependency_context(requested_metrics: list[str], dependency_metrics: set[str]) -> RollingRequestDependencyContext:
+def _request_dependency_context(
+    requested_metrics: list[str], dependency_metrics: set[str]
+) -> RollingRequestDependencyContext:
     requested = [metric for metric in requested_metrics if metric in dependency_metrics]
     return RollingRequestDependencyContext(
         requested=bool(requested),

--- a/tests/integration/test_drawdown_live_characterization.py
+++ b/tests/integration/test_drawdown_live_characterization.py
@@ -98,7 +98,9 @@ def test_live_stateful_drawdown_reconciles_with_upstream_returns() -> None:
         request_payload=returns_payload,
     )
     with httpx.Client(timeout=30.0) as client:
-        drawdown_response = client.post(f"{RISK_BASE_URL}/analytics/risk/drawdown", json=drawdown_payload)
+        drawdown_response = client.post(
+            f"{RISK_BASE_URL}/analytics/risk/drawdown", json=drawdown_payload
+        )
         drawdown_response.raise_for_status()
     drawdown_body = drawdown_response.json()
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -348,18 +348,18 @@ def test_historical_attribution_openapi_examples_and_description_reflect_statefu
         "grouping_dimensions"
     ] == ["SECTOR"]
     assert response_schema["example"]["input_mode"] == "stateful"
-    assert response_schema["example"]["results"]["YTD"]["attribution_sets"][0][
-        "attribution_type"
-    ] == "ACTIVE_RISK"
+    assert (
+        response_schema["example"]["results"]["YTD"]["attribution_sets"][0]["attribution_type"]
+        == "ACTIVE_RISK"
+    )
     assert response_schema["example"]["results"]["YTD"]["attribution_sets"][0]["metric"] == (
         "TRACKING_ERROR"
     )
-    assert response_schema["example"]["results"]["YTD"]["attribution_sets"][0][
-        "grouping_dimension"
-    ] == "SECTOR"
-    assert response_schema["example"]["metadata"]["requested_attribution_types"] == [
-        "ACTIVE_RISK"
-    ]
+    assert (
+        response_schema["example"]["results"]["YTD"]["attribution_sets"][0]["grouping_dimension"]
+        == "SECTOR"
+    )
+    assert response_schema["example"]["metadata"]["requested_attribution_types"] == ["ACTIVE_RISK"]
     assert response_schema["example"]["metadata"]["requested_grouping_dimensions"] == ["SECTOR"]
 
 
@@ -393,16 +393,12 @@ def test_drawdown_openapi_examples_are_present_and_canonical() -> None:
         ]
         is True
     )
-    assert (
-        drawdown_schema["properties"]["analysis_options"]["example"]["top_n_episodes"] == 5
-    )
+    assert drawdown_schema["properties"]["analysis_options"]["example"]["top_n_episodes"] == 5
     assert response_schema["properties"]["metadata"]["example"]["missing_benchmark_policy"] in {
         "IGNORE",
         "REQUIRE",
     }
-    assert response_schema["properties"]["results"]["example"]["YTD"]["summary"][
-        "max_drawdown"
-    ] < 0
+    assert response_schema["properties"]["results"]["example"]["YTD"]["summary"]["max_drawdown"] < 0
 
 
 def test_risk_calculate_openapi_examples_are_present_and_canonical() -> None:
@@ -412,14 +408,14 @@ def test_risk_calculate_openapi_examples_are_present_and_canonical() -> None:
     response_schema = spec["components"]["schemas"]["RiskResponse"]
 
     assert request_schema["properties"]["input_mode"]["example"] == "stateless"
+    assert request_schema["properties"]["stateful_input"]["example"]["metrics"] == [
+        "VOLATILITY",
+        "BETA",
+        "TRACKING_ERROR",
+        "INFORMATION_RATIO",
+    ]
     assert (
-        request_schema["properties"]["stateful_input"]["example"]["metrics"]
-        == ["VOLATILITY", "BETA", "TRACKING_ERROR", "INFORMATION_RATIO"]
-    )
-    assert (
-        request_schema["properties"]["stateful_input"]["example"]["options"]["var"][
-            "horizon_days"
-        ]
+        request_schema["properties"]["stateful_input"]["example"]["options"]["var"]["horizon_days"]
         == 4
     )
     assert (
@@ -429,9 +425,9 @@ def test_risk_calculate_openapi_examples_are_present_and_canonical() -> None:
         == "SQRT_TIME"
     )
     assert (
-        response_schema["example"]["results"]["YTD"]["metrics"]["INFORMATION_RATIO"][
-            "details"
-        ]["annualized_active_return"]
+        response_schema["example"]["results"]["YTD"]["metrics"]["INFORMATION_RATIO"]["details"][
+            "annualized_active_return"
+        ]
         > 0
     )
     assert response_schema["example"]["metadata"]["var_horizon_days"] == 4
@@ -464,7 +460,10 @@ def test_rolling_openapi_examples_are_present_and_canonical() -> None:
     assert response_schema["example"]["results"]["YTD"]["window_lengths_emitted"] == [21]
     assert response_schema["example"]["results"]["YTD"]["window_count_emitted"] == 1
     assert response_schema["example"]["results"]["YTD"]["benchmark_context"]["reason"] == "APPLIED"
-    assert response_schema["example"]["results"]["YTD"]["risk_free_context"]["reason"] == "NOT_REQUESTED"
+    assert (
+        response_schema["example"]["results"]["YTD"]["risk_free_context"]["reason"]
+        == "NOT_REQUESTED"
+    )
     assert response_schema["example"]["metadata"]["benchmark_context"]["requested"] is True
     assert response_schema["example"]["metadata"]["risk_free_context"]["requested"] is False
     assert response_schema["example"]["results"]["YTD"]["window_results"][0]["window_length"] == 21

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -421,9 +421,7 @@ def test_historical_attribution_stateful_active_risk_issuer_is_explicitly_gated(
     body = response.json()["error"]
     assert body["code"] == "INVALID_REQUEST"
     assert body["message"] == "Request validation failed"
-    assert any(
-        "grouping_dimension=ISSUER" in detail["msg"] for detail in body["details"]
-    )
+    assert any("grouping_dimension=ISSUER" in detail["msg"] for detail in body["details"])
     assert body["correlation_id"] == "corr-attr-active-issuer"
 
 

--- a/tests/integration/test_risk_calculate_live_characterization.py
+++ b/tests/integration/test_risk_calculate_live_characterization.py
@@ -46,8 +46,7 @@ def _tracking_error(portfolio_returns: list[float], benchmark_returns: list[floa
 def _information_ratio(portfolio_returns: list[float], benchmark_returns: list[float]) -> float:
     active_returns = np.array(portfolio_returns) - np.array(benchmark_returns)
     return float(
-        (np.mean(active_returns) / np.std(active_returns, ddof=1))
-        * np.sqrt(ANNUALIZATION_FACTOR)
+        (np.mean(active_returns) / np.std(active_returns, ddof=1)) * np.sqrt(ANNUALIZATION_FACTOR)
     )
 
 

--- a/tests/integration/test_rolling_live_characterization.py
+++ b/tests/integration/test_rolling_live_characterization.py
@@ -130,15 +130,14 @@ def test_live_stateful_rolling_reconciles_selected_metrics() -> None:
         window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH
     ).std(ddof=1) * (ANNUALIZATION_BASIS**0.5)
     active = aligned["portfolio"] - aligned["benchmark"]
-    rolling_tracking_error = active.rolling(
+    rolling_tracking_error = active.rolling(window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH).std(
+        ddof=1
+    ) * (ANNUALIZATION_BASIS**0.5)
+    rolling_beta = aligned["portfolio"].rolling(
         window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH
-    ).std(ddof=1) * (ANNUALIZATION_BASIS**0.5)
-    rolling_beta = (
-        aligned["portfolio"].rolling(window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH).cov(
-            aligned["benchmark"]
-        )
-        / aligned["benchmark"].rolling(window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH).var(ddof=1)
-    )
+    ).cov(aligned["benchmark"]) / aligned["benchmark"].rolling(
+        window=WINDOW_LENGTH, min_periods=WINDOW_LENGTH
+    ).var(ddof=1)
 
     body = rolling_response.json()
     period = body["results"]["YTD"]

--- a/tests/unit/test_live_returns_series.py
+++ b/tests/unit/test_live_returns_series.py
@@ -25,7 +25,9 @@ def _response(status_code: int, payload: dict[str, object]) -> httpx.Response:
     return httpx.Response(status_code, json=payload, request=request)
 
 
-def test_request_json_with_retries_returns_first_non_retryable_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_request_json_with_retries_returns_first_non_retryable_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr("tests.support.live_returns_series.time.sleep", lambda _: None)
     client = _FakeClient(
         [
@@ -46,7 +48,9 @@ def test_request_json_with_retries_returns_first_non_retryable_success(monkeypat
     assert len(client.calls) == 2
 
 
-def test_request_json_with_retries_raises_after_retry_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_request_json_with_retries_raises_after_retry_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr("tests.support.live_returns_series.time.sleep", lambda _: None)
     client = _FakeClient(
         [
@@ -67,7 +71,9 @@ def test_request_json_with_retries_raises_after_retry_budget(monkeypatch: pytest
     assert len(client.calls) == 2
 
 
-def test_fetch_live_risk_free_series_uses_reference_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_live_risk_free_series_uses_reference_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured: dict[str, object] = {}
 
     def _fake_request_json_with_retries(**kwargs: object) -> dict[str, object]:
@@ -117,9 +123,7 @@ def test_fetch_live_benchmark_exposure_context_uses_performance_endpoint(
 
     assert payload == {"rows": []}
     assert captured["method"] == "POST"
-    assert (
-        captured["url"] == "http://performance.example/integration/benchmarks/exposure-context"
-    )
+    assert captured["url"] == "http://performance.example/integration/benchmarks/exposure-context"
     assert captured["request_kwargs"] == {"json": {"portfolio_id": "PB_001"}}
     assert captured["max_attempts"] == 4
     assert captured["retry_interval_seconds"] == 0.5


### PR DESCRIPTION
## Summary
- apply repo-wide formatter output required by CI
- no behavior changes; formatting-only follow-up to the already merged feature PR

## Validation
- `python -m pytest -q` -> `297 passed, 8 skipped`
- `python -m ruff check .`
- `python -m ruff format --check .`
- `python scripts/openapi_quality_gate.py`
