### PR TITLE
Fix remaining CI typecheck regressions

### DIFF
--- a/src/app/contracts/attribution.py
+++ b/src/app/contracts/attribution.py
@@ -31,6 +31,14 @@ def _default_groupings() -> list[GroupingDimension]:
     return ["POSITION"]
 
 
+def _default_stateful_active_risk_supported_groupings() -> list[GroupingDimension]:
+    return ["POSITION", "SECTOR", "ASSET_CLASS"]
+
+
+def _default_stateful_active_risk_gated_groupings() -> list[GroupingDimension]:
+    return ["ISSUER"]
+
+
 class AttributionOptions(BaseModel):
     attribution_types: list[AttributionType] = Field(
         default_factory=_default_attribution_types,
@@ -503,12 +511,12 @@ class HistoricalAttributionMetadata(BaseModel):
         json_schema_extra={"example": "STRICT"},
     )
     stateful_active_risk_supported_grouping_dimensions: list[GroupingDimension] = Field(
-        default_factory=lambda: ["POSITION", "SECTOR", "ASSET_CLASS"],
+        default_factory=_default_stateful_active_risk_supported_groupings,
         description="Grouping dimensions currently supported for stateful ACTIVE_RISK attribution.",
         json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS"]},
     )
     stateful_active_risk_gated_grouping_dimensions: list[GroupingDimension] = Field(
-        default_factory=lambda: ["ISSUER"],
+        default_factory=_default_stateful_active_risk_gated_groupings,
         description="Grouping dimensions intentionally gated for stateful ACTIVE_RISK attribution.",
         json_schema_extra={"example": ["ISSUER"]},
     )

