### PR TITLE
Add RFC-0087 trust telemetry snapshot

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -33,7 +33,10 @@ Current repository posture:
 4. RFC-0008 establishes the current enterprise-readiness baseline: supported risk analytics are credible for the canonical private-banking portfolio, while unrestricted enterprise-bank approval still requires downstream proof and broader seeded portfolio archetype coverage,
 5. current work often involves balancing analytical correctness, contract quality, and front-office usability,
 6. upstream use of `lotus-core` and `lotus-performance` is now documented under the RFC-0082 upstream contract-family map,
-7. repo-native RFC-0086 product and consumer declarations now live under `contracts/domain-data-products/` with a local `make domain-data-product-gate` validation path.
+7. repo-native RFC-0086 product and consumer declarations now live under `contracts/domain-data-products/` with a local `make domain-data-product-gate` validation path,
+8. RFC-0087 trust telemetry proof for `RiskMetricsReport` now lives under
+   `contracts/trust-telemetry/` and is validated by `tests/unit/test_trust_telemetry.py` against
+   the platform trust telemetry validator when `lotus-platform` is available.
 
 ## Architecture And Module Map
 
@@ -42,7 +45,8 @@ Primary areas:
 1. `src/`
    risk application and analytics implementation.
 2. `contracts/`
-   repo-native domain product declarations and related machine-readable contract files.
+   repo-native domain product declarations, trust telemetry fixtures, and related machine-readable
+   contract files.
 3. `scripts/`
    OpenAPI, vocabulary, dependency-health, and test-pyramid governance.
 4. `docs/standards/`

--- a/contracts/trust-telemetry/README.md
+++ b/contracts/trust-telemetry/README.md
@@ -1,0 +1,19 @@
+# Lotus Risk Trust Telemetry
+
+This directory contains repo-owned RFC-0087 trust telemetry snapshots for governed `lotus-risk`
+domain products.
+
+The current first-wave snapshot is:
+
+1. `risk-metrics-report.telemetry.v1.json`
+   Runtime trust proof for `lotus-risk:RiskMetricsReport:v1`.
+
+Validate locally with:
+
+```powershell
+python -m pytest tests\unit\test_trust_telemetry.py -q
+```
+
+When `../lotus-platform` is available, the test validates the snapshot with the platform
+`automation/validate_trust_telemetry.py` contract validator and checks that observed trust metadata
+matches the repo-native declaration in `contracts/domain-data-products/lotus-risk-products.v1.json`.

--- a/contracts/trust-telemetry/risk-metrics-report.telemetry.v1.json
+++ b/contracts/trust-telemetry/risk-metrics-report.telemetry.v1.json
@@ -1,0 +1,62 @@
+{
+  "contract_id": "lotus-domain-product-trust-telemetry-snapshot",
+  "contract_version": "1.0.0",
+  "governed_by_rfcs": [
+    "RFC-0087"
+  ],
+  "emitted_at_utc": "2026-04-19T00:00:00Z",
+  "product_id": "lotus-risk:RiskMetricsReport:v1",
+  "producer_repository": "lotus-risk",
+  "product_name": "RiskMetricsReport",
+  "product_version": "v1",
+  "source_repository": "lotus-risk",
+  "freshness": {
+    "freshness_class": "daily",
+    "freshness_state": "current",
+    "evaluated_at_utc": "2026-04-19T00:00:00Z",
+    "observed_at_utc": "2026-04-19T00:00:00Z",
+    "age_seconds": 0,
+    "max_allowed_age_seconds": 86400
+  },
+  "completeness_status": "complete",
+  "reconciliation_status": "reconciled",
+  "data_quality_status": "quality_passed",
+  "lineage": {
+    "lineage_materialized": true,
+    "lineage_bundle_id": "lineage:lotus-risk:risk-metrics-report:2026-04-19",
+    "evidence_access_class": "customer_consumable",
+    "evidence_uris": [
+      "lotus-risk://evidence/risk-metrics/PB_SG_GLOBAL_BAL_001/2026-04-19"
+    ]
+  },
+  "blocking": {
+    "blocked": false
+  },
+  "observed_trust_metadata": {
+    "product_name": "RiskMetricsReport",
+    "product_version": "v1",
+    "as_of_date": "2026-04-19",
+    "lineage_version": "risk_audit_lineage.v1",
+    "request_fingerprint": "sha256:risk-metrics-request-demo",
+    "source_services": [
+      "lotus-risk",
+      "lotus-performance",
+      "lotus-core"
+    ],
+    "upstream_request_fingerprints": {
+      "lotus-performance:/integration/returns/series": "sha256:returns-series-demo",
+      "lotus-core:/query/portfolio-state": "sha256:portfolio-state-demo"
+    },
+    "benchmark_context": "MSCI_ACWI_PRIVATE_BANKING_DEMO",
+    "risk_free_context": "SGD_OVERNIGHT_DEMO"
+  },
+  "evidence": {
+    "correlation_id": "rfc-0087-lotus-risk-risk-metrics",
+    "validation_lanes": [
+      "feature",
+      "pr-merge"
+    ],
+    "source_event_id": "source-event:lotus-risk:risk-metrics:2026-04-19",
+    "source_artifact_uri": "lotus-risk://contracts/trust-telemetry/risk-metrics-report.telemetry.v1.json"
+  }
+}

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -1,5 +1,13 @@
 from __future__ import annotations
 
+import importlib
+import json
+import sys
+from types import ModuleType
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
 from fastapi import FastAPI
 
 from app.contracts.audit import AuditMetadataFields
@@ -7,6 +15,66 @@ from app.trust_telemetry import (
     build_declared_product_trust_telemetry_snapshot,
     build_product_trust_telemetry_seed,
 )
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLATFORM_ROOT = REPO_ROOT.parent / "lotus-platform"
+TELEMETRY_DIR = REPO_ROOT / "contracts" / "trust-telemetry"
+SNAPSHOT_PATH = TELEMETRY_DIR / "risk-metrics-report.telemetry.v1.json"
+DECLARATION_PATH = REPO_ROOT / "contracts" / "domain-data-products" / "lotus-risk-products.v1.json"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(path.read_text(encoding="utf-8")))
+
+
+def _load_platform_validator() -> ModuleType:
+    validator_path = PLATFORM_ROOT / "automation" / "validate_trust_telemetry.py"
+    if not validator_path.exists():
+        pytest.skip("lotus-platform trust telemetry validator is not available")
+    automation_path = str(PLATFORM_ROOT / "automation")
+    if automation_path not in sys.path:
+        sys.path.insert(0, automation_path)
+    return importlib.import_module("validate_trust_telemetry")
+
+
+def test_risk_metrics_report_trust_telemetry_validates_with_platform_contract() -> None:
+    validator = _load_platform_validator()
+
+    issues = validator.validate_trust_telemetry_path(
+        TELEMETRY_DIR,
+        catalog_path=PLATFORM_ROOT / "generated" / "domain-product-catalog.json",
+    )
+
+    assert issues == []
+
+
+def test_risk_metrics_report_trust_telemetry_is_tied_to_repo_declaration() -> None:
+    snapshot = _load_json(SNAPSHOT_PATH)
+    declaration = _load_json(DECLARATION_PATH)
+    declared_product = next(
+        product
+        for product in declaration["products"]
+        if product["product_name"] == "RiskMetricsReport"
+    )
+
+    assert snapshot["product_id"] == "lotus-risk:RiskMetricsReport:v1"
+    assert snapshot["producer_repository"] == declaration["producer_repository"]
+    assert snapshot["product_name"] == declared_product["product_name"]
+    assert snapshot["product_version"] == declared_product["product_version"]
+    assert (
+        snapshot["freshness"]["freshness_class"]
+        == (declared_product["freshness_policy"]["freshness_class"])
+    )
+    assert set(snapshot["observed_trust_metadata"]) == set(
+        declared_product["required_trust_metadata"]
+    )
+    assert snapshot["lineage"]["lineage_materialized"] is True
+    assert (
+        snapshot["lineage"]["evidence_access_class"]
+        == (declared_product["lineage_policy"]["evidence_access_class_ref"])
+    )
+    assert snapshot["blocking"]["blocked"] is False
 
 
 def test_build_product_trust_telemetry_seed_uses_runtime_and_lineage_inputs() -> None:


### PR DESCRIPTION
## Summary
- adds repo-owned RFC-0087 trust telemetry snapshot for `lotus-risk:RiskMetricsReport:v1`
- validates the snapshot against the platform trust telemetry contract when `lotus-platform` is available
- checks observed trust metadata against the repo-native domain-product declaration
- updates repository context and adds a short contract README

## Validation
- python -m pytest tests\\unit\\test_trust_telemetry.py -q
- python -m ruff check tests\\unit\\test_trust_telemetry.py
- python -m ruff format --check tests\\unit\\test_trust_telemetry.py
- make domain-data-product-gate
- make check
- platform: python automation\\validate_trust_telemetry.py C:\\Users\\Sandeep\\projects\\lotus-risk\\contracts\\trust-telemetry
- platform combined live trust generation: 4 snapshots certified, 0 issues