### PR TITLE
ci: converge lotus-risk monetary guard and RFC-0072 lanes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Advanced risk analytics service for Lotus platform.
 
+Repository-local engineering context: `REPOSITORY-ENGINEERING-CONTEXT.md`
+
 ## Quick Start
 
 ```powershell

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -1,0 +1,127 @@
+# Repository Engineering Context
+
+This file provides repository-local engineering context for `lotus-risk`.
+
+For platform-wide truth, read:
+
+1. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-QUICKSTART-CONTEXT.md`
+2. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-ENGINEERING-CONTEXT.md`
+3. `C:\Users\Sandeep\projects\lotus-platform\context\CONTEXT-REFERENCE-MAP.md`
+
+## Repository Role
+
+`lotus-risk` is the authoritative risk analytics service in Lotus.
+
+It owns drawdown, rolling risk, attribution, concentration, and related risk review analytics.
+
+## Business And Domain Responsibility
+
+This repository owns:
+
+1. risk analytics calculations,
+2. risk workspace supportability and decomposition payloads,
+3. drawdown and concentration review data,
+4. integration-ready risk contracts consumed by `lotus-gateway`.
+
+## Current-State Summary
+
+Current repository posture:
+
+1. `lotus-risk` is the domain authority for risk analytics in the ecosystem,
+2. the service supports the current Workbench risk workspace through gateway-backed contracts,
+3. the CI contract is explicit and strong, with no-alias, vocabulary, OpenAPI, test-pyramid, security, coverage, and Docker enforcement,
+4. current work often involves balancing analytical correctness, contract quality, and front-office usability.
+
+## Architecture And Module Map
+
+Primary areas:
+
+1. `src/`
+   risk application and analytics implementation.
+2. `scripts/`
+   OpenAPI, vocabulary, dependency-health, and test-pyramid governance.
+3. `docs/standards/`
+   local standards and contract guidance.
+4. `tests/`
+   unit, integration, and e2e validation.
+
+## Runtime And Integration Boundaries
+
+Runtime model:
+
+1. FastAPI-backed risk analytics service,
+2. primarily consumed through `lotus-gateway`,
+3. integrates with `lotus-core` and `lotus-performance` for stateful or cross-analytic flows where required.
+
+Boundary rules:
+
+1. risk analytics authority stays here,
+2. gateway and UI should not duplicate risk logic or narrative improperly,
+3. monetary-float governance applies only where money-bearing identifiers require it, not generic analytics terms,
+4. supportability and evidence posture should remain truthful and data-backed.
+
+## Repo-Native Commands
+
+Use these commands as the primary local contract:
+
+1. install
+   `make install`
+2. fast local gate
+   `make check`
+3. PR-grade local gate
+   `make ci`
+4. run unit tests
+   `make test-unit`
+5. run integration tests
+   `make test-integration`
+6. run e2e tests
+   `make test-e2e`
+
+## Validation And CI Expectations
+
+`lotus-risk` uses explicit CI lanes:
+
+1. `Remote Feature Lane`
+2. `Pull Request Merge Gate`
+3. `Main Releasability Gate`
+
+Important validation expectations:
+
+1. no-alias, OpenAPI, vocabulary, and test-pyramid gates are active,
+2. security audit and migration smoke are required,
+3. split test suites plus coverage and Docker build are part of the merge gate,
+4. risk correctness and evidence posture must remain aligned with the product and gateway contract.
+
+## Standards And RFCs That Govern This Repository
+
+Most relevant current governance:
+
+1. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0065-lotus-performance-to-lotus-performance-and-lotus-risk-split.md`
+2. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0067-centralized-api-vocabulary-inventory-and-openapi-documentation-governance.md`
+3. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0072-platform-wide-multi-lane-ci-validation-and-release-governance.md`
+4. `C:\Users\Sandeep\projects\lotus-platform\rfcs\RFC-0073-lotus-ecosystem-engineering-context-and-agent-guidance-system.md`
+5. `docs/standards/`
+
+## Known Constraints And Implementation Notes
+
+1. this repo sits close to front-office-facing risk workflows, so analytical contract drift is visible quickly in the UI,
+2. over-broad governance rules can damage analytics work if they are not scoped carefully,
+3. risk evidence and supportability posture must remain data-backed, not decorative or speculative,
+4. when risk review flows change in Workbench or Gateway, this repo’s context should be checked for alignment.
+
+## Context Maintenance Rule
+
+Update this document when:
+
+1. major risk modules or payload families change,
+2. repo-native commands or CI lane expectations change,
+3. upstream integration posture changes materially,
+4. supportability, evidence, or decomposition model assumptions change,
+5. current product-facing usage or rollout posture changes.
+
+## Cross-Links
+
+1. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-QUICKSTART-CONTEXT.md`
+2. `C:\Users\Sandeep\projects\lotus-platform\context\LOTUS-ENGINEERING-CONTEXT.md`
+3. `C:\Users\Sandeep\projects\lotus-platform\context\CONTEXT-REFERENCE-MAP.md`
+4. `C:\Users\Sandeep\projects\lotus-platform\context\Repository-Engineering-Context-Contract.md`

--- a/docs/standards/platform-compliance-assessment.md
+++ b/docs/standards/platform-compliance-assessment.md
@@ -33,3 +33,9 @@
 - `python scripts/test_pyramid_gate.py`
 
 All commands passed in local verification for this change set.
+
+## Monetary Float Guard Scope
+
+- The guard now targets money-bearing identifiers only.
+- Analytics-only identifiers such as `risk`, `return`, and `weight` are no longer treated as monetary fields by default.
+- Monetary-bearing identifiers such as `amount`, `price`, `market_value`, `cash_balance`, `fee_amount`, and `notional` remain blocked unless explicitly allowlisted or annotated for temporary review.

--- a/scripts/check_monetary_float_usage.py
+++ b/scripts/check_monetary_float_usage.py
@@ -4,22 +4,27 @@ import re
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-KEYWORDS = (
+MONETARY_KEYWORD_COMPONENTS = {
     "amount",
-    "price",
-    "rate",
-    "value",
-    "market_value",
+    "aum",
+    "balance",
+    "cash",
     "cost",
-    "pnl",
-    "return",
-    "risk",
+    "fee",
+    "fees",
+    "market",
+    "money",
+    "nav",
     "notional",
-    "weight",
-)
+    "pnl",
+    "price",
+    "principal",
+    "value",
+}
 IGNORE_DIRS = {"tests", ".venv", "venv", "docs", "rfcs", "output", "build", "dist", "__pycache__"}
 
 FLOAT_ANNOTATION = re.compile(r"\bfloat\b")
+IDENTIFIER_PATTERN = re.compile(r"\b[a-zA-Z_][a-zA-Z0-9_]*\b")
 
 
 def is_candidate(path: Path) -> bool:
@@ -27,6 +32,14 @@ def is_candidate(path: Path) -> bool:
     if any(p in parts for p in IGNORE_DIRS):
         return False
     return path.suffix == ".py"
+
+
+def has_monetary_identifier(line: str) -> bool:
+    for identifier in IDENTIFIER_PATTERN.findall(line.lower()):
+        components = {component for component in identifier.split("_") if component}
+        if MONETARY_KEYWORD_COMPONENTS.intersection(components):
+            return True
+    return False
 
 
 def scan_repo(repo_root: Path) -> list[str]:
@@ -37,7 +50,7 @@ def scan_repo(repo_root: Path) -> list[str]:
         rel = file_path.relative_to(repo_root).as_posix()
         for line_no, line in enumerate(file_path.read_text(encoding="utf-8").splitlines(), start=1):
             lowered = line.lower()
-            if not any(k in lowered for k in KEYWORDS):
+            if not has_monetary_identifier(lowered):
                 continue
             if not FLOAT_ANNOTATION.search(lowered):
                 continue

--- a/tests/unit/test_check_monetary_float_usage.py
+++ b/tests/unit/test_check_monetary_float_usage.py
@@ -52,3 +52,48 @@ def test_scan_repo_ignores_tests_and_explicit_allow_comments(tmp_path: Path) -> 
     findings = check_monetary_float_usage.scan_repo(tmp_path)
 
     assert findings == ["src/app/engine.py:2:unauthorized_amount: float"]
+
+
+def test_scan_repo_ignores_non_monetary_analytics_float_annotations(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "app"
+    src_dir.mkdir(parents=True)
+
+    (src_dir / "analytics.py").write_text(
+        "\n".join(
+            [
+                "rolling_risk: float",
+                "benchmark_return: float",
+                "position_weight: float",
+                "active_exposure: float",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = check_monetary_float_usage.scan_repo(tmp_path)
+
+    assert findings == []
+
+
+def test_scan_repo_flags_money_bearing_snake_case_identifiers(tmp_path: Path) -> None:
+    src_dir = tmp_path / "src" / "app"
+    src_dir.mkdir(parents=True)
+
+    (src_dir / "portfolio.py").write_text(
+        "\n".join(
+            [
+                "portfolio_market_value: float",
+                "cash_balance: float",
+                "booking_fee_amount: float",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    findings = check_monetary_float_usage.scan_repo(tmp_path)
+
+    assert findings == [
+        "src/app/portfolio.py:1:portfolio_market_value: float",
+        "src/app/portfolio.py:2:cash_balance: float",
+        "src/app/portfolio.py:3:booking_fee_amount: float",
+    ]


### PR DESCRIPTION
## Summary
- scope the monetary-float guard to money-bearing identifiers so analytics math is not incorrectly flagged
- keep `risk`, `return`, and `weight` analytics identifiers out of monetary governance unless money-bearing
- preserve the RFC-0072 explicit lane rollout and repository context work already on the branch

## Validation
- `python -m pytest tests/unit/test_check_monetary_float_usage.py -q`
- `python scripts/check_monetary_float_usage.py`
- `python -m ruff check scripts/check_monetary_float_usage.py tests/unit/test_check_monetary_float_usage.py`
- GitHub checks green: Feature Lane and PR Merge Gate

## Review Notes
- This fixes a real governance false-positive without weakening the monetary-float rule for money-bearing fields.
- Merge remains gated by branch protection and required review.