--- a/src/app/services/drawdown_engine.py
+++ b/src/app/services/drawdown_engine.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import date
 from math import sqrt
 from collections.abc import Sequence
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -195,7 +195,7 @@ def _build_metadata(
     *,
     analysis_options: DrawdownAnalysisOptions,
     include_benchmark: bool | None,
-    missing_benchmark_policy: str | None,
+    missing_benchmark_policy: Literal["IGNORE", "REQUIRE"] | None,
 ) -> DrawdownMetadata:
     return DrawdownMetadata(
         include_underwater_series=analysis_options.include_underwater_series,
@@ -215,7 +215,7 @@ def calculate_drawdown(
     input_mode: DrawdownInputMode,
     analysis_options: DrawdownAnalysisOptions,
     include_benchmark: bool | None = None,
-    missing_benchmark_policy: str | None = None,
+    missing_benchmark_policy: Literal["IGNORE", "REQUIRE"] | None = None,
 ) -> DrawdownResponse:
     returns_df = _build_returns_df(request.returns)
     benchmark_df = _build_returns_df(request.benchmark_returns)

--- a/src/app/services/risk_engine.py
+++ b/src/app/services/risk_engine.py
@@ -31,6 +31,7 @@ RISK_METRIC_DURATION_SECONDS = Histogram(
 )
 
 BENCHMARK_METRICS = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
+RiskMetricDetails = dict[str, str | float | int | bool | None]
 
 
 def _as_number(number: SupportsFloat) -> float:
@@ -184,7 +185,7 @@ def _expected_shortfall(returns: pd.Series, var_value: float) -> float:
     return _as_number(tail.mean())
 
 
-def _beta(portfolio: pd.Series, benchmark: pd.Series) -> tuple[float, dict[str, float | int]]:
+def _beta(portfolio: pd.Series, benchmark: pd.Series) -> tuple[float, RiskMetricDetails]:
     covariance = np.cov(portfolio, benchmark, ddof=1)
     denominator = covariance[1, 1]
     if np.isclose(denominator, 0.0):
@@ -205,7 +206,7 @@ def _beta(portfolio: pd.Series, benchmark: pd.Series) -> tuple[float, dict[str, 
 
 def _tracking_error(
     portfolio: pd.Series, benchmark: pd.Series, annual_factor: int
-) -> tuple[float, dict[str, float | int]]:
+) -> tuple[float, RiskMetricDetails]:
     active = portfolio - benchmark
     active_std = _as_number(active.std(ddof=1))
     annualized_tracking_error = _as_number(active_std * sqrt(annual_factor))
@@ -225,7 +226,7 @@ def _tracking_error(
 
 def _information_ratio(
     portfolio: pd.Series, benchmark: pd.Series, annual_factor: int
-) -> tuple[float, dict[str, float | int]]:
+) -> tuple[float, RiskMetricDetails]:
     active = portfolio - benchmark
     tracking_err = active.std(ddof=1)
     if np.isclose(tracking_err, 0.0):
@@ -251,7 +252,7 @@ def _information_ratio(
 
 def _calculate_benchmark_metric(
     metric_name: str, portfolio: pd.Series, benchmark: pd.Series, annual_factor: int
-) -> tuple[float, dict[str, float | int]]:
+) -> tuple[float, RiskMetricDetails]:
     if metric_name == "BETA":
         return _beta(portfolio, benchmark)
     if metric_name == "TRACKING_ERROR":
@@ -282,7 +283,7 @@ def _build_metadata(
     periodic_rf: float,
 ) -> RiskResponseMetadata:
     risk_free_requested = "SHARPE" in request.metrics
-    benchmark_metrics = [metric for metric in request.metrics if metric in BENCHMARK_METRICS]
+    benchmark_metrics = [str(metric) for metric in request.metrics if metric in BENCHMARK_METRICS]
     return RiskResponseMetadata(
         frequency=request.options.frequency,
         annualization_factor=annual_factor,
@@ -518,7 +519,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                     horizon_scale_factor = _as_number(sqrt(request.options.var.horizon_days))
                     scaled_var = _as_number(base_var * horizon_scale_factor)
                     tail_observation_count = int((metric_series <= base_var).sum())
-                    details: dict[str, str | float | int | bool | None] = {
+                    var_details: dict[str, str | float | int | bool | None] = {
                         "method": request.options.var.method,
                         "confidence": request.options.var.confidence,
                         "tail_probability": _as_number(1.0 - request.options.var.confidence),
@@ -533,10 +534,12 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                     }
                     if request.options.var.include_expected_shortfall:
                         base_es = _expected_shortfall(metric_series, base_var)
-                        details["base_expected_shortfall"] = base_es
-                        details["expected_shortfall_observation_count"] = tail_observation_count
-                        details["expected_shortfall"] = _as_number(base_es * horizon_scale_factor)
-                    metric_map["VAR"] = RiskValue(value=scaled_var, details=details)
+                        var_details["base_expected_shortfall"] = base_es
+                        var_details["expected_shortfall_observation_count"] = tail_observation_count
+                        var_details["expected_shortfall"] = _as_number(
+                            base_es * horizon_scale_factor
+                        )
+                    metric_map["VAR"] = RiskValue(value=scaled_var, details=var_details)
                 except ValueError as exc:
                     metric_map["VAR"] = _metric_error(str(exc))
 
@@ -555,7 +558,7 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
                     else ("NO_ALIGNED_OBSERVATIONS" if aligned_count == 0 else "APPLIED")
                 ),
                 "requested_metric_count": len(benchmark_metrics),
-                "requested_metrics": benchmark_metrics,
+                "requested_metrics": list(benchmark_metrics),
             }
 
         results[period_name] = RiskPeriodResult(

--- a/src/app/services/rolling_engine.py
+++ b/src/app/services/rolling_engine.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date
 from math import sqrt
 from typing import cast
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -224,7 +225,7 @@ def _window_series_points(
 
 
 def _benchmark_context(
-    requested_metrics: list[str],
+    requested_metrics: Sequence[str],
     benchmark_series_count: int,
     aligned_benchmark_series_count: int,
 ) -> RollingBenchmarkContext:
@@ -259,7 +260,7 @@ def _benchmark_context(
 
 
 def _risk_free_context(
-    requested_metrics: list[str],
+    requested_metrics: Sequence[str],
     risk_free_series_count: int,
     aligned_risk_free_series_count: int,
 ) -> RollingRiskFreeContext:
@@ -294,7 +295,7 @@ def _risk_free_context(
 
 
 def _request_dependency_context(
-    requested_metrics: list[str], dependency_metrics: set[str]
+    requested_metrics: Sequence[str], dependency_metrics: set[str]
 ) -> RollingRequestDependencyContext:
     requested = [metric for metric in requested_metrics if metric in dependency_metrics]
     return RollingRequestDependencyContext(
@@ -347,7 +348,7 @@ def calculate_rolling_metrics(
             results={},
             metadata=RollingMetadata(
                 annualization_basis=request.rolling_options.annualization_basis,
-                requested_metrics=list(request.rolling_options.metrics),
+                requested_metrics=[str(metric) for metric in request.rolling_options.metrics],
                 window_lengths_requested=list(request.rolling_options.window_lengths),
                 window_count_requested=len(request.rolling_options.window_lengths),
                 alignment_policy=request.rolling_options.alignment_policy,
@@ -366,7 +367,7 @@ def calculate_rolling_metrics(
 
     open_date = cast(pd.Timestamp, portfolio_df.index.min()).date()
     options = request.rolling_options
-    requested_metrics = list(options.metrics)
+    requested_metrics = [str(metric) for metric in options.metrics]
 
     results: dict[str, RollingPeriodResult] = {}
     for period in request.periods:

--- a/tests/support/live_returns_series.py
+++ b/tests/support/live_returns_series.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -12,7 +12,7 @@ RETRYABLE_STATUS_CODES = {502, 503, 504}
 
 def _request_json_with_retries(
     *,
-    client: httpx.Client,
+    client: Any,
     method: str,
     url: str,
     request_kwargs: dict[str, Any] | None = None,
@@ -25,7 +25,7 @@ def _request_json_with_retries(
         response = client.request(method, url, **kwargs)
         if response.status_code not in RETRYABLE_STATUS_CODES:
             response.raise_for_status()
-            return response.json()
+            return cast(dict[str, Any], response.json())
         last_response = response
         if attempt < max_attempts - 1:
             time.sleep(retry_interval_seconds)
@@ -116,7 +116,7 @@ def extract_decimal_returns(rows: Sequence[dict[str, Any]]) -> list[tuple[str, f
     for row in rows:
         date_value = row.get("date")
         return_value = row.get("return_value")
-        if not isinstance(date_value, str):
+        if not isinstance(date_value, str) or return_value is None:
             continue
         result.append((date_value, float(return_value)))
     return result


### PR DESCRIPTION
## Summary
- fix mypy invariance and literal-typing regressions in the analytics contracts/services
- align drawdown and rolling helper typing with the current contract model
- simplify the live returns helper typing seam so CI typecheck matches runtime usage

## Validation
- python -m pytest -q
- python -m ruff check .
- python -m ruff format --check .
- python scripts/openapi_quality_gate.py
- python -m mypy --config-file mypy.ini src tests