### PR TITLE
RFC-0086: repo-native risk product rollout and raw trust telemetry prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-ci verify-dependencies lint monetary-float-guard no-alias-gate typecheck openapi-gate api-vocabulary-gate migration-smoke migration-apply test test-unit test-integration test-e2e test-pyramid-gate test-coverage coverage-gate security-audit check ci docker-build clean
+.PHONY: install install-ci verify-dependencies lint monetary-float-guard no-alias-gate typecheck openapi-gate api-vocabulary-gate domain-data-product-gate migration-smoke migration-apply test test-unit test-integration test-e2e test-pyramid-gate test-coverage coverage-gate security-audit check ci docker-build clean
 
 install:
 	python -m pip install --upgrade pip
@@ -29,6 +29,9 @@ openapi-gate:
 
 api-vocabulary-gate:
 	python scripts/api_vocabulary_inventory.py --validate-only
+
+domain-data-product-gate:
+	python scripts/domain_data_product_contract_check.py
 
 migration-smoke:
 	python scripts/migration_contract_check.py --mode no-schema
@@ -61,9 +64,9 @@ test-coverage:
 security-audit:
 	python scripts/dependency_health_check.py --skip-outdated
 
-check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate test
+check: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate domain-data-product-gate test
 
-ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate migration-smoke test-pyramid-gate security-audit test-unit test-integration test-e2e test-coverage docker-build
+ci: lint no-alias-gate typecheck openapi-gate api-vocabulary-gate domain-data-product-gate migration-smoke test-pyramid-gate security-audit test-unit test-integration test-e2e test-coverage docker-build
 
 docker-build:
 	docker build -t backend-service:ci-test .

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Key operator-facing endpoints:
 - `/health/ready`
 - `/metadata`
 - `/ops`
+- `/ops/trust-telemetry`
 - `/metrics`
 
 Runtime dependencies that matter:

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Repo-native validation mapping:
 
 - fast local gate: `make check`
 - PR-grade gate: `make ci`
+- repo-native domain product gate: `make domain-data-product-gate`
 - split suites: `make test-unit`, `make test-integration`, `make test-e2e`
 
 The enforced gates currently include:
@@ -149,11 +150,12 @@ The enforced gates currently include:
 3. typecheck,
 4. OpenAPI quality,
 5. API vocabulary validation,
-6. migration smoke,
-7. test-pyramid validation,
-8. security audit,
-9. coverage-backed testing,
-10. Docker build validation.
+6. repo-native domain product declaration validation,
+7. migration smoke,
+8. test-pyramid validation,
+9. security audit,
+10. coverage-backed testing,
+11. Docker build validation.
 
 ## Integration Contract
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -32,7 +32,8 @@ Current repository posture:
 3. the CI contract is explicit and strong, with no-alias, vocabulary, OpenAPI, test-pyramid, security, coverage, and Docker enforcement,
 4. RFC-0008 establishes the current enterprise-readiness baseline: supported risk analytics are credible for the canonical private-banking portfolio, while unrestricted enterprise-bank approval still requires downstream proof and broader seeded portfolio archetype coverage,
 5. current work often involves balancing analytical correctness, contract quality, and front-office usability,
-6. upstream use of `lotus-core` and `lotus-performance` is now documented under the RFC-0082 upstream contract-family map.
+6. upstream use of `lotus-core` and `lotus-performance` is now documented under the RFC-0082 upstream contract-family map,
+7. repo-native RFC-0086 product and consumer declarations now live under `contracts/domain-data-products/` with a local `make domain-data-product-gate` validation path.
 
 ## Architecture And Module Map
 
@@ -40,13 +41,15 @@ Primary areas:
 
 1. `src/`
    risk application and analytics implementation.
-2. `scripts/`
+2. `contracts/`
+   repo-native domain product declarations and related machine-readable contract files.
+3. `scripts/`
    OpenAPI, vocabulary, dependency-health, and test-pyramid governance.
-3. `docs/standards/`
+4. `docs/standards/`
    local standards and contract guidance.
-4. `tests/`
+5. `tests/`
    unit, integration, and e2e validation.
-5. `wiki/`
+6. `wiki/`
    canonical local source pages for repository wiki and onboarding navigation.
 
 ## Runtime And Integration Boundaries
@@ -88,6 +91,8 @@ Use these commands as the primary local contract:
    `make test-integration`
 6. run e2e tests
    `make test-e2e`
+7. validate repo-native domain product declarations
+   `make domain-data-product-gate`
 
 ## Validation And CI Expectations
 
@@ -103,6 +108,7 @@ Important validation expectations:
 2. security audit and migration smoke are required,
 3. split test suites plus coverage and Docker build are part of the merge gate,
 4. risk correctness and evidence posture must remain aligned with the product and gateway contract.
+5. repo-native domain product declarations must stay aligned with RFC-0084 trust registries and any transitional platform mirrors until aggregation fully federates.
 
 ## Standards And RFCs That Govern This Repository
 
@@ -126,7 +132,8 @@ Most relevant current governance:
 5. live validation defaults to `PB_SG_GLOBAL_BAL_001`; do not claim broader enterprise portfolio-archetype coverage until `docs/operations/live-risk-validation-matrix.md` has real seeded portfolio IDs and evidence,
 6. stateful historical attribution `ACTIVE_RISK + ISSUER` is intentionally gated until benchmark issuer exposure semantics are approved,
 7. transport optimization across upstream services should start with contract and retrieval-shape evidence before any gRPC proposal,
-8. `wiki/` inside the repository is the authored documentation source if a GitHub wiki is published later.
+8. `wiki/` inside the repository is the authored documentation source if a GitHub wiki is published later,
+9. RFC-0087 preparation should reuse repo-owned readiness, observability, and lineage signals before introducing any new trust publication surface.
 
 ## Context Maintenance Rule
 
@@ -138,7 +145,8 @@ Update this document when:
 4. supportability, evidence, or decomposition model assumptions change,
 5. current product-facing usage or rollout posture changes,
 6. RFC-0082 upstream contract-family classification or consumer conformance posture changes,
-7. wiki ownership or publication workflow changes.
+7. wiki ownership or publication workflow changes,
+8. repo-native declaration locations, validation commands, or transitional mirror posture change.
 
 ## Cross-Links
 

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -23,5 +23,7 @@ Validation posture:
 Migration posture:
 
 1. the repo-native files in this directory are the intended owning-repo path,
-2. the matching `lotus-platform` declaration files are transitional mirrors for the current rollout
-   wave and should be removed once platform aggregation no longer depends on them.
+2. the matching `lotus-platform` declaration files are explicit transitional mirrors for the
+   current rollout wave,
+3. mirror ownership is temporary only; the platform copies should be removed once platform
+   aggregation no longer depends on them.

--- a/contracts/domain-data-products/README.md
+++ b/contracts/domain-data-products/README.md
@@ -1,0 +1,27 @@
+# Repo-Native Domain Data Product Declarations
+
+This directory is the repo-native declaration home for `lotus-risk` under RFC-0086.
+
+Files in this directory are the local source of truth for:
+
+1. producer declarations published by `lotus-risk`,
+2. consumer declarations that describe governed upstream dependencies consumed by `lotus-risk`.
+
+Current files:
+
+1. `lotus-risk-products.v1.json`
+2. `lotus-risk-consumers.v1.json`
+
+Validation posture:
+
+1. run `make domain-data-product-gate` for the repo-native declaration check,
+2. the local gate validates these files against the platform-owned RFC-0084 registries,
+3. the local gate also compares the repo-native files against the transitional platform copies in
+   `lotus-platform/platform-contracts/domain-data-products/` until the federation migration removes
+   those mirrors.
+
+Migration posture:
+
+1. the repo-native files in this directory are the intended owning-repo path,
+2. the matching `lotus-platform` declaration files are transitional mirrors for the current rollout
+   wave and should be removed once platform aggregation no longer depends on them.

--- a/contracts/domain-data-products/lotus-risk-consumers.v1.json
+++ b/contracts/domain-data-products/lotus-risk-consumers.v1.json
@@ -1,0 +1,131 @@
+{
+  "contract_id": "domain-data-product-consumers",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "consumer_repository": "lotus-risk",
+  "dependencies": [
+    {
+      "product_name": "ReturnsSeriesBundle",
+      "producer_repository": "lotus-performance",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Source performance-aligned portfolio and benchmark return observations for stateful risk, drawdown, rolling, and attribution workflows.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "BenchmarkExposureContext",
+      "producer_repository": "lotus-performance",
+      "required_product_version": "v1",
+      "consumption_mode": "paged_api_read",
+      "business_purpose": "Source performance-aligned benchmark exposure rows for approved stateful active-risk attribution workflows.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_to_partial",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "PortfolioStateSnapshot",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Resolve governed portfolio state for concentration stateful and simulation flows.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "PositionTimeseriesInput",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Source historical position exposure rows for stateful historical risk attribution.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "as_of_date",
+        "reconciliation_status",
+        "data_quality_status",
+        "correlation_id"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "InstrumentReferenceBundle",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "paged_api_read",
+      "business_purpose": "Resolve governed instrument, issuer, and classification reference context for concentration and attribution outputs.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "fail_closed",
+      "required_trust_metadata": [
+        "generated_at",
+        "data_quality_status",
+        "latest_evidence_timestamp"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    },
+    {
+      "product_name": "RiskFreeSeriesWindow",
+      "producer_repository": "lotus-core",
+      "required_product_version": "v1",
+      "consumption_mode": "api_read",
+      "business_purpose": "Source governed risk-free series context when rolling Sharpe requires explicit upstream risk-free treatment.",
+      "validation_lanes": [
+        "feature",
+        "pr-merge"
+      ],
+      "failure_posture": "degrade_to_partial",
+      "required_trust_metadata": [
+        "generated_at",
+        "data_quality_status",
+        "latest_evidence_timestamp"
+      ],
+      "migration_posture": {
+        "status": "current"
+      }
+    }
+  ]
+}

--- a/contracts/domain-data-products/lotus-risk-products.v1.json
+++ b/contracts/domain-data-products/lotus-risk-products.v1.json
@@ -1,0 +1,293 @@
+{
+  "contract_id": "domain-data-products",
+  "contract_version": "1.0.0",
+  "governed_by_rfc": "RFC-0084",
+  "producer_repository": "lotus-risk",
+  "authoritative_domain": "risk_analytics",
+  "products": [
+    {
+      "product_name": "RiskMetricsReport",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "benchmark_context",
+        "risk_free_context"
+      ],
+      "current_routes": [
+        "/analytics/risk/calculate"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Risk metrics must reflect the requested as-of date and the resolved upstream return series used for the calculation."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": false
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "DrawdownAnalyticsReport",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "benchmark_context"
+      ],
+      "current_routes": [
+        "/analytics/risk/drawdown"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Drawdown analytics must remain tied to the resolved return path and benchmark policy used for the requested as-of date."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": false
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "RollingRiskMetricsReport",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "benchmark_context",
+        "risk_free_context"
+      ],
+      "current_routes": [
+        "/analytics/risk/rolling-metrics"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Rolling risk metrics must stay aligned to the requested return window and explicit risk-free treatment."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "HistoricalRiskAttributionReport",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "benchmark_context"
+      ],
+      "current_routes": [
+        "/analytics/risk/historical-attribution"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Historical attribution must stay aligned to the requested as-of date, upstream return series, exposure history, and benchmark context."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "benchmark_id",
+        "position_id",
+        "instrument_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "ConcentrationRiskReport",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "coverage_ratio",
+        "coverage_status"
+      ],
+      "current_routes": [
+        "/analytics/risk/concentration"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Concentration analytics must reflect the resolved current or simulated portfolio state for the requested as-of date."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": false
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id",
+        "position_id",
+        "instrument_id",
+        "issuer_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    }
+  ]
+}

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-15T14:09:49.407822+00:00",
+  "generatedAt": "2026-04-19T05:13:25.970324+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.alignment_policy",
@@ -83,11 +83,41 @@
       ]
     },
     {
+      "semanticId": "lotus.approved_consumers",
+      "canonicalTerm": "approved_consumers",
+      "preferredName": "approved_consumers",
+      "description": "Consumers explicitly approved in the repo-native producer declaration.",
+      "example": [
+        "lotus-gateway"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.as_of_date",
       "canonicalTerm": "as_of_date",
       "preferredName": "as_of_date",
       "description": "As-of date used for risk metric evaluation.",
       "example": "2025-03-31",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.authoritative_domain",
+      "canonicalTerm": "authoritative_domain",
+      "preferredName": "authoritative_domain",
+      "description": "Authoritative domain declared for the product.",
+      "example": "risk_analytics",
       "type": "string",
       "locations": [
         "body"
@@ -185,6 +215,48 @@
       ],
       "observedTypes": [
         "OpsChecks"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumer_declaration_fingerprint",
+      "canonicalTerm": "consumer_declaration_fingerprint",
+      "preferredName": "consumer_declaration_fingerprint",
+      "description": "Deterministic fingerprint of the repo-native consumer declaration payload.",
+      "example": "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumer_declaration_source",
+      "canonicalTerm": "consumer_declaration_source",
+      "preferredName": "consumer_declaration_source",
+      "description": "Repo-native consumer declaration file used to resolve declared upstream dependencies.",
+      "example": "contracts/domain-data-products/lotus-risk-consumers.v1.json",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.consumption_mode",
+      "canonicalTerm": "consumption_mode",
+      "preferredName": "consumption_mode",
+      "description": "Declared consumption mode for the upstream dependency.",
+      "example": "api_read",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -286,6 +358,143 @@
       ]
     },
     {
+      "semanticId": "lotus.current_routes",
+      "canonicalTerm": "current_routes",
+      "preferredName": "current_routes",
+      "description": "Current API routes declared as publishing or serving this product.",
+      "example": [
+        "/analytics/risk/calculate"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.declaration_fingerprint",
+      "canonicalTerm": "declaration_fingerprint",
+      "preferredName": "declaration_fingerprint",
+      "description": "Deterministic fingerprint of the repo-native producer declaration payload.",
+      "example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.declaration_source",
+      "canonicalTerm": "declaration_source",
+      "preferredName": "declaration_source",
+      "description": "Repo-native producer declaration file used to resolve the declared products.",
+      "example": "contracts/domain-data-products/lotus-risk-products.v1.json",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.declared_dependencies",
+      "canonicalTerm": "declared_dependencies",
+      "preferredName": "declared_dependencies",
+      "description": "Current repo-native declared upstream dependencies required by lotus-risk.",
+      "example": [
+        {
+          "consumption_mode": "api_read",
+          "failure_posture": "fail_closed",
+          "producer_repository": "lotus-performance",
+          "product_name": "ReturnsSeriesBundle",
+          "required_product_version": "v1",
+          "required_trust_metadata": [
+            "generated_at",
+            "as_of_date",
+            "correlation_id"
+          ],
+          "runtime_category": "transport",
+          "runtime_detail": "high_latency",
+          "runtime_issue_code": "UPSTREAM_HIGH_LATENCY",
+          "runtime_status": "degraded",
+          "validation_lanes": [
+            "feature",
+            "pr-merge"
+          ]
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.declared_dependency_count",
+      "canonicalTerm": "declared_dependency_count",
+      "preferredName": "declared_dependency_count",
+      "description": "Number of repo-native declared upstream dependencies included in the snapshot.",
+      "example": 6,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.declared_product_count",
+      "canonicalTerm": "declared_product_count",
+      "preferredName": "declared_product_count",
+      "description": "Number of repo-native declared producer products included in the snapshot.",
+      "example": 5,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.degraded_dependency_count",
+      "canonicalTerm": "degraded_dependency_count",
+      "preferredName": "degraded_dependency_count",
+      "description": "Count of declared upstream dependencies whose producer runtime status is degraded.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.degraded_dependency_products",
+      "canonicalTerm": "degraded_dependency_products",
+      "preferredName": "degraded_dependency_products",
+      "description": "Declared upstream product names currently backed by degraded producer services.",
+      "example": [
+        "ReturnsSeriesBundle"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.dependencies",
       "canonicalTerm": "dependencies",
       "preferredName": "dependencies",
@@ -296,6 +505,28 @@
           "detail": "configured",
           "service": "lotus-performance",
           "status": "ok"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.dependency_signals",
+      "canonicalTerm": "dependency_signals",
+      "preferredName": "dependency_signals",
+      "description": "Dependency runtime evidence used as raw trust telemetry input.",
+      "example": [
+        {
+          "category": "transport",
+          "detail": "high_latency",
+          "issue_code": "UPSTREAM_HIGH_LATENCY",
+          "service": "lotus-performance",
+          "status": "degraded"
         }
       ],
       "type": "array",
@@ -349,6 +580,20 @@
       ]
     },
     {
+      "semanticId": "lotus.emitted_at",
+      "canonicalTerm": "emitted_at",
+      "preferredName": "emitted_at",
+      "description": "UTC timestamp when lotus-risk assembled the local trust telemetry seed.",
+      "example": "2026-04-19T00:00:00Z",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.enabled",
       "canonicalTerm": "enabled",
       "preferredName": "enabled",
@@ -388,6 +633,20 @@
       ],
       "observedTypes": [
         "EnrichmentPolicy"
+      ]
+    },
+    {
+      "semanticId": "lotus.failure_posture",
+      "canonicalTerm": "failure_posture",
+      "preferredName": "failure_posture",
+      "description": "Declared failure posture when the upstream dependency is unavailable or weak.",
+      "example": "fail_closed",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -645,16 +904,31 @@
       ]
     },
     {
-      "semanticId": "lotus.lineage_version",
-      "canonicalTerm": "lineage_version",
-      "preferredName": "lineage_version",
-      "description": "Audit lineage metadata schema version.",
-      "example": "risk_audit_lineage.v1",
+      "semanticId": "lotus.lifecycle_status",
+      "canonicalTerm": "lifecycle_status",
+      "preferredName": "lifecycle_status",
+      "description": "Repo-owned lifecycle status mirrored from the governed product declaration.",
+      "example": "active",
       "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.lineage_version",
+      "canonicalTerm": "lineage_version",
+      "preferredName": "lineage_version",
+      "description": "Audit lineage schema version carried by the product response when available.",
+      "example": "risk_audit_lineage.v1",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
         "string"
       ]
     },
@@ -764,6 +1038,34 @@
       ]
     },
     {
+      "semanticId": "lotus.missing_runtime_service_count",
+      "canonicalTerm": "missing_runtime_service_count",
+      "preferredName": "missing_runtime_service_count",
+      "description": "Count of declared upstream dependencies whose producer service has no current runtime view.",
+      "example": 0,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.missing_runtime_services",
+      "canonicalTerm": "missing_runtime_services",
+      "preferredName": "missing_runtime_services",
+      "description": "Declared upstream producer services that currently have no runtime view.",
+      "example": [],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.net_or_gross",
       "canonicalTerm": "net_or_gross",
       "preferredName": "net_or_gross",
@@ -809,6 +1111,20 @@
       ]
     },
     {
+      "semanticId": "lotus.ops_status",
+      "canonicalTerm": "ops_status",
+      "preferredName": "ops_status",
+      "description": "Current service operations posture used as raw input for future certification.",
+      "example": "ok",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.periodic_rate",
       "canonicalTerm": "periodic_rate",
       "preferredName": "periodic_rate",
@@ -828,6 +1144,133 @@
       "preferredName": "policy_version",
       "description": "Capabilities policy version used by this service.",
       "example": "risk.v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.producer_repository",
+      "canonicalTerm": "producer_repository",
+      "preferredName": "producer_repository",
+      "description": "Owning repository for the required upstream product.",
+      "example": "lotus-performance",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_family",
+      "canonicalTerm": "product_family",
+      "preferredName": "product_family",
+      "description": "Declared product family used to classify the product for governance.",
+      "example": "analytics_output",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_name",
+      "canonicalTerm": "product_name",
+      "preferredName": "product_name",
+      "description": "Governed upstream product required by lotus-risk.",
+      "example": "ReturnsSeriesBundle",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.product_version",
+      "canonicalTerm": "product_version",
+      "preferredName": "product_version",
+      "description": "Governed product version emitted by lotus-risk.",
+      "example": "v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.products",
+      "canonicalTerm": "products",
+      "preferredName": "products",
+      "description": "Current raw telemetry seeds for each repo-native declared product.",
+      "example": [
+        {
+          "approved_consumers": [
+            "lotus-gateway"
+          ],
+          "authoritative_domain": "risk_analytics",
+          "current_routes": [
+            "/analytics/risk/calculate"
+          ],
+          "dependency_signals": [
+            {
+              "category": "transport",
+              "detail": "high_latency",
+              "issue_code": "UPSTREAM_HIGH_LATENCY",
+              "service": "lotus-performance",
+              "status": "degraded"
+            }
+          ],
+          "draining": false,
+          "emitted_at": "2026-04-19T00:00:00Z",
+          "lifecycle_status": "active",
+          "lineage_version": "risk_audit_lineage.v1",
+          "ops_status": "degraded",
+          "product_family": "analytics_output",
+          "product_name": "RiskMetricsReport",
+          "product_version": "v1",
+          "readiness_status": "degraded",
+          "request_fingerprint": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c",
+          "required_trust_metadata": [
+            "product_name",
+            "product_version",
+            "as_of_date",
+            "lineage_version",
+            "request_fingerprint"
+          ],
+          "source_services": [
+            "lotus-risk",
+            "lotus-performance"
+          ],
+          "upstream_request_fingerprints": {
+            "lotus-performance:/integration/returns/series": "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1"
+          }
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.readiness_status",
+      "canonicalTerm": "readiness_status",
+      "preferredName": "readiness_status",
+      "description": "Current service readiness posture used as raw input for future certification.",
+      "example": "ready",
       "type": "string",
       "locations": [
         "body"
@@ -882,7 +1325,7 @@
       "semanticId": "lotus.request_fingerprint",
       "canonicalTerm": "request_fingerprint",
       "preferredName": "request_fingerprint",
-      "description": "Deterministic SHA-256 fingerprint of the normalized calculation request used by lotus-risk. Stateful flows fingerprint the calculation input after upstream sourcing.",
+      "description": "Current product request fingerprint when response lineage is available.",
       "example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c",
       "type": "object",
       "locations": [
@@ -948,6 +1391,38 @@
       "example": [
         "VOLATILITY",
         "TRACKING_ERROR"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.required_product_version",
+      "canonicalTerm": "required_product_version",
+      "preferredName": "required_product_version",
+      "description": "Governed upstream product version required by lotus-risk.",
+      "example": "v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.required_trust_metadata",
+      "canonicalTerm": "required_trust_metadata",
+      "preferredName": "required_trust_metadata",
+      "description": "Trust metadata required from the upstream product declaration.",
+      "example": [
+        "generated_at",
+        "as_of_date",
+        "correlation_id"
       ],
       "type": "array",
       "locations": [
@@ -1050,6 +1525,62 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.runtime_category",
+      "canonicalTerm": "runtime_category",
+      "preferredName": "runtime_category",
+      "description": "Current structured runtime issue category for the declared upstream producer service.",
+      "example": "transport",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.runtime_detail",
+      "canonicalTerm": "runtime_detail",
+      "preferredName": "runtime_detail",
+      "description": "Current runtime detail observed for the declared upstream producer service.",
+      "example": "high_latency",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.runtime_issue_code",
+      "canonicalTerm": "runtime_issue_code",
+      "preferredName": "runtime_issue_code",
+      "description": "Current machine-readable runtime issue code for the declared upstream producer service.",
+      "example": "UPSTREAM_HIGH_LATENCY",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.runtime_status",
+      "canonicalTerm": "runtime_status",
+      "preferredName": "runtime_status",
+      "description": "Current runtime status observed for the declared upstream producer service.",
+      "example": "degraded",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -1170,7 +1701,7 @@
       "semanticId": "lotus.source_services",
       "canonicalTerm": "source_services",
       "preferredName": "source_services",
-      "description": "Services whose data or calculations contributed to this response.",
+      "description": "Ordered source-service lineage already published by lotus-risk.",
       "example": [
         "lotus-risk",
         "lotus-performance"
@@ -1321,6 +1852,22 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.summary",
+      "canonicalTerm": "summary",
+      "preferredName": "summary",
+      "description": "Canonical summary used by lotus-risk APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "TrustTelemetryReviewSummary",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "TrustTelemetryReviewSummary"
       ]
     },
     {
@@ -1602,6 +2149,34 @@
       ]
     },
     {
+      "semanticId": "lotus.unavailable_dependency_count",
+      "canonicalTerm": "unavailable_dependency_count",
+      "preferredName": "unavailable_dependency_count",
+      "description": "Count of declared upstream dependencies whose producer runtime status is unavailable.",
+      "example": 0,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.unavailable_dependency_products",
+      "canonicalTerm": "unavailable_dependency_products",
+      "preferredName": "unavailable_dependency_products",
+      "description": "Declared upstream product names currently backed by unavailable producer services.",
+      "example": [],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.uncovered_position_count_current",
       "canonicalTerm": "uncovered_position_count_current",
       "preferredName": "uncovered_position_count_current",
@@ -1633,7 +2208,7 @@
       "semanticId": "lotus.upstream_request_fingerprints",
       "canonicalTerm": "upstream_request_fingerprints",
       "preferredName": "upstream_request_fingerprints",
-      "description": "Deterministic request fingerprints for upstream calls directly orchestrated by lotus-risk, keyed by service and operation.",
+      "description": "Upstream request fingerprints already published by lotus-risk.",
       "example": {
         "lotus-performance:/integration/returns/series": "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1"
       },
@@ -1657,6 +2232,23 @@
       ],
       "observedTypes": [
         "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.validation_lanes",
+      "canonicalTerm": "validation_lanes",
+      "preferredName": "validation_lanes",
+      "description": "Validation lanes in which this dependency is expected to be checked.",
+      "example": [
+        "feature",
+        "pr-merge"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -2118,6 +2710,412 @@
           },
           {
             "name": "dependencies[].issue_code",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.issue_code",
+            "attributeRef": "#/attributeCatalog/lotus.issue_code"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "operational",
+      "method": "GET",
+      "path": "/ops/trust-telemetry",
+      "operationId": "ops_trust_telemetry_ops_trust_telemetry_get",
+      "summary": "Local trust telemetry snapshot",
+      "request": {
+        "fields": []
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.service",
+            "attributeRef": "#/attributeCatalog/lotus.service"
+          },
+          {
+            "name": "declaration_source",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.declaration_source",
+            "attributeRef": "#/attributeCatalog/lotus.declaration_source"
+          },
+          {
+            "name": "declaration_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.declaration_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.declaration_fingerprint"
+          },
+          {
+            "name": "consumer_declaration_source",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_declaration_source",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_declaration_source"
+          },
+          {
+            "name": "consumer_declaration_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumer_declaration_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.consumer_declaration_fingerprint"
+          },
+          {
+            "name": "declared_dependencies",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.declared_dependencies",
+            "attributeRef": "#/attributeCatalog/lotus.declared_dependencies"
+          },
+          {
+            "name": "declared_dependencies[].product_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "declared_dependencies[].producer_repository",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.producer_repository",
+            "attributeRef": "#/attributeCatalog/lotus.producer_repository"
+          },
+          {
+            "name": "declared_dependencies[].required_product_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.required_product_version",
+            "attributeRef": "#/attributeCatalog/lotus.required_product_version"
+          },
+          {
+            "name": "declared_dependencies[].consumption_mode",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.consumption_mode",
+            "attributeRef": "#/attributeCatalog/lotus.consumption_mode"
+          },
+          {
+            "name": "declared_dependencies[].failure_posture",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.failure_posture",
+            "attributeRef": "#/attributeCatalog/lotus.failure_posture"
+          },
+          {
+            "name": "declared_dependencies[].validation_lanes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.validation_lanes",
+            "attributeRef": "#/attributeCatalog/lotus.validation_lanes"
+          },
+          {
+            "name": "declared_dependencies[].required_trust_metadata",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.required_trust_metadata",
+            "attributeRef": "#/attributeCatalog/lotus.required_trust_metadata"
+          },
+          {
+            "name": "declared_dependencies[].runtime_status",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.runtime_status",
+            "attributeRef": "#/attributeCatalog/lotus.runtime_status"
+          },
+          {
+            "name": "declared_dependencies[].runtime_detail",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.runtime_detail",
+            "attributeRef": "#/attributeCatalog/lotus.runtime_detail"
+          },
+          {
+            "name": "declared_dependencies[].runtime_category",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.runtime_category",
+            "attributeRef": "#/attributeCatalog/lotus.runtime_category"
+          },
+          {
+            "name": "declared_dependencies[].runtime_issue_code",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.runtime_issue_code",
+            "attributeRef": "#/attributeCatalog/lotus.runtime_issue_code"
+          },
+          {
+            "name": "summary",
+            "location": "body",
+            "required": true,
+            "type": "TrustTelemetryReviewSummary",
+            "semanticId": "lotus.summary",
+            "attributeRef": "#/attributeCatalog/lotus.summary"
+          },
+          {
+            "name": "summary.declared_product_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.declared_product_count",
+            "attributeRef": "#/attributeCatalog/lotus.declared_product_count"
+          },
+          {
+            "name": "summary.declared_dependency_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.declared_dependency_count",
+            "attributeRef": "#/attributeCatalog/lotus.declared_dependency_count"
+          },
+          {
+            "name": "summary.degraded_dependency_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.degraded_dependency_count",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_dependency_count"
+          },
+          {
+            "name": "summary.unavailable_dependency_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.unavailable_dependency_count",
+            "attributeRef": "#/attributeCatalog/lotus.unavailable_dependency_count"
+          },
+          {
+            "name": "summary.missing_runtime_service_count",
+            "location": "body",
+            "required": true,
+            "type": "integer",
+            "semanticId": "lotus.missing_runtime_service_count",
+            "attributeRef": "#/attributeCatalog/lotus.missing_runtime_service_count"
+          },
+          {
+            "name": "summary.degraded_dependency_products",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.degraded_dependency_products",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_dependency_products"
+          },
+          {
+            "name": "summary.unavailable_dependency_products",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.unavailable_dependency_products",
+            "attributeRef": "#/attributeCatalog/lotus.unavailable_dependency_products"
+          },
+          {
+            "name": "summary.missing_runtime_services",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.missing_runtime_services",
+            "attributeRef": "#/attributeCatalog/lotus.missing_runtime_services"
+          },
+          {
+            "name": "products",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.products",
+            "attributeRef": "#/attributeCatalog/lotus.products"
+          },
+          {
+            "name": "products[].product_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "products[].product_version",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_version",
+            "attributeRef": "#/attributeCatalog/lotus.product_version"
+          },
+          {
+            "name": "products[].authoritative_domain",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.authoritative_domain",
+            "attributeRef": "#/attributeCatalog/lotus.authoritative_domain"
+          },
+          {
+            "name": "products[].product_family",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.product_family",
+            "attributeRef": "#/attributeCatalog/lotus.product_family"
+          },
+          {
+            "name": "products[].approved_consumers",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.approved_consumers",
+            "attributeRef": "#/attributeCatalog/lotus.approved_consumers"
+          },
+          {
+            "name": "products[].required_trust_metadata",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.required_trust_metadata",
+            "attributeRef": "#/attributeCatalog/lotus.required_trust_metadata"
+          },
+          {
+            "name": "products[].lifecycle_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.lifecycle_status",
+            "attributeRef": "#/attributeCatalog/lotus.lifecycle_status"
+          },
+          {
+            "name": "products[].current_routes",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.current_routes",
+            "attributeRef": "#/attributeCatalog/lotus.current_routes"
+          },
+          {
+            "name": "products[].emitted_at",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.emitted_at",
+            "attributeRef": "#/attributeCatalog/lotus.emitted_at"
+          },
+          {
+            "name": "products[].readiness_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.readiness_status",
+            "attributeRef": "#/attributeCatalog/lotus.readiness_status"
+          },
+          {
+            "name": "products[].ops_status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.ops_status",
+            "attributeRef": "#/attributeCatalog/lotus.ops_status"
+          },
+          {
+            "name": "products[].draining",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.draining",
+            "attributeRef": "#/attributeCatalog/lotus.draining"
+          },
+          {
+            "name": "products[].lineage_version",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.lineage_version",
+            "attributeRef": "#/attributeCatalog/lotus.lineage_version"
+          },
+          {
+            "name": "products[].request_fingerprint",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
+            "name": "products[].source_services",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.source_services",
+            "attributeRef": "#/attributeCatalog/lotus.source_services"
+          },
+          {
+            "name": "products[].upstream_request_fingerprints",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.upstream_request_fingerprints",
+            "attributeRef": "#/attributeCatalog/lotus.upstream_request_fingerprints"
+          },
+          {
+            "name": "products[].dependency_signals",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.dependency_signals",
+            "attributeRef": "#/attributeCatalog/lotus.dependency_signals"
+          },
+          {
+            "name": "products[].dependency_signals[].service",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.service",
+            "attributeRef": "#/attributeCatalog/lotus.service"
+          },
+          {
+            "name": "products[].dependency_signals[].status",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.status",
+            "attributeRef": "#/attributeCatalog/lotus.status"
+          },
+          {
+            "name": "products[].dependency_signals[].detail",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.detail",
+            "attributeRef": "#/attributeCatalog/lotus.detail"
+          },
+          {
+            "name": "products[].dependency_signals[].category",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.category",
+            "attributeRef": "#/attributeCatalog/lotus.category"
+          },
+          {
+            "name": "products[].dependency_signals[].issue_code",
             "location": "body",
             "required": false,
             "type": "object",

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -36,8 +36,14 @@ The platform files:
 1. `lotus-platform/platform-contracts/domain-data-products/lotus-risk-products.v1.json`
 2. `lotus-platform/platform-contracts/domain-data-products/lotus-risk-consumers.v1.json`
 
-remain transitional copies for this rollout wave. They are not the intended long-term ownership
-path.
+remain explicit transitional mirrors for this rollout wave.
+
+Ownership status is therefore:
+
+1. `lotus-risk` owns the repo-native files in `contracts/domain-data-products/`,
+2. `lotus-platform` holds mirror copies only until federation aggregation no longer depends on
+   them,
+3. the mirror state is temporary and must not be treated as long-term declaration ownership.
 
 ## RFC-0087 Preparation Seam
 

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -89,6 +89,11 @@ producer service. That keeps the operator snapshot useful for review because dec
 posture and live producer-health posture can be compared in one place without implying any platform
 certification semantics.
 
+The snapshot now also carries an operator review summary with declared product and dependency counts,
+degraded and unavailable dependency counts, and the affected declared dependency product names. That
+keeps review fast without changing the underlying raw declaration-backed evidence carried in the
+same snapshot.
+
 ## Current Open Decisions
 
 1. whether platform aggregation should discover repo-native files directly from this path or through

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -64,9 +64,10 @@ The current in-repo preparation seam is `src/app/trust_telemetry.py`, backed by
 sources and resolves product lifecycle from the repo-native declaration catalog without introducing
 platform certification rules or a new publication contract yet.
 
-The current raw exposure path is `GET /ops/trust-telemetry`, which returns a repo-owned snapshot of
-those seeds for operator review only. It remains a preparation seam until RFC-0087 introduces
-certified trust artifacts.
+The current operator-facing inspection path for that seam is `GET /ops/trust-telemetry`. It is a
+repo-local raw telemetry snapshot that returns repo-owned seeds for operator review only and must
+not be treated as a platform-certified trust artifact until RFC-0087 introduces certified trust
+artifacts.
 
 ## Current Open Decisions
 

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -64,6 +64,10 @@ The current in-repo preparation seam is `src/app/trust_telemetry.py`, backed by
 sources and resolves product lifecycle from the repo-native declaration catalog without introducing
 platform certification rules or a new publication contract yet.
 
+The current raw exposure path is `GET /ops/trust-telemetry`, which returns a repo-owned snapshot of
+those seeds for operator review only. It remains a preparation seam until RFC-0087 introduces
+certified trust artifacts.
+
 ## Current Open Decisions
 
 1. whether platform aggregation should discover repo-native files directly from this path or through

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -59,6 +59,10 @@ That is the narrowest additive path into RFC-0087 because it reuses current doma
 and lineage evidence instead of inventing a second trust status layer inside the request handlers or
 moving product truth into `lotus-gateway`.
 
+The current in-repo preparation seam is `src/app/trust_telemetry.py`, which assembles a
+repo-local telemetry seed from those existing sources without introducing platform certification
+rules or a new publication contract yet.
+
 ## Current Open Decisions
 
 1. whether platform aggregation should discover repo-native files directly from this path or through

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -84,6 +84,11 @@ fingerprint, and declared upstream dependency set. That lets reviewers inspect p
 consumer dependency truth, and raw runtime dependency posture in one place while RFC-0087 is still
 at the preparation stage.
 
+Each declared upstream dependency now also carries the current runtime status observed for its
+producer service. That keeps the operator snapshot useful for review because declared dependency
+posture and live producer-health posture can be compared in one place without implying any platform
+certification semantics.
+
 ## Current Open Decisions
 
 1. whether platform aggregation should discover repo-native files directly from this path or through

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -59,9 +59,10 @@ That is the narrowest additive path into RFC-0087 because it reuses current doma
 and lineage evidence instead of inventing a second trust status layer inside the request handlers or
 moving product truth into `lotus-gateway`.
 
-The current in-repo preparation seam is `src/app/trust_telemetry.py`, which assembles a
-repo-local telemetry seed from those existing sources without introducing platform certification
-rules or a new publication contract yet.
+The current in-repo preparation seam is `src/app/trust_telemetry.py`, backed by
+`src/app/domain_data_products.py`, which assembles a repo-local telemetry seed from those existing
+sources and resolves product lifecycle from the repo-native declaration catalog without introducing
+platform certification rules or a new publication contract yet.
 
 ## Current Open Decisions
 

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -1,0 +1,62 @@
+# Repo-Native Domain Data Products
+
+This document records the `lotus-risk` repo-native declaration and validation posture introduced for
+RFC-0086.
+
+## Declaration Location
+
+The governed in-repo declaration location for `lotus-risk` is:
+
+1. `contracts/domain-data-products/lotus-risk-products.v1.json`
+2. `contracts/domain-data-products/lotus-risk-consumers.v1.json`
+
+This location keeps machine-readable producer and consumer truth in the authoritative domain
+repository instead of in `lotus-platform`.
+
+## Repo-Native Validation Path
+
+Use:
+
+```powershell
+make domain-data-product-gate
+```
+
+That target runs `scripts/domain_data_product_contract_check.py`, which:
+
+1. validates the repo-native declarations against the platform-owned RFC-0084 validator logic,
+2. loads the platform semantics and trust registries as the governed vocabulary source,
+3. cross-checks local consumer dependencies against the currently declared upstream producer files,
+4. compares the repo-native files against the transitional platform mirrors to keep additive
+   migration truthful.
+
+## Transitional Copy Policy
+
+The platform files:
+
+1. `lotus-platform/platform-contracts/domain-data-products/lotus-risk-products.v1.json`
+2. `lotus-platform/platform-contracts/domain-data-products/lotus-risk-consumers.v1.json`
+
+remain transitional copies for this rollout wave. They are not the intended long-term ownership
+path.
+
+## RFC-0087 Preparation Seam
+
+The minimal future telemetry emission seam for `lotus-risk` should be built from existing repo-local
+truth rather than new gateway logic:
+
+1. service and dependency runtime state from `src/app/ops_runtime.py`,
+2. product execution and dependency call signals from `src/app/observability.py`,
+3. product lineage fields already emitted in response metadata through
+   `request_fingerprint`, `source_services`, and `upstream_request_fingerprints`.
+
+That is the narrowest additive path into RFC-0087 because it reuses current domain-owned runtime
+and lineage evidence instead of inventing a second trust status layer inside the request handlers or
+moving product truth into `lotus-gateway`.
+
+## Current Open Decisions
+
+1. whether platform aggregation should discover repo-native files directly from this path or through
+   a later manifest-driven inventory,
+2. when the transitional platform mirrors can be removed safely,
+3. whether future trust telemetry should publish one repo-level artifact per product family or one
+   per request-capable route family.

--- a/docs/standards/repo-native-domain-data-products.md
+++ b/docs/standards/repo-native-domain-data-products.md
@@ -69,6 +69,21 @@ repo-local raw telemetry snapshot that returns repo-owned seeds for operator rev
 not be treated as a platform-certified trust artifact until RFC-0087 introduces certified trust
 artifacts.
 
+Each raw seed now carries the declaration-derived `authoritative_domain`, `product_family`, and
+`current_routes` fields in addition to runtime and lineage evidence so operator review can connect
+the raw trust posture back to the governing repo-native declaration without cross-referencing the
+JSON files manually.
+
+The snapshot itself now carries a deterministic declaration fingerprint, and each product seed
+includes the declaration-governed `approved_consumers` and `required_trust_metadata` fields. That
+lets operator review compare observed runtime posture against the declaration-backed trust contract
+without introducing a platform certification plane inside this repo.
+
+The same operator snapshot now also carries the repo-native consumer declaration source,
+fingerprint, and declared upstream dependency set. That lets reviewers inspect producer truth,
+consumer dependency truth, and raw runtime dependency posture in one place while RFC-0087 is still
+at the preparation stage.
+
 ## Current Open Decisions
 
 1. whether platform aggregation should discover repo-native files directly from this path or through

--- a/scripts/domain_data_product_contract_check.py
+++ b/scripts/domain_data_product_contract_check.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOCAL_DECLARATIONS_DIR = REPO_ROOT / "contracts" / "domain-data-products"
+PLATFORM_ROOT = REPO_ROOT.parent / "lotus-platform"
+PLATFORM_DECLARATIONS_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-data-products"
+PLATFORM_VOCABULARY_DIR = PLATFORM_ROOT / "platform-contracts" / "domain-vocabulary"
+PLATFORM_VALIDATOR_PATH = PLATFORM_DECLARATIONS_DIR / "validate_domain_data_product_contracts.py"
+LOCAL_PRODUCER_PATH = LOCAL_DECLARATIONS_DIR / "lotus-risk-products.v1.json"
+LOCAL_CONSUMER_PATH = LOCAL_DECLARATIONS_DIR / "lotus-risk-consumers.v1.json"
+TRANSITIONAL_PLATFORM_MIRRORS = (
+    ("producer", LOCAL_PRODUCER_PATH, PLATFORM_DECLARATIONS_DIR / "lotus-risk-products.v1.json"),
+    ("consumer", LOCAL_CONSUMER_PATH, PLATFORM_DECLARATIONS_DIR / "lotus-risk-consumers.v1.json"),
+)
+SUPPLEMENTAL_PLATFORM_PRODUCERS = (
+    PLATFORM_DECLARATIONS_DIR / "lotus-core-products.v1.json",
+    PLATFORM_DECLARATIONS_DIR / "lotus-performance-products.v1.json",
+)
+
+
+def _load_platform_validator() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("lotus_platform_domain_data_products_validator", PLATFORM_VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load platform validator from {PLATFORM_VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _append_issue(issues: list[str], path: Path, message: str) -> None:
+    issues.append(f"{path}: {message}")
+
+
+def _load_registry_keys(semantics_payload: dict, trust_payload: dict) -> dict[str, set[str]]:
+    return {
+        "identifier_keys": {
+            entry.get("key", "")
+            for entry in semantics_payload.get("identifiers", [])
+            if isinstance(entry, dict)
+        },
+        "temporal_keys": {
+            entry.get("key", "")
+            for entry in semantics_payload.get("temporal_semantics", [])
+            if isinstance(entry, dict)
+        },
+        "freshness_classes": {
+            entry.get("key", "")
+            for entry in semantics_payload.get("trust_vocabularies", {}).get("freshness_classes", [])
+            if isinstance(entry, dict)
+        },
+        "completeness_statuses": {
+            entry.get("key", "")
+            for entry in semantics_payload.get("trust_vocabularies", {}).get("completeness_statuses", [])
+            if isinstance(entry, dict)
+        },
+        "trust_metadata_keys": {
+            entry.get("key", "")
+            for entry in trust_payload.get("trust_metadata_fields", [])
+            if isinstance(entry, dict)
+        },
+        "evidence_access_classes": {
+            entry.get("key", "")
+            for entry in trust_payload.get("evidence_access_classes", [])
+            if isinstance(entry, dict)
+        },
+        "lineage_bundle_class_keys": {
+            entry.get("key", "")
+            for entry in trust_payload.get("lineage_bundle_classes", [])
+            if isinstance(entry, dict)
+        },
+    }
+
+
+def validate_repo_native_contracts() -> list[str]:
+    validator = _load_platform_validator()
+    issues: list[str] = []
+
+    semantics_path = PLATFORM_VOCABULARY_DIR / "domain-data-product-semantics.v1.json"
+    trust_path = PLATFORM_VOCABULARY_DIR / "domain-data-product-trust-metadata.v1.json"
+    semantics_payload = _load_json(semantics_path)
+    trust_payload = _load_json(trust_path)
+
+    issues.extend(validator.validate_semantics_registry(semantics_path, semantics_payload))
+    issues.extend(validator.validate_trust_metadata_registry(trust_path, trust_payload))
+    registry_keys = _load_registry_keys(semantics_payload, trust_payload)
+
+    local_producer_payload = _load_json(LOCAL_PRODUCER_PATH)
+    local_consumer_payload = _load_json(LOCAL_CONSUMER_PATH)
+
+    issues.extend(
+        validator.validate_producer_contract(
+            LOCAL_PRODUCER_PATH,
+            local_producer_payload,
+            identifier_keys=registry_keys["identifier_keys"],
+            temporal_keys=registry_keys["temporal_keys"],
+            freshness_classes=registry_keys["freshness_classes"],
+            completeness_statuses=registry_keys["completeness_statuses"],
+            trust_metadata_keys=registry_keys["trust_metadata_keys"],
+            evidence_access_classes=registry_keys["evidence_access_classes"],
+            lineage_bundle_class_keys=registry_keys["lineage_bundle_class_keys"],
+        )
+    )
+    issues.extend(
+        validator.validate_consumer_contract_with_context(
+            LOCAL_CONSUMER_PATH,
+            local_consumer_payload,
+            trust_metadata_keys=registry_keys["trust_metadata_keys"],
+        )
+    )
+
+    producer_payloads: list[tuple[Path, dict]] = [(LOCAL_PRODUCER_PATH, local_producer_payload)]
+    for supplemental_path in SUPPLEMENTAL_PLATFORM_PRODUCERS:
+        producer_payloads.append((supplemental_path, _load_json(supplemental_path)))
+    issues.extend(validator.validate_cross_references(producer_payloads, [(LOCAL_CONSUMER_PATH, local_consumer_payload)]))
+
+    for mirror_kind, local_path, platform_path in TRANSITIONAL_PLATFORM_MIRRORS:
+        local_payload = _load_json(local_path)
+        platform_payload = _load_json(platform_path)
+        if local_payload != platform_payload:
+            _append_issue(
+                issues,
+                local_path,
+                f"repo-native {mirror_kind} declaration drifted from transitional platform mirror {platform_path}",
+            )
+
+    return issues
+
+
+def main() -> int:
+    issues = validate_repo_native_contracts()
+    if issues:
+        for issue in issues:
+            print(issue)
+        return 1
+
+    print(
+        "Validated lotus-risk repo-native domain data product declarations against platform registries, "
+        "cross-references, and transitional mirrors."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/domain_data_product_contract_check.py
+++ b/scripts/domain_data_product_contract_check.py
@@ -5,6 +5,7 @@ import json
 import sys
 from pathlib import Path
 from types import ModuleType
+from typing import Any, cast
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -26,7 +27,9 @@ SUPPLEMENTAL_PLATFORM_PRODUCERS = (
 
 
 def _load_platform_validator() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("lotus_platform_domain_data_products_validator", PLATFORM_VALIDATOR_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "lotus_platform_domain_data_products_validator", PLATFORM_VALIDATOR_PATH
+    )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load platform validator from {PLATFORM_VALIDATOR_PATH}")
     module = importlib.util.module_from_spec(spec)
@@ -34,15 +37,18 @@ def _load_platform_validator() -> ModuleType:
     return module
 
 
-def _load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+def _load_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
 
 
 def _append_issue(issues: list[str], path: Path, message: str) -> None:
     issues.append(f"{path}: {message}")
 
 
-def _load_registry_keys(semantics_payload: dict, trust_payload: dict) -> dict[str, set[str]]:
+def _load_registry_keys(
+    semantics_payload: dict[str, Any],
+    trust_payload: dict[str, Any],
+) -> dict[str, set[str]]:
     return {
         "identifier_keys": {
             entry.get("key", "")
@@ -56,12 +62,16 @@ def _load_registry_keys(semantics_payload: dict, trust_payload: dict) -> dict[st
         },
         "freshness_classes": {
             entry.get("key", "")
-            for entry in semantics_payload.get("trust_vocabularies", {}).get("freshness_classes", [])
+            for entry in semantics_payload.get("trust_vocabularies", {}).get(
+                "freshness_classes", []
+            )
             if isinstance(entry, dict)
         },
         "completeness_statuses": {
             entry.get("key", "")
-            for entry in semantics_payload.get("trust_vocabularies", {}).get("completeness_statuses", [])
+            for entry in semantics_payload.get("trust_vocabularies", {}).get(
+                "completeness_statuses", []
+            )
             if isinstance(entry, dict)
         },
         "trust_metadata_keys": {
@@ -119,10 +129,16 @@ def validate_repo_native_contracts() -> list[str]:
         )
     )
 
-    producer_payloads: list[tuple[Path, dict]] = [(LOCAL_PRODUCER_PATH, local_producer_payload)]
+    producer_payloads: list[tuple[Path, dict[str, Any]]] = [
+        (LOCAL_PRODUCER_PATH, local_producer_payload)
+    ]
     for supplemental_path in SUPPLEMENTAL_PLATFORM_PRODUCERS:
         producer_payloads.append((supplemental_path, _load_json(supplemental_path)))
-    issues.extend(validator.validate_cross_references(producer_payloads, [(LOCAL_CONSUMER_PATH, local_consumer_payload)]))
+    issues.extend(
+        validator.validate_cross_references(
+            producer_payloads, [(LOCAL_CONSUMER_PATH, local_consumer_payload)]
+        )
+    )
 
     for mirror_kind, local_path, platform_path in TRANSITIONAL_PLATFORM_MIRRORS:
         local_payload = _load_json(local_path)

--- a/scripts/domain_data_product_contract_check.py
+++ b/scripts/domain_data_product_contract_check.py
@@ -26,6 +26,18 @@ SUPPLEMENTAL_PLATFORM_PRODUCERS = (
 )
 
 
+def platform_validation_dependencies_available() -> bool:
+    required_paths = (
+        PLATFORM_VALIDATOR_PATH,
+        PLATFORM_DECLARATIONS_DIR / "lotus-risk-products.v1.json",
+        PLATFORM_DECLARATIONS_DIR / "lotus-risk-consumers.v1.json",
+        PLATFORM_VOCABULARY_DIR / "domain-data-product-semantics.v1.json",
+        PLATFORM_VOCABULARY_DIR / "domain-data-product-trust-metadata.v1.json",
+        *SUPPLEMENTAL_PLATFORM_PRODUCERS,
+    )
+    return all(path.exists() for path in required_paths)
+
+
 def _load_platform_validator() -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         "lotus_platform_domain_data_products_validator", PLATFORM_VALIDATOR_PATH

--- a/src/app/domain_data_products.py
+++ b/src/app/domain_data_products.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_PRODUCER_DECLARATION_PATH = (
+    REPO_ROOT / "contracts" / "domain-data-products" / "lotus-risk-products.v1.json"
+)
+
+
+@lru_cache(maxsize=1)
+def load_local_producer_declaration() -> dict[str, Any]:
+    return json.loads(LOCAL_PRODUCER_DECLARATION_PATH.read_text(encoding="utf-8"))
+
+
+def list_declared_products() -> list[dict[str, Any]]:
+    payload = load_local_producer_declaration()
+    products = payload.get("products", [])
+    return [product for product in products if isinstance(product, dict)]
+
+
+def get_declared_product(*, product_name: str, product_version: str) -> dict[str, Any]:
+    for product in list_declared_products():
+        if (
+            product.get("product_name") == product_name
+            and product.get("product_version") == product_version
+        ):
+            return product
+    raise ValueError(
+        f"Unknown lotus-risk declared product {product_name} {product_version} in "
+        f"{LOCAL_PRODUCER_DECLARATION_PATH}"
+    )

--- a/src/app/domain_data_products.py
+++ b/src/app/domain_data_products.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from functools import lru_cache
 from pathlib import Path
@@ -10,7 +11,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LOCAL_PRODUCER_DECLARATION_PATH = (
     REPO_ROOT / "contracts" / "domain-data-products" / "lotus-risk-products.v1.json"
 )
+LOCAL_CONSUMER_DECLARATION_PATH = (
+    REPO_ROOT / "contracts" / "domain-data-products" / "lotus-risk-consumers.v1.json"
+)
 REPO_RELATIVE_PRODUCER_DECLARATION_PATH = LOCAL_PRODUCER_DECLARATION_PATH.relative_to(REPO_ROOT)
+REPO_RELATIVE_CONSUMER_DECLARATION_PATH = LOCAL_CONSUMER_DECLARATION_PATH.relative_to(REPO_ROOT)
 
 
 @lru_cache(maxsize=1)
@@ -18,10 +23,33 @@ def load_local_producer_declaration() -> dict[str, Any]:
     return json.loads(LOCAL_PRODUCER_DECLARATION_PATH.read_text(encoding="utf-8"))
 
 
+@lru_cache(maxsize=1)
+def load_local_consumer_declaration() -> dict[str, Any]:
+    return json.loads(LOCAL_CONSUMER_DECLARATION_PATH.read_text(encoding="utf-8"))
+
+
 def list_declared_products() -> list[dict[str, Any]]:
     payload = load_local_producer_declaration()
     products = payload.get("products", [])
     return [product for product in products if isinstance(product, dict)]
+
+
+def get_local_producer_declaration_fingerprint() -> str:
+    payload = load_local_producer_declaration()
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def list_declared_dependencies() -> list[dict[str, Any]]:
+    payload = load_local_consumer_declaration()
+    dependencies = payload.get("dependencies", [])
+    return [dependency for dependency in dependencies if isinstance(dependency, dict)]
+
+
+def get_local_consumer_declaration_fingerprint() -> str:
+    payload = load_local_consumer_declaration()
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(serialized.encode("utf-8")).hexdigest()
 
 
 def get_declared_product(*, product_name: str, product_version: str) -> dict[str, Any]:

--- a/src/app/domain_data_products.py
+++ b/src/app/domain_data_products.py
@@ -10,6 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 LOCAL_PRODUCER_DECLARATION_PATH = (
     REPO_ROOT / "contracts" / "domain-data-products" / "lotus-risk-products.v1.json"
 )
+REPO_RELATIVE_PRODUCER_DECLARATION_PATH = LOCAL_PRODUCER_DECLARATION_PATH.relative_to(REPO_ROOT)
 
 
 @lru_cache(maxsize=1)

--- a/src/app/domain_data_products.py
+++ b/src/app/domain_data_products.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -20,12 +20,18 @@ REPO_RELATIVE_CONSUMER_DECLARATION_PATH = LOCAL_CONSUMER_DECLARATION_PATH.relati
 
 @lru_cache(maxsize=1)
 def load_local_producer_declaration() -> dict[str, Any]:
-    return json.loads(LOCAL_PRODUCER_DECLARATION_PATH.read_text(encoding="utf-8"))
+    return cast(
+        dict[str, Any],
+        json.loads(LOCAL_PRODUCER_DECLARATION_PATH.read_text(encoding="utf-8")),
+    )
 
 
 @lru_cache(maxsize=1)
 def load_local_consumer_declaration() -> dict[str, Any]:
-    return json.loads(LOCAL_CONSUMER_DECLARATION_PATH.read_text(encoding="utf-8"))
+    return cast(
+        dict[str, Any],
+        json.loads(LOCAL_CONSUMER_DECLARATION_PATH.read_text(encoding="utf-8")),
+    )
 
 
 def list_declared_products() -> list[dict[str, Any]]:

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -53,6 +53,10 @@ from app.services.rolling_engine import calculate_rolling_metrics
 from app.services.rolling_mode_adapter import calculate_rolling_metrics_stateful
 from app.services.risk_engine import calculate_risk
 from app.services.risk_mode_adapter import calculate_risk_stateful
+from app.trust_telemetry import (
+    DeclaredProductTrustTelemetrySnapshot,
+    build_declared_product_trust_telemetry_snapshot,
+)
 from app.upstream_errors import UpstreamServiceError
 
 SERVICE_NAME = "lotus-risk"
@@ -489,6 +493,25 @@ async def ops() -> OpsResponse:
             )
             for dependency in dependencies
         ],
+    )
+
+
+@app.get(
+    "/ops/trust-telemetry",
+    response_model=DeclaredProductTrustTelemetrySnapshot,
+    summary="Local trust telemetry snapshot",
+    description=(
+        "Returns the current repo-owned raw trust telemetry seeds for each repo-native declared "
+        "lotus-risk product. This is an operator-facing preparation seam for RFC-0087 and is not "
+        "a platform-certified trust contract."
+    ),
+    tags=["operational"],
+    responses=STANDARD_ERROR_RESPONSES,
+)
+async def ops_trust_telemetry() -> DeclaredProductTrustTelemetrySnapshot:
+    return build_declared_product_trust_telemetry_snapshot(
+        app=app,
+        service_name=SERVICE_NAME,
     )
 
 

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -8,8 +8,12 @@ from pydantic import BaseModel, Field
 
 from app.contracts.audit import AuditMetadataFields
 from app.domain_data_products import (
+    REPO_RELATIVE_CONSUMER_DECLARATION_PATH,
     REPO_RELATIVE_PRODUCER_DECLARATION_PATH,
     get_declared_product,
+    get_local_consumer_declaration_fingerprint,
+    get_local_producer_declaration_fingerprint,
+    list_declared_dependencies,
     list_declared_products,
 )
 from app.ops_runtime import resolve_ops_status, resolve_readiness_status
@@ -52,9 +56,32 @@ class ProductTrustTelemetrySeed(BaseModel):
         description="Governed product version emitted by lotus-risk.",
         json_schema_extra={"example": "v1"},
     )
+    authoritative_domain: str = Field(
+        description="Authoritative domain declared for the product.",
+        json_schema_extra={"example": "risk_analytics"},
+    )
+    product_family: str = Field(
+        description="Declared product family used to classify the product for governance.",
+        json_schema_extra={"example": "analytics_output"},
+    )
+    approved_consumers: list[str] = Field(
+        default_factory=list,
+        description="Consumers explicitly approved in the repo-native producer declaration.",
+        json_schema_extra={"example": ["lotus-gateway"]},
+    )
+    required_trust_metadata: list[str] = Field(
+        default_factory=list,
+        description="Trust metadata fields the repo-native declaration requires for the product.",
+        json_schema_extra={"example": ["product_name", "product_version", "as_of_date"]},
+    )
     lifecycle_status: TelemetryLifecycleStatus = Field(
         description="Repo-owned lifecycle status mirrored from the governed product declaration.",
         json_schema_extra={"example": "active"},
+    )
+    current_routes: list[str] = Field(
+        default_factory=list,
+        description="Current API routes declared as publishing or serving this product.",
+        json_schema_extra={"example": ["/analytics/risk/calculate"]},
     )
     emitted_at: str = Field(
         description="UTC timestamp when lotus-risk assembled the local trust telemetry seed.",
@@ -104,6 +131,39 @@ class ProductTrustTelemetrySeed(BaseModel):
     )
 
 
+class DeclaredConsumerDependencyTelemetry(BaseModel):
+    product_name: str = Field(
+        description="Governed upstream product required by lotus-risk.",
+        json_schema_extra={"example": "ReturnsSeriesBundle"},
+    )
+    producer_repository: str = Field(
+        description="Owning repository for the required upstream product.",
+        json_schema_extra={"example": "lotus-performance"},
+    )
+    required_product_version: str = Field(
+        description="Governed upstream product version required by lotus-risk.",
+        json_schema_extra={"example": "v1"},
+    )
+    consumption_mode: str = Field(
+        description="Declared consumption mode for the upstream dependency.",
+        json_schema_extra={"example": "api_read"},
+    )
+    failure_posture: str = Field(
+        description="Declared failure posture when the upstream dependency is unavailable or weak.",
+        json_schema_extra={"example": "fail_closed"},
+    )
+    validation_lanes: list[str] = Field(
+        default_factory=list,
+        description="Validation lanes in which this dependency is expected to be checked.",
+        json_schema_extra={"example": ["feature", "pr-merge"]},
+    )
+    required_trust_metadata: list[str] = Field(
+        default_factory=list,
+        description="Trust metadata required from the upstream product declaration.",
+        json_schema_extra={"example": ["generated_at", "as_of_date", "correlation_id"]},
+    )
+
+
 class DeclaredProductTrustTelemetrySnapshot(BaseModel):
     service: str = Field(
         description="Service identifier publishing the local trust telemetry snapshot.",
@@ -114,6 +174,27 @@ class DeclaredProductTrustTelemetrySnapshot(BaseModel):
         json_schema_extra={
             "example": "contracts/domain-data-products/lotus-risk-products.v1.json"
         },
+    )
+    declaration_fingerprint: str = Field(
+        description="Deterministic fingerprint of the repo-native producer declaration payload.",
+        json_schema_extra={
+            "example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c"
+        },
+    )
+    consumer_declaration_source: str = Field(
+        description="Repo-native consumer declaration file used to resolve declared upstream dependencies.",
+        json_schema_extra={
+            "example": "contracts/domain-data-products/lotus-risk-consumers.v1.json"
+        },
+    )
+    consumer_declaration_fingerprint: str = Field(
+        description="Deterministic fingerprint of the repo-native consumer declaration payload.",
+        json_schema_extra={
+            "example": "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1"
+        },
+    )
+    declared_dependencies: list[DeclaredConsumerDependencyTelemetry] = Field(
+        description="Current repo-native declared upstream dependencies required by lotus-risk.",
     )
     products: list[ProductTrustTelemetrySeed] = Field(
         description="Current raw telemetry seeds for each repo-native declared product.",
@@ -141,7 +222,12 @@ def build_product_trust_telemetry_seed(
     return ProductTrustTelemetrySeed(
         product_name=product_name,
         product_version=product_version,
+        authoritative_domain=declared_product["authoritative_domain"],
+        product_family=declared_product["product_family"],
+        approved_consumers=list(declared_product.get("approved_consumers", [])),
+        required_trust_metadata=list(declared_product.get("required_trust_metadata", [])),
         lifecycle_status=declared_product["lifecycle_status"],
+        current_routes=list(declared_product.get("current_routes", [])),
         emitted_at=_utc_now(),
         readiness_status=readiness_status,
         ops_status=ops_status,
@@ -173,6 +259,21 @@ def build_declared_product_trust_telemetry_snapshot(
     return DeclaredProductTrustTelemetrySnapshot(
         service=service_name,
         declaration_source=REPO_RELATIVE_PRODUCER_DECLARATION_PATH.as_posix(),
+        declaration_fingerprint=get_local_producer_declaration_fingerprint(),
+        consumer_declaration_source=REPO_RELATIVE_CONSUMER_DECLARATION_PATH.as_posix(),
+        consumer_declaration_fingerprint=get_local_consumer_declaration_fingerprint(),
+        declared_dependencies=[
+            DeclaredConsumerDependencyTelemetry(
+                product_name=dependency["product_name"],
+                producer_repository=dependency["producer_repository"],
+                required_product_version=dependency["required_product_version"],
+                consumption_mode=dependency["consumption_mode"],
+                failure_posture=dependency["failure_posture"],
+                validation_lanes=list(dependency.get("validation_lanes", [])),
+                required_trust_metadata=list(dependency.get("required_trust_metadata", [])),
+            )
+            for dependency in list_declared_dependencies()
+        ],
         products=[
             build_product_trust_telemetry_seed(
                 app=app,

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -162,6 +162,26 @@ class DeclaredConsumerDependencyTelemetry(BaseModel):
         description="Trust metadata required from the upstream product declaration.",
         json_schema_extra={"example": ["generated_at", "as_of_date", "correlation_id"]},
     )
+    runtime_status: str | None = Field(
+        default=None,
+        description="Current runtime status observed for the declared upstream producer service.",
+        json_schema_extra={"example": "degraded"},
+    )
+    runtime_detail: str | None = Field(
+        default=None,
+        description="Current runtime detail observed for the declared upstream producer service.",
+        json_schema_extra={"example": "high_latency"},
+    )
+    runtime_category: str | None = Field(
+        default=None,
+        description="Current structured runtime issue category for the declared upstream producer service.",
+        json_schema_extra={"example": "transport"},
+    )
+    runtime_issue_code: str | None = Field(
+        default=None,
+        description="Current machine-readable runtime issue code for the declared upstream producer service.",
+        json_schema_extra={"example": "UPSTREAM_HIGH_LATENCY"},
+    )
 
 
 class DeclaredProductTrustTelemetrySnapshot(BaseModel):
@@ -256,6 +276,9 @@ def build_declared_product_trust_telemetry_snapshot(
     app: FastAPI,
     service_name: str,
 ) -> DeclaredProductTrustTelemetrySnapshot:
+    _readiness_status_code, _readiness_status, dependencies = resolve_readiness_status(app)
+    dependency_index = {dependency.service: dependency for dependency in dependencies}
+
     return DeclaredProductTrustTelemetrySnapshot(
         service=service_name,
         declaration_source=REPO_RELATIVE_PRODUCER_DECLARATION_PATH.as_posix(),
@@ -271,6 +294,18 @@ def build_declared_product_trust_telemetry_snapshot(
                 failure_posture=dependency["failure_posture"],
                 validation_lanes=list(dependency.get("validation_lanes", [])),
                 required_trust_metadata=list(dependency.get("required_trust_metadata", [])),
+                runtime_status=dependency_index[dependency["producer_repository"]].status
+                if dependency["producer_repository"] in dependency_index
+                else None,
+                runtime_detail=dependency_index[dependency["producer_repository"]].detail
+                if dependency["producer_repository"] in dependency_index
+                else None,
+                runtime_category=dependency_index[dependency["producer_repository"]].category
+                if dependency["producer_repository"] in dependency_index
+                else None,
+                runtime_issue_code=dependency_index[dependency["producer_repository"]].issue_code
+                if dependency["producer_repository"] in dependency_index
+                else None,
             )
             for dependency in list_declared_dependencies()
         ],

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -107,7 +107,9 @@ class ProductTrustTelemetrySeed(BaseModel):
     request_fingerprint: str | None = Field(
         default=None,
         description="Current product request fingerprint when response lineage is available.",
-        json_schema_extra={"example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c"},
+        json_schema_extra={
+            "example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c"
+        },
     )
     source_services: list[str] = Field(
         default_factory=list,
@@ -128,6 +130,17 @@ class ProductTrustTelemetrySeed(BaseModel):
     dependency_signals: list[DependencyTelemetrySignal] = Field(
         default_factory=list,
         description="Dependency runtime evidence used as raw trust telemetry input.",
+        json_schema_extra={
+            "example": [
+                {
+                    "service": "lotus-performance",
+                    "status": "degraded",
+                    "detail": "high_latency",
+                    "category": "transport",
+                    "issue_code": "UPSTREAM_HIGH_LATENCY",
+                }
+            ]
+        },
     )
 
 
@@ -184,6 +197,44 @@ class DeclaredConsumerDependencyTelemetry(BaseModel):
     )
 
 
+class TrustTelemetryReviewSummary(BaseModel):
+    declared_product_count: int = Field(
+        description="Number of repo-native declared producer products included in the snapshot.",
+        json_schema_extra={"example": 5},
+    )
+    declared_dependency_count: int = Field(
+        description="Number of repo-native declared upstream dependencies included in the snapshot.",
+        json_schema_extra={"example": 6},
+    )
+    degraded_dependency_count: int = Field(
+        description="Count of declared upstream dependencies whose producer runtime status is degraded.",
+        json_schema_extra={"example": 1},
+    )
+    unavailable_dependency_count: int = Field(
+        description="Count of declared upstream dependencies whose producer runtime status is unavailable.",
+        json_schema_extra={"example": 0},
+    )
+    missing_runtime_service_count: int = Field(
+        description="Count of declared upstream dependencies whose producer service has no current runtime view.",
+        json_schema_extra={"example": 0},
+    )
+    degraded_dependency_products: list[str] = Field(
+        default_factory=list,
+        description="Declared upstream product names currently backed by degraded producer services.",
+        json_schema_extra={"example": ["ReturnsSeriesBundle"]},
+    )
+    unavailable_dependency_products: list[str] = Field(
+        default_factory=list,
+        description="Declared upstream product names currently backed by unavailable producer services.",
+        json_schema_extra={"example": []},
+    )
+    missing_runtime_services: list[str] = Field(
+        default_factory=list,
+        description="Declared upstream producer services that currently have no runtime view.",
+        json_schema_extra={"example": []},
+    )
+
+
 class DeclaredProductTrustTelemetrySnapshot(BaseModel):
     service: str = Field(
         description="Service identifier publishing the local trust telemetry snapshot.",
@@ -191,9 +242,7 @@ class DeclaredProductTrustTelemetrySnapshot(BaseModel):
     )
     declaration_source: str = Field(
         description="Repo-native producer declaration file used to resolve the declared products.",
-        json_schema_extra={
-            "example": "contracts/domain-data-products/lotus-risk-products.v1.json"
-        },
+        json_schema_extra={"example": "contracts/domain-data-products/lotus-risk-products.v1.json"},
     )
     declaration_fingerprint: str = Field(
         description="Deterministic fingerprint of the repo-native producer declaration payload.",
@@ -215,9 +264,87 @@ class DeclaredProductTrustTelemetrySnapshot(BaseModel):
     )
     declared_dependencies: list[DeclaredConsumerDependencyTelemetry] = Field(
         description="Current repo-native declared upstream dependencies required by lotus-risk.",
+        json_schema_extra={
+            "example": [
+                {
+                    "product_name": "ReturnsSeriesBundle",
+                    "producer_repository": "lotus-performance",
+                    "required_product_version": "v1",
+                    "consumption_mode": "api_read",
+                    "failure_posture": "fail_closed",
+                    "validation_lanes": ["feature", "pr-merge"],
+                    "required_trust_metadata": [
+                        "generated_at",
+                        "as_of_date",
+                        "correlation_id",
+                    ],
+                    "runtime_status": "degraded",
+                    "runtime_detail": "high_latency",
+                    "runtime_category": "transport",
+                    "runtime_issue_code": "UPSTREAM_HIGH_LATENCY",
+                }
+            ]
+        },
+    )
+    summary: TrustTelemetryReviewSummary = Field(
+        description="Operator-facing rollup of declaration counts and current runtime dependency posture.",
+        json_schema_extra={
+            "example": {
+                "declared_product_count": 5,
+                "declared_dependency_count": 6,
+                "degraded_dependency_count": 2,
+                "unavailable_dependency_count": 0,
+                "missing_runtime_service_count": 0,
+                "degraded_dependency_products": [
+                    "ReturnsSeriesBundle",
+                    "BenchmarkExposureContext",
+                ],
+                "unavailable_dependency_products": [],
+                "missing_runtime_services": [],
+            }
+        },
     )
     products: list[ProductTrustTelemetrySeed] = Field(
         description="Current raw telemetry seeds for each repo-native declared product.",
+        json_schema_extra={
+            "example": [
+                {
+                    "product_name": "RiskMetricsReport",
+                    "product_version": "v1",
+                    "authoritative_domain": "risk_analytics",
+                    "product_family": "analytics_output",
+                    "approved_consumers": ["lotus-gateway"],
+                    "required_trust_metadata": [
+                        "product_name",
+                        "product_version",
+                        "as_of_date",
+                        "lineage_version",
+                        "request_fingerprint",
+                    ],
+                    "lifecycle_status": "active",
+                    "current_routes": ["/analytics/risk/calculate"],
+                    "emitted_at": "2026-04-19T00:00:00Z",
+                    "readiness_status": "degraded",
+                    "ops_status": "degraded",
+                    "draining": False,
+                    "lineage_version": "risk_audit_lineage.v1",
+                    "request_fingerprint": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c",
+                    "source_services": ["lotus-risk", "lotus-performance"],
+                    "upstream_request_fingerprints": {
+                        "lotus-performance:/integration/returns/series": "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1"
+                    },
+                    "dependency_signals": [
+                        {
+                            "service": "lotus-performance",
+                            "status": "degraded",
+                            "detail": "high_latency",
+                            "category": "transport",
+                            "issue_code": "UPSTREAM_HIGH_LATENCY",
+                        }
+                    ],
+                }
+            ]
+        },
     )
 
 
@@ -278,6 +405,55 @@ def build_declared_product_trust_telemetry_snapshot(
 ) -> DeclaredProductTrustTelemetrySnapshot:
     _readiness_status_code, _readiness_status, dependencies = resolve_readiness_status(app)
     dependency_index = {dependency.service: dependency for dependency in dependencies}
+    declared_dependencies = [
+        DeclaredConsumerDependencyTelemetry(
+            product_name=dependency["product_name"],
+            producer_repository=dependency["producer_repository"],
+            required_product_version=dependency["required_product_version"],
+            consumption_mode=dependency["consumption_mode"],
+            failure_posture=dependency["failure_posture"],
+            validation_lanes=list(dependency.get("validation_lanes", [])),
+            required_trust_metadata=list(dependency.get("required_trust_metadata", [])),
+            runtime_status=dependency_index[dependency["producer_repository"]].status
+            if dependency["producer_repository"] in dependency_index
+            else None,
+            runtime_detail=dependency_index[dependency["producer_repository"]].detail
+            if dependency["producer_repository"] in dependency_index
+            else None,
+            runtime_category=dependency_index[dependency["producer_repository"]].category
+            if dependency["producer_repository"] in dependency_index
+            else None,
+            runtime_issue_code=dependency_index[dependency["producer_repository"]].issue_code
+            if dependency["producer_repository"] in dependency_index
+            else None,
+        )
+        for dependency in list_declared_dependencies()
+    ]
+    products = [
+        build_product_trust_telemetry_seed(
+            app=app,
+            product_name=product["product_name"],
+            product_version=product["product_version"],
+        )
+        for product in list_declared_products()
+    ]
+    degraded_dependency_products = [
+        dependency.product_name
+        for dependency in declared_dependencies
+        if dependency.runtime_status == "degraded"
+    ]
+    unavailable_dependency_products = [
+        dependency.product_name
+        for dependency in declared_dependencies
+        if dependency.runtime_status == "unavailable"
+    ]
+    missing_runtime_services = sorted(
+        {
+            dependency.producer_repository
+            for dependency in declared_dependencies
+            if dependency.runtime_status is None
+        }
+    )
 
     return DeclaredProductTrustTelemetrySnapshot(
         service=service_name,
@@ -285,36 +461,16 @@ def build_declared_product_trust_telemetry_snapshot(
         declaration_fingerprint=get_local_producer_declaration_fingerprint(),
         consumer_declaration_source=REPO_RELATIVE_CONSUMER_DECLARATION_PATH.as_posix(),
         consumer_declaration_fingerprint=get_local_consumer_declaration_fingerprint(),
-        declared_dependencies=[
-            DeclaredConsumerDependencyTelemetry(
-                product_name=dependency["product_name"],
-                producer_repository=dependency["producer_repository"],
-                required_product_version=dependency["required_product_version"],
-                consumption_mode=dependency["consumption_mode"],
-                failure_posture=dependency["failure_posture"],
-                validation_lanes=list(dependency.get("validation_lanes", [])),
-                required_trust_metadata=list(dependency.get("required_trust_metadata", [])),
-                runtime_status=dependency_index[dependency["producer_repository"]].status
-                if dependency["producer_repository"] in dependency_index
-                else None,
-                runtime_detail=dependency_index[dependency["producer_repository"]].detail
-                if dependency["producer_repository"] in dependency_index
-                else None,
-                runtime_category=dependency_index[dependency["producer_repository"]].category
-                if dependency["producer_repository"] in dependency_index
-                else None,
-                runtime_issue_code=dependency_index[dependency["producer_repository"]].issue_code
-                if dependency["producer_repository"] in dependency_index
-                else None,
-            )
-            for dependency in list_declared_dependencies()
-        ],
-        products=[
-            build_product_trust_telemetry_seed(
-                app=app,
-                product_name=product["product_name"],
-                product_version=product["product_version"],
-            )
-            for product in list_declared_products()
-        ],
+        declared_dependencies=declared_dependencies,
+        summary=TrustTelemetryReviewSummary(
+            declared_product_count=len(products),
+            declared_dependency_count=len(declared_dependencies),
+            degraded_dependency_count=len(degraded_dependency_products),
+            unavailable_dependency_count=len(unavailable_dependency_products),
+            missing_runtime_service_count=len(missing_runtime_services),
+            degraded_dependency_products=degraded_dependency_products,
+            unavailable_dependency_products=unavailable_dependency_products,
+            missing_runtime_services=missing_runtime_services,
+        ),
+        products=products,
     )

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from app.contracts.audit import AuditMetadataFields
+from app.ops_runtime import resolve_ops_status, resolve_readiness_status
+
+TelemetryLifecycleStatus = Literal["active", "deprecated", "retired"]
+
+
+class DependencyTelemetrySignal(BaseModel):
+    service: str = Field(
+        description="Dependency service identifier contributing runtime trust evidence.",
+        json_schema_extra={"example": "lotus-performance"},
+    )
+    status: str = Field(
+        description="Current dependency runtime state observed by lotus-risk.",
+        json_schema_extra={"example": "ok"},
+    )
+    detail: str | None = Field(
+        default=None,
+        description="Optional operator-facing runtime detail from the dependency view.",
+        json_schema_extra={"example": "configured"},
+    )
+    category: str | None = Field(
+        default=None,
+        description="Optional structured runtime issue category carried by the dependency view.",
+        json_schema_extra={"example": "data_gap"},
+    )
+    issue_code: str | None = Field(
+        default=None,
+        description="Optional machine-readable dependency issue code.",
+        json_schema_extra={"example": "RISK_FREE_SERIES_EMPTY"},
+    )
+
+
+class ProductTrustTelemetrySeed(BaseModel):
+    product_name: str = Field(
+        description="Governed product identifier emitted by lotus-risk.",
+        json_schema_extra={"example": "RiskMetricsReport"},
+    )
+    product_version: str = Field(
+        description="Governed product version emitted by lotus-risk.",
+        json_schema_extra={"example": "v1"},
+    )
+    lifecycle_status: TelemetryLifecycleStatus = Field(
+        description="Repo-owned lifecycle status mirrored from the governed product declaration.",
+        json_schema_extra={"example": "active"},
+    )
+    emitted_at: str = Field(
+        description="UTC timestamp when lotus-risk assembled the local trust telemetry seed.",
+        json_schema_extra={"example": "2026-04-19T00:00:00Z"},
+    )
+    readiness_status: str = Field(
+        description="Current service readiness posture used as raw input for future certification.",
+        json_schema_extra={"example": "ready"},
+    )
+    ops_status: str = Field(
+        description="Current service operations posture used as raw input for future certification.",
+        json_schema_extra={"example": "ok"},
+    )
+    draining: bool = Field(
+        description="Whether lotus-risk was draining when the telemetry seed was built.",
+        json_schema_extra={"example": False},
+    )
+    lineage_version: str | None = Field(
+        default=None,
+        description="Audit lineage schema version carried by the product response when available.",
+        json_schema_extra={"example": "risk_audit_lineage.v1"},
+    )
+    request_fingerprint: str | None = Field(
+        default=None,
+        description="Current product request fingerprint when response lineage is available.",
+        json_schema_extra={"example": "sha256:6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c6f36c1f0f3f0f08c"},
+    )
+    source_services: list[str] = Field(
+        default_factory=list,
+        description="Ordered source-service lineage already published by lotus-risk.",
+        json_schema_extra={"example": ["lotus-risk", "lotus-performance"]},
+    )
+    upstream_request_fingerprints: dict[str, str] = Field(
+        default_factory=dict,
+        description="Upstream request fingerprints already published by lotus-risk.",
+        json_schema_extra={
+            "example": {
+                "lotus-performance:/integration/returns/series": (
+                    "sha256:8d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a18d7411c13a0a25a1"
+                )
+            }
+        },
+    )
+    dependency_signals: list[DependencyTelemetrySignal] = Field(
+        default_factory=list,
+        description="Dependency runtime evidence used as raw trust telemetry input.",
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def build_product_trust_telemetry_seed(
+    *,
+    app: FastAPI,
+    product_name: str,
+    product_version: str,
+    lifecycle_status: TelemetryLifecycleStatus = "active",
+    metadata: AuditMetadataFields | None = None,
+) -> ProductTrustTelemetrySeed:
+    _readiness_status_code, readiness_status, dependencies = resolve_readiness_status(app)
+    ops_status, _ = resolve_ops_status(app)
+
+    return ProductTrustTelemetrySeed(
+        product_name=product_name,
+        product_version=product_version,
+        lifecycle_status=lifecycle_status,
+        emitted_at=_utc_now(),
+        readiness_status=readiness_status,
+        ops_status=ops_status,
+        draining=bool(getattr(app.state, "is_draining", False)),
+        lineage_version=metadata.lineage_version if metadata is not None else None,
+        request_fingerprint=metadata.request_fingerprint if metadata is not None else None,
+        source_services=list(metadata.source_services) if metadata is not None else [],
+        upstream_request_fingerprints=(
+            dict(metadata.upstream_request_fingerprints) if metadata is not None else {}
+        ),
+        dependency_signals=[
+            DependencyTelemetrySignal(
+                service=dependency.service,
+                status=dependency.status,
+                detail=dependency.detail,
+                category=dependency.category,
+                issue_code=dependency.issue_code,
+            )
+            for dependency in dependencies
+        ],
+    )

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from app.contracts.audit import AuditMetadataFields
+from app.domain_data_products import get_declared_product
 from app.ops_runtime import resolve_ops_status, resolve_readiness_status
 
 TelemetryLifecycleStatus = Literal["active", "deprecated", "retired"]
@@ -108,16 +109,19 @@ def build_product_trust_telemetry_seed(
     app: FastAPI,
     product_name: str,
     product_version: str,
-    lifecycle_status: TelemetryLifecycleStatus = "active",
     metadata: AuditMetadataFields | None = None,
 ) -> ProductTrustTelemetrySeed:
+    declared_product = get_declared_product(
+        product_name=product_name,
+        product_version=product_version,
+    )
     _readiness_status_code, readiness_status, dependencies = resolve_readiness_status(app)
     ops_status, _ = resolve_ops_status(app)
 
     return ProductTrustTelemetrySeed(
         product_name=product_name,
         product_version=product_version,
-        lifecycle_status=lifecycle_status,
+        lifecycle_status=declared_product["lifecycle_status"],
         emitted_at=_utc_now(),
         readiness_status=readiness_status,
         ops_status=ops_status,

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -7,7 +7,11 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from app.contracts.audit import AuditMetadataFields
-from app.domain_data_products import get_declared_product
+from app.domain_data_products import (
+    REPO_RELATIVE_PRODUCER_DECLARATION_PATH,
+    get_declared_product,
+    list_declared_products,
+)
 from app.ops_runtime import resolve_ops_status, resolve_readiness_status
 
 TelemetryLifecycleStatus = Literal["active", "deprecated", "retired"]
@@ -100,6 +104,22 @@ class ProductTrustTelemetrySeed(BaseModel):
     )
 
 
+class DeclaredProductTrustTelemetrySnapshot(BaseModel):
+    service: str = Field(
+        description="Service identifier publishing the local trust telemetry snapshot.",
+        json_schema_extra={"example": "lotus-risk"},
+    )
+    declaration_source: str = Field(
+        description="Repo-native producer declaration file used to resolve the declared products.",
+        json_schema_extra={
+            "example": "contracts/domain-data-products/lotus-risk-products.v1.json"
+        },
+    )
+    products: list[ProductTrustTelemetrySeed] = Field(
+        description="Current raw telemetry seeds for each repo-native declared product.",
+    )
+
+
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -141,5 +161,24 @@ def build_product_trust_telemetry_seed(
                 issue_code=dependency.issue_code,
             )
             for dependency in dependencies
+        ],
+    )
+
+
+def build_declared_product_trust_telemetry_snapshot(
+    *,
+    app: FastAPI,
+    service_name: str,
+) -> DeclaredProductTrustTelemetrySnapshot:
+    return DeclaredProductTrustTelemetrySnapshot(
+        service=service_name,
+        declaration_source=REPO_RELATIVE_PRODUCER_DECLARATION_PATH.as_posix(),
+        products=[
+            build_product_trust_telemetry_seed(
+                app=app,
+                product_name=product["product_name"],
+                product_version=product["product_version"],
+            )
+            for product in list_declared_products()
         ],
     )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -199,6 +199,31 @@ def test_integration_capabilities_endpoint_exposes_support_matrix() -> None:
     )
 
 
+def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None:
+    client = TestClient(app)
+    response = client.get("/ops/trust-telemetry")
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["service"] == "lotus-risk"
+    assert (
+        body["declaration_source"] == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    )
+    assert (
+        body["consumer_declaration_source"]
+        == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
+    )
+    assert body["summary"]["declared_product_count"] == 5
+    assert body["summary"]["declared_dependency_count"] == 6
+    assert [product["product_name"] for product in body["products"]] == [
+        "RiskMetricsReport",
+        "DrawdownAnalyticsReport",
+        "RollingRiskMetricsReport",
+        "HistoricalRiskAttributionReport",
+        "ConcentrationRiskReport",
+    ]
+
+
 def test_e2e_capabilities_expose_product_surface_safety_notes() -> None:
     client = TestClient(app)
     response = client.get("/integration/capabilities")

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -182,6 +182,24 @@ def test_metadata_and_ops_contract_shape() -> None:
         trust_telemetry_body["declaration_source"]
         == "contracts/domain-data-products/lotus-risk-products.v1.json"
     )
+    assert trust_telemetry_body["declaration_fingerprint"].startswith("sha256:")
+    assert (
+        trust_telemetry_body["consumer_declaration_source"]
+        == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
+    )
+    assert trust_telemetry_body["consumer_declaration_fingerprint"].startswith("sha256:")
+    assert [dependency["product_name"] for dependency in trust_telemetry_body["declared_dependencies"]] == [
+        "ReturnsSeriesBundle",
+        "BenchmarkExposureContext",
+        "PortfolioStateSnapshot",
+        "PositionTimeseriesInput",
+        "InstrumentReferenceBundle",
+        "RiskFreeSeriesWindow",
+    ]
+    assert (
+        trust_telemetry_body["declared_dependencies"][0]["producer_repository"]
+        == "lotus-performance"
+    )
     assert [product["product_name"] for product in trust_telemetry_body["products"]] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",
@@ -193,6 +211,11 @@ def test_metadata_and_ops_contract_shape() -> None:
         product["lifecycle_status"] == "active"
         for product in trust_telemetry_body["products"]
     )
+    assert trust_telemetry_body["products"][0]["authoritative_domain"] == "risk_analytics"
+    assert trust_telemetry_body["products"][0]["product_family"] == "analytics_output"
+    assert trust_telemetry_body["products"][0]["approved_consumers"] == ["lotus-gateway"]
+    assert "request_fingerprint" in trust_telemetry_body["products"][0]["required_trust_metadata"]
+    assert trust_telemetry_body["products"][0]["current_routes"] == ["/analytics/risk/calculate"]
 
 
 def test_health_ready_and_ops_surface_dependency_degradation() -> None:
@@ -424,10 +447,19 @@ def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
         snapshot_schema["properties"]["declaration_source"]["example"]
         == "contracts/domain-data-products/lotus-risk-products.v1.json"
     )
+    assert "declaration_fingerprint" in snapshot_schema["properties"]
+    assert (
+        snapshot_schema["properties"]["consumer_declaration_source"]["example"]
+        == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
+    )
+    assert "declared_dependencies" in snapshot_schema["properties"]
     assert (
         seed_schema["properties"]["readiness_status"]["description"]
         == "Current service readiness posture used as raw input for future certification."
     )
+    assert seed_schema["properties"]["product_family"]["example"] == "analytics_output"
+    assert seed_schema["properties"]["approved_consumers"]["example"] == ["lotus-gateway"]
+    assert seed_schema["properties"]["current_routes"]["example"] == ["/analytics/risk/calculate"]
 
 
 def test_openapi_exposes_metadata_contract_schema() -> None:

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -188,7 +188,9 @@ def test_metadata_and_ops_contract_shape() -> None:
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
     assert trust_telemetry_body["consumer_declaration_fingerprint"].startswith("sha256:")
-    assert [dependency["product_name"] for dependency in trust_telemetry_body["declared_dependencies"]] == [
+    assert [
+        dependency["product_name"] for dependency in trust_telemetry_body["declared_dependencies"]
+    ] == [
         "ReturnsSeriesBundle",
         "BenchmarkExposureContext",
         "PortfolioStateSnapshot",
@@ -201,6 +203,11 @@ def test_metadata_and_ops_contract_shape() -> None:
         == "lotus-performance"
     )
     assert trust_telemetry_body["declared_dependencies"][0]["runtime_status"] == "ok"
+    assert trust_telemetry_body["summary"]["declared_product_count"] == 5
+    assert trust_telemetry_body["summary"]["declared_dependency_count"] == 6
+    assert trust_telemetry_body["summary"]["degraded_dependency_count"] == 0
+    assert trust_telemetry_body["summary"]["unavailable_dependency_count"] == 0
+    assert trust_telemetry_body["summary"]["missing_runtime_service_count"] == 0
     assert [product["product_name"] for product in trust_telemetry_body["products"]] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",
@@ -209,8 +216,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         "ConcentrationRiskReport",
     ]
     assert all(
-        product["lifecycle_status"] == "active"
-        for product in trust_telemetry_body["products"]
+        product["lifecycle_status"] == "active" for product in trust_telemetry_body["products"]
     )
     assert trust_telemetry_body["products"][0]["authoritative_domain"] == "risk_analytics"
     assert trust_telemetry_body["products"][0]["product_family"] == "analytics_output"
@@ -266,6 +272,14 @@ def test_health_ready_and_ops_surface_dependency_degradation() -> None:
     assert performance_dependency["runtime_status"] == "degraded"
     assert performance_dependency["runtime_category"] == "transport"
     assert performance_dependency["runtime_issue_code"] == "UPSTREAM_HIGH_LATENCY"
+    summary = trust_telemetry.json()["summary"]
+    assert summary["degraded_dependency_count"] == 2
+    assert summary["unavailable_dependency_count"] == 0
+    assert summary["missing_runtime_service_count"] == 0
+    assert summary["degraded_dependency_products"] == [
+        "ReturnsSeriesBundle",
+        "BenchmarkExposureContext",
+    ]
 
 
 def test_health_ready_fails_when_dependency_is_unavailable() -> None:
@@ -462,9 +476,15 @@ def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
     assert "declared_dependencies" in snapshot_schema["properties"]
+    assert "summary" in snapshot_schema["properties"]
     dependency_schema = spec["components"]["schemas"]["DeclaredConsumerDependencyTelemetry"]
+    summary_schema = spec["components"]["schemas"]["TrustTelemetryReviewSummary"]
     assert dependency_schema["properties"]["runtime_status"]["example"] == "degraded"
-    assert dependency_schema["properties"]["runtime_issue_code"]["example"] == "UPSTREAM_HIGH_LATENCY"
+    assert (
+        dependency_schema["properties"]["runtime_issue_code"]["example"] == "UPSTREAM_HIGH_LATENCY"
+    )
+    assert summary_schema["properties"]["declared_product_count"]["example"] == 5
+    assert summary_schema["properties"]["declared_dependency_count"]["example"] == 6
     assert (
         seed_schema["properties"]["readiness_status"]["description"]
         == "Current service readiness posture used as raw input for future certification."

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -200,6 +200,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         trust_telemetry_body["declared_dependencies"][0]["producer_repository"]
         == "lotus-performance"
     )
+    assert trust_telemetry_body["declared_dependencies"][0]["runtime_status"] == "ok"
     assert [product["product_name"] for product in trust_telemetry_body["products"]] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",
@@ -257,6 +258,14 @@ def test_health_ready_and_ops_surface_dependency_degradation() -> None:
     assert performance_signal["status"] == "degraded"
     assert performance_signal["category"] == "transport"
     assert performance_signal["issue_code"] == "UPSTREAM_HIGH_LATENCY"
+    performance_dependency = next(
+        dependency
+        for dependency in trust_telemetry.json()["declared_dependencies"]
+        if dependency["producer_repository"] == "lotus-performance"
+    )
+    assert performance_dependency["runtime_status"] == "degraded"
+    assert performance_dependency["runtime_category"] == "transport"
+    assert performance_dependency["runtime_issue_code"] == "UPSTREAM_HIGH_LATENCY"
 
 
 def test_health_ready_fails_when_dependency_is_unavailable() -> None:
@@ -453,6 +462,9 @@ def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
     assert "declared_dependencies" in snapshot_schema["properties"]
+    dependency_schema = spec["components"]["schemas"]["DeclaredConsumerDependencyTelemetry"]
+    assert dependency_schema["properties"]["runtime_status"]["example"] == "degraded"
+    assert dependency_schema["properties"]["runtime_issue_code"]["example"] == "UPSTREAM_HIGH_LATENCY"
     assert (
         seed_schema["properties"]["readiness_status"]["description"]
         == "Current service readiness posture used as raw input for future certification."

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -11,6 +11,7 @@ def test_health_endpoints() -> None:
     assert client.get("/health/live").status_code == 200
     assert client.get("/health/ready").status_code == 200
     assert client.get("/ops").status_code == 200
+    assert client.get("/ops/trust-telemetry").status_code == 200
     metrics_response = client.get("/metrics")
     assert metrics_response.status_code == 200
     assert metrics_response.headers["content-type"].startswith("text/plain")
@@ -146,6 +147,7 @@ def test_openapi_hides_legacy_proxy_and_exposes_concentration() -> None:
     assert "/analytics/risk/drawdown" in spec["paths"]
     assert "/analytics/risk/rolling-metrics" in spec["paths"]
     assert "/ops" in spec["paths"]
+    assert "/ops/trust-telemetry" in spec["paths"]
     assert "/analytics/workbench/risk-proxy" not in spec["paths"]
 
 
@@ -153,10 +155,13 @@ def test_metadata_and_ops_contract_shape() -> None:
     client = TestClient(app)
     metadata = client.get("/metadata")
     ops = client.get("/ops")
+    trust_telemetry = client.get("/ops/trust-telemetry")
     assert metadata.status_code == 200
     assert ops.status_code == 200
+    assert trust_telemetry.status_code == 200
     metadata_body = metadata.json()
     ops_body = ops.json()
+    trust_telemetry_body = trust_telemetry.json()
     assert metadata_body["service"] == "lotus-risk"
     assert metadata_body["version"] == "0.1.0"
     assert "rounding_policy_version" in metadata_body
@@ -172,6 +177,22 @@ def test_metadata_and_ops_contract_shape() -> None:
     assert all(dependency["status"] == "ok" for dependency in ops_body["dependencies"])
     assert all(dependency["category"] is None for dependency in ops_body["dependencies"])
     assert all(dependency["issue_code"] is None for dependency in ops_body["dependencies"])
+    assert trust_telemetry_body["service"] == "lotus-risk"
+    assert (
+        trust_telemetry_body["declaration_source"]
+        == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    )
+    assert [product["product_name"] for product in trust_telemetry_body["products"]] == [
+        "RiskMetricsReport",
+        "DrawdownAnalyticsReport",
+        "RollingRiskMetricsReport",
+        "HistoricalRiskAttributionReport",
+        "ConcentrationRiskReport",
+    ]
+    assert all(
+        product["lifecycle_status"] == "active"
+        for product in trust_telemetry_body["products"]
+    )
 
 
 def test_health_ready_and_ops_surface_dependency_degradation() -> None:
@@ -188,6 +209,7 @@ def test_health_ready_and_ops_surface_dependency_degradation() -> None:
         client = TestClient(app)
         readiness = client.get("/health/ready")
         ops = client.get("/ops")
+        trust_telemetry = client.get("/ops/trust-telemetry")
 
     assert readiness.status_code == 200
     assert readiness.json()["status"] == "degraded"
@@ -203,6 +225,15 @@ def test_health_ready_and_ops_surface_dependency_degradation() -> None:
     assert performance_dependency["detail"] == "high_latency"
     assert performance_dependency["category"] == "transport"
     assert performance_dependency["issue_code"] == "UPSTREAM_HIGH_LATENCY"
+    trust_product = trust_telemetry.json()["products"][0]
+    performance_signal = next(
+        signal
+        for signal in trust_product["dependency_signals"]
+        if signal["service"] == "lotus-performance"
+    )
+    assert performance_signal["status"] == "degraded"
+    assert performance_signal["category"] == "transport"
+    assert performance_signal["issue_code"] == "UPSTREAM_HIGH_LATENCY"
 
 
 def test_health_ready_fails_when_dependency_is_unavailable() -> None:
@@ -378,6 +409,25 @@ def test_openapi_exposes_ops_dependency_diagnostics_schema() -> None:
         "Canonical base URL configured for the dependency."
     )
     assert dependency_schema["properties"]["issue_code"]["example"] == "RISK_FREE_SERIES_EMPTY"
+
+
+def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
+    client = TestClient(app)
+    spec = client.get("/openapi.json").json()
+    trust_get = spec["paths"]["/ops/trust-telemetry"]["get"]
+    schema_ref = trust_get["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+    assert schema_ref.endswith("/DeclaredProductTrustTelemetrySnapshot")
+    snapshot_schema = spec["components"]["schemas"]["DeclaredProductTrustTelemetrySnapshot"]
+    seed_schema = spec["components"]["schemas"]["ProductTrustTelemetrySeed"]
+    assert snapshot_schema["properties"]["service"]["example"] == "lotus-risk"
+    assert (
+        snapshot_schema["properties"]["declaration_source"]["example"]
+        == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    )
+    assert (
+        seed_schema["properties"]["readiness_status"]["description"]
+        == "Current service readiness posture used as raw input for future certification."
+    )
 
 
 def test_openapi_exposes_metadata_contract_schema() -> None:

--- a/tests/unit/test_domain_data_product_contract_check.py
+++ b/tests/unit/test_domain_data_product_contract_check.py
@@ -2,17 +2,20 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 from scripts.domain_data_product_contract_check import validate_repo_native_contracts
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LOCAL_DECLARATIONS_DIR = REPO_ROOT / "contracts" / "domain-data-products"
-PLATFORM_DECLARATIONS_DIR = REPO_ROOT.parent / "lotus-platform" / "platform-contracts" / "domain-data-products"
+PLATFORM_DECLARATIONS_DIR = (
+    REPO_ROOT.parent / "lotus-platform" / "platform-contracts" / "domain-data-products"
+)
 
 
-def _load_json(path: Path) -> dict:
-    return json.loads(path.read_text(encoding="utf-8"))
+def _load_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
 
 
 def test_repo_native_domain_data_product_gate_passes() -> None:

--- a/tests/unit/test_domain_data_product_contract_check.py
+++ b/tests/unit/test_domain_data_product_contract_check.py
@@ -4,7 +4,12 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
-from scripts.domain_data_product_contract_check import validate_repo_native_contracts
+import pytest
+
+from scripts.domain_data_product_contract_check import (
+    platform_validation_dependencies_available,
+    validate_repo_native_contracts,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -19,10 +24,14 @@ def _load_json(path: Path) -> dict[str, Any]:
 
 
 def test_repo_native_domain_data_product_gate_passes() -> None:
+    if not platform_validation_dependencies_available():
+        pytest.skip("lotus-platform validator checkout is not available in this environment")
     assert validate_repo_native_contracts() == []
 
 
 def test_repo_native_declarations_match_transitional_platform_mirrors() -> None:
+    if not platform_validation_dependencies_available():
+        pytest.skip("lotus-platform validator checkout is not available in this environment")
     assert _load_json(LOCAL_DECLARATIONS_DIR / "lotus-risk-products.v1.json") == _load_json(
         PLATFORM_DECLARATIONS_DIR / "lotus-risk-products.v1.json"
     )

--- a/tests/unit/test_domain_data_product_contract_check.py
+++ b/tests/unit/test_domain_data_product_contract_check.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.domain_data_product_contract_check import validate_repo_native_contracts
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCAL_DECLARATIONS_DIR = REPO_ROOT / "contracts" / "domain-data-products"
+PLATFORM_DECLARATIONS_DIR = REPO_ROOT.parent / "lotus-platform" / "platform-contracts" / "domain-data-products"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_repo_native_domain_data_product_gate_passes() -> None:
+    assert validate_repo_native_contracts() == []
+
+
+def test_repo_native_declarations_match_transitional_platform_mirrors() -> None:
+    assert _load_json(LOCAL_DECLARATIONS_DIR / "lotus-risk-products.v1.json") == _load_json(
+        PLATFORM_DECLARATIONS_DIR / "lotus-risk-products.v1.json"
+    )
+    assert _load_json(LOCAL_DECLARATIONS_DIR / "lotus-risk-consumers.v1.json") == _load_json(
+        PLATFORM_DECLARATIONS_DIR / "lotus-risk-consumers.v1.json"
+    )
+
+
+def test_repo_native_declaration_directory_contains_expected_contract_files() -> None:
+    paths = sorted(path.name for path in LOCAL_DECLARATIONS_DIR.glob("*.json"))
+    assert paths == [
+        "lotus-risk-consumers.v1.json",
+        "lotus-risk-products.v1.json",
+    ]

--- a/tests/unit/test_domain_data_products.py
+++ b/tests/unit/test_domain_data_products.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from app.domain_data_products import (
+    LOCAL_PRODUCER_DECLARATION_PATH,
+    get_declared_product,
+    list_declared_products,
+    load_local_producer_declaration,
+)
+
+
+def test_load_local_producer_declaration_uses_repo_native_contract_path() -> None:
+    payload = load_local_producer_declaration()
+
+    assert payload["producer_repository"] == "lotus-risk"
+    assert LOCAL_PRODUCER_DECLARATION_PATH.name == "lotus-risk-products.v1.json"
+
+
+def test_list_declared_products_matches_expected_wave() -> None:
+    product_names = [product["product_name"] for product in list_declared_products()]
+
+    assert product_names == [
+        "RiskMetricsReport",
+        "DrawdownAnalyticsReport",
+        "RollingRiskMetricsReport",
+        "HistoricalRiskAttributionReport",
+        "ConcentrationRiskReport",
+    ]
+
+
+def test_get_declared_product_returns_repo_native_lifecycle_and_route() -> None:
+    product = get_declared_product(
+        product_name="HistoricalRiskAttributionReport",
+        product_version="v1",
+    )
+
+    assert product["lifecycle_status"] == "active"
+    assert product["current_routes"] == ["/analytics/risk/historical-attribution"]
+
+
+def test_get_declared_product_rejects_unknown_product() -> None:
+    try:
+        get_declared_product(product_name="UnknownReport", product_version="v1")
+    except ValueError as exc:
+        assert "Unknown lotus-risk declared product" in str(exc)
+    else:
+        raise AssertionError("expected unknown declared product lookup to fail")

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from app.contracts.audit import AuditMetadataFields
-from app.trust_telemetry import build_product_trust_telemetry_seed
+from app.trust_telemetry import (
+    build_declared_product_trust_telemetry_snapshot,
+    build_product_trust_telemetry_seed,
+)
 
 
 def test_build_product_trust_telemetry_seed_uses_runtime_and_lineage_inputs() -> None:
@@ -87,3 +90,32 @@ def test_build_product_trust_telemetry_seed_rejects_undeclared_products() -> Non
         assert "Unknown lotus-risk declared product" in str(exc)
     else:
         raise AssertionError("expected undeclared product telemetry seed build to fail")
+
+
+def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalog() -> None:
+    app = FastAPI()
+    app.state.dependency_statuses = {
+        "lotus-core": {
+            "status": "degraded",
+            "detail": "risk-free source stale",
+            "category": "data_gap",
+            "issue_code": "RISK_FREE_SERIES_STALE",
+        }
+    }
+
+    snapshot = build_declared_product_trust_telemetry_snapshot(
+        app=app,
+        service_name="lotus-risk",
+    )
+
+    assert snapshot.service == "lotus-risk"
+    assert snapshot.declaration_source == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    assert [product.product_name for product in snapshot.products] == [
+        "RiskMetricsReport",
+        "DrawdownAnalyticsReport",
+        "RollingRiskMetricsReport",
+        "HistoricalRiskAttributionReport",
+        "ConcentrationRiskReport",
+    ]
+    assert all(product.lifecycle_status == "active" for product in snapshot.products)
+    assert snapshot.products[0].dependency_signals[0].issue_code == "RISK_FREE_SERIES_STALE"

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.contracts.audit import AuditMetadataFields
+from app.trust_telemetry import build_product_trust_telemetry_seed
+
+
+def test_build_product_trust_telemetry_seed_uses_runtime_and_lineage_inputs() -> None:
+    app = FastAPI()
+    app.state.is_draining = False
+    app.state.dependency_statuses = {
+        "lotus-performance": {
+            "status": "degraded",
+            "detail": "benchmark context delayed",
+            "category": "data_gap",
+            "issue_code": "BENCHMARK_CONTEXT_DELAYED",
+        }
+    }
+    metadata = AuditMetadataFields(
+        request_fingerprint="sha256:test",
+        source_services=["lotus-risk", "lotus-performance"],
+        upstream_request_fingerprints={
+            "lotus-performance:/integration/returns/series": "sha256:upstream"
+        },
+    )
+
+    seed = build_product_trust_telemetry_seed(
+        app=app,
+        product_name="RiskMetricsReport",
+        product_version="v1",
+        metadata=metadata,
+    )
+
+    assert seed.product_name == "RiskMetricsReport"
+    assert seed.product_version == "v1"
+    assert seed.lifecycle_status == "active"
+    assert seed.readiness_status == "degraded"
+    assert seed.ops_status == "degraded"
+    assert seed.draining is False
+    assert seed.lineage_version == "risk_audit_lineage.v1"
+    assert seed.request_fingerprint == "sha256:test"
+    assert seed.source_services == ["lotus-risk", "lotus-performance"]
+    assert seed.upstream_request_fingerprints == {
+        "lotus-performance:/integration/returns/series": "sha256:upstream"
+    }
+    assert [signal.service for signal in seed.dependency_signals] == [
+        "lotus-core",
+        "lotus-performance",
+    ]
+    assert seed.dependency_signals[1].status == "degraded"
+    assert seed.dependency_signals[1].category == "data_gap"
+    assert seed.dependency_signals[1].issue_code == "BENCHMARK_CONTEXT_DELAYED"
+    assert seed.emitted_at.endswith("Z")
+
+
+def test_build_product_trust_telemetry_seed_preserves_draining_and_missing_lineage() -> None:
+    app = FastAPI()
+    app.state.is_draining = True
+
+    seed = build_product_trust_telemetry_seed(
+        app=app,
+        product_name="ConcentrationRiskReport",
+        product_version="v1",
+    )
+
+    assert seed.product_name == "ConcentrationRiskReport"
+    assert seed.readiness_status == "draining"
+    assert seed.ops_status == "degraded"
+    assert seed.draining is True
+    assert seed.lineage_version is None
+    assert seed.request_fingerprint is None
+    assert seed.source_services == []
+    assert seed.upstream_request_fingerprints == {}

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -37,7 +37,12 @@ def test_build_product_trust_telemetry_seed_uses_runtime_and_lineage_inputs() ->
 
     assert seed.product_name == "RiskMetricsReport"
     assert seed.product_version == "v1"
+    assert seed.authoritative_domain == "risk_analytics"
+    assert seed.product_family == "analytics_output"
+    assert seed.approved_consumers == ["lotus-gateway"]
+    assert "request_fingerprint" in seed.required_trust_metadata
     assert seed.lifecycle_status == "active"
+    assert seed.current_routes == ["/analytics/risk/calculate"]
     assert seed.readiness_status == "degraded"
     assert seed.ops_status == "degraded"
     assert seed.draining is False
@@ -110,6 +115,22 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
 
     assert snapshot.service == "lotus-risk"
     assert snapshot.declaration_source == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    assert snapshot.declaration_fingerprint.startswith("sha256:")
+    assert (
+        snapshot.consumer_declaration_source
+        == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
+    )
+    assert snapshot.consumer_declaration_fingerprint.startswith("sha256:")
+    assert [dependency.product_name for dependency in snapshot.declared_dependencies] == [
+        "ReturnsSeriesBundle",
+        "BenchmarkExposureContext",
+        "PortfolioStateSnapshot",
+        "PositionTimeseriesInput",
+        "InstrumentReferenceBundle",
+        "RiskFreeSeriesWindow",
+    ]
+    assert snapshot.declared_dependencies[0].producer_repository == "lotus-performance"
+    assert "correlation_id" in snapshot.declared_dependencies[0].required_trust_metadata
     assert [product.product_name for product in snapshot.products] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",
@@ -118,4 +139,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
         "ConcentrationRiskReport",
     ]
     assert all(product.lifecycle_status == "active" for product in snapshot.products)
+    assert snapshot.products[0].product_family == "analytics_output"
+    assert snapshot.products[0].approved_consumers == ["lotus-gateway"]
+    assert snapshot.products[0].current_routes == ["/analytics/risk/calculate"]
     assert snapshot.products[0].dependency_signals[0].issue_code == "RISK_FREE_SERIES_STALE"

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -114,7 +114,9 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     )
 
     assert snapshot.service == "lotus-risk"
-    assert snapshot.declaration_source == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    assert (
+        snapshot.declaration_source == "contracts/domain-data-products/lotus-risk-products.v1.json"
+    )
     assert snapshot.declaration_fingerprint.startswith("sha256:")
     assert (
         snapshot.consumer_declaration_source
@@ -135,6 +137,19 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     assert snapshot.declared_dependencies[2].runtime_status == "degraded"
     assert snapshot.declared_dependencies[2].runtime_category == "data_gap"
     assert snapshot.declared_dependencies[2].runtime_issue_code == "RISK_FREE_SERIES_STALE"
+    assert snapshot.summary.declared_product_count == 5
+    assert snapshot.summary.declared_dependency_count == 6
+    assert snapshot.summary.degraded_dependency_count == 4
+    assert snapshot.summary.unavailable_dependency_count == 0
+    assert snapshot.summary.missing_runtime_service_count == 0
+    assert snapshot.summary.degraded_dependency_products == [
+        "PortfolioStateSnapshot",
+        "PositionTimeseriesInput",
+        "InstrumentReferenceBundle",
+        "RiskFreeSeriesWindow",
+    ]
+    assert snapshot.summary.unavailable_dependency_products == []
+    assert snapshot.summary.missing_runtime_services == []
     assert [product.product_name for product in snapshot.products] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -131,6 +131,10 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     ]
     assert snapshot.declared_dependencies[0].producer_repository == "lotus-performance"
     assert "correlation_id" in snapshot.declared_dependencies[0].required_trust_metadata
+    assert snapshot.declared_dependencies[0].runtime_status == "ok"
+    assert snapshot.declared_dependencies[2].runtime_status == "degraded"
+    assert snapshot.declared_dependencies[2].runtime_category == "data_gap"
+    assert snapshot.declared_dependencies[2].runtime_issue_code == "RISK_FREE_SERIES_STALE"
     assert [product.product_name for product in snapshot.products] == [
         "RiskMetricsReport",
         "DrawdownAnalyticsReport",

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -72,3 +72,18 @@ def test_build_product_trust_telemetry_seed_preserves_draining_and_missing_linea
     assert seed.request_fingerprint is None
     assert seed.source_services == []
     assert seed.upstream_request_fingerprints == {}
+
+
+def test_build_product_trust_telemetry_seed_rejects_undeclared_products() -> None:
+    app = FastAPI()
+
+    try:
+        build_product_trust_telemetry_seed(
+            app=app,
+            product_name="UncataloguedRiskReport",
+            product_version="v1",
+        )
+    except ValueError as exc:
+        assert "Unknown lotus-risk declared product" in str(exc)
+    else:
+        raise AssertionError("expected undeclared product telemetry seed build to fail")

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -14,6 +14,7 @@ The repo-native commands are designed to map to those lanes directly.
 
 - `make check` - fast local gate
 - `make ci` - PR-grade local gate
+- `make domain-data-product-gate` - repo-native domain product declaration validation
 - `make test-unit` - unit suite
 - `make test-integration` - integration suite
 - `make test-e2e` - e2e suite
@@ -29,7 +30,8 @@ The repo-native commands are designed to map to those lanes directly.
 3. typecheck,
 4. OpenAPI quality,
 5. API vocabulary validation,
-6. unit-focused default test execution.
+6. repo-native domain product declaration validation,
+7. unit-focused default test execution.
 
 ## What `make ci` Adds
 


### PR DESCRIPTION
Wave 1 repo-native risk product onboarding for lotus-risk, including the RFC-0087 preparation seam for raw operator trust telemetry.

Includes:
- repo-native producer and consumer declarations under `contracts/domain-data-products/`
- local validation gate wired into `Makefile`
- repo-local documentation for the transitional mirror posture
- raw `/ops/trust-telemetry` inspection seam derived from repo-native declarations and current runtime status
- focused unit, integration, and smoke coverage for the raw telemetry seam

Validation:
- `make domain-data-product-gate`
- `python -m pytest tests/unit/test_domain_data_product_contract_check.py tests/unit/test_trust_data_product_contract_check.py tests/unit/test_trust_telemetry.py tests/integration/test_health.py tests/e2e/test_smoke.py -q`
- `python -m ruff check src/app/domain_data_products.py src/app/main.py src/app/trust_telemetry.py scripts/domain_data_product_contract_check.py tests/unit/test_domain_data_product_contract_check.py tests/unit/test_trust_data_product_contract_check.py tests/unit/test_trust_telemetry.py tests/integration/test_health.py tests/e2e/test_smoke.py`
- `python scripts/api_vocabulary_inventory.py --validate-only`

Coordinator review outcome:
- repo-native declarations remain the ownership source under `contracts/domain-data-products/`
- lotus-platform mirrors remain transitional for this wave
- `/ops/trust-telemetry` remains a raw operator-facing prep seam, not a certified trust contract