### PR TITLE
Sync lotus-core contract clarifications in risk

### DIFF
--- a/docs/domain-apis/RFC-0082-upstream-contract-family-map.md
+++ b/docs/domain-apis/RFC-0082-upstream-contract-family-map.md
@@ -76,6 +76,17 @@ stateful mode is requested.
 6. signed VaR semantics, attribution reconciliation fields, issuer active-risk gating, concentration-only simulation support, and audit lineage metadata remain preserved for downstream consumers;
 7. watchlist routes from `lotus-core` require explicit RFC-0082 review before their semantics are expanded.
 
+Route-specific downstream interpretations that must stay truthful:
+
+1. `POST /integration/reference/risk-free-series` returning an empty `points` list means the core
+   route is reachable but usable source data is absent for the requested currency/window; this must
+   remain a data-availability failure or explicit degradation path, not a silent Sharpe fallback to
+   zero risk-free assumptions;
+2. `POST /integration/indices/catalog` classification labels are source-owned. If canonical
+   benchmark component rows carry governed broad-market sector labels such as
+   `broad_market_equity` or `broad_market_fixed_income`, `lotus-risk` should consume those labels
+   as published and should not infer replacements when labels are absent.
+
 ## Existing Conformance Evidence
 
 Current test and implementation evidence:

--- a/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
+++ b/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
@@ -268,7 +268,7 @@ Minimum response contract:
 
 Required behavior:
 
-1. Records may omit unknown securities, but response shape must remain valid.
+1. Response order must follow request order. Unknown securities must remain present with null enrichment fields rather than being omitted.
 2. `issuer_id` and `issuer_name` must be deterministic for a given `security_id`.
 3. Correlation ID must be propagated end-to-end.
 

--- a/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
+++ b/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
@@ -22,6 +22,12 @@ This is aligned with RFC-0006 and RFC-0067 governance.
 - security classification dimensions
 - benchmark assignment, benchmark composition, and benchmark classification metadata
 
+Downstream interpretation rule:
+
+- benchmark and index classification labels are source-owned by `lotus-core`; if a classification
+  label is absent, downstream services should preserve that absence as a governed coverage gap
+  rather than synthesize local fallback taxonomy.
+
 3. `lotus-risk` only computes risk attribution. It must not reconstruct master data that belongs to `lotus-core` or return series that belongs to `lotus-performance`.
 
 ## Required Upstream Contracts


### PR DESCRIPTION
## Summary
- sync `lotus-risk` docs with the latest certified `lotus-core` contract semantics
- correct the historical-attribution enrichment contract note so unknown securities remain present with null fields rather than being omitted
- keep risk-side upstream guidance aligned with the current core control-plane and enrichment contracts

## Why
`lotus-core` RFC-0082 endpoint certification tightened source-state, enrichment, and analytics-input contract truth. The remaining risk-side drift was documentation: local guidance still implied that enrichment responses could omit unknown securities, which no longer matches the certified core contract.

## Changes
- refresh risk upstream contract guidance
- correct enrichment-bulk semantics in historical-attribution requirements

## Validation
- `python -m pytest tests/unit/test_lotus_core_client.py tests/unit/test_rolling_mode_adapter.py tests/unit/test_benchmark_exposure_history.py -q`

## Upstream follow-on
- aligns downstream issue `#93` with the current `lotus-core` certification and local feature-branch truth