### PR TITLE
docs(mesh): document mesh wiki posture

### DIFF
--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -1,0 +1,20 @@
+# Mesh Data Products
+
+## Mesh role
+
+`lotus-risk` is a maturity-wave producer in the Lotus enterprise data mesh.
+
+## Governed product
+
+- Product ID: `lotus-risk:RiskMetricsReport:v1`
+- Product role: governed risk metrics report for advisory, reporting, gateway, and Workbench discovery flows
+- Source declaration: `contracts/domain-data-products/`
+- Trust telemetry: `contracts/trust-telemetry/`
+
+## Platform relationship
+
+`lotus-platform` aggregates the repo-native declaration, validates trust telemetry, applies mesh SLO/access/evidence policies, and includes this product in generated catalog, dependency graph, live certification, maturity matrix, evidence packs, and RFC-0092 operating reports.
+
+## Operating rule
+
+Risk product trust must include freshness, completeness, data quality, lineage, and upstream dependency posture. Do not present risk mesh posture as certified unless platform mesh certification passes.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -10,3 +10,5 @@
 * [RFC Index](RFC-Index)
 * [Roadmap](Roadmap)
 * [Troubleshooting](Troubleshooting)
+
+- [Mesh Data Products](Mesh-Data-Products)


### PR DESCRIPTION
Updates the authored repo wiki with an explicit Mesh Data Products page and sidebar link so the repo's published wiki can reflect the implemented Lotus mesh RFC posture. This is documentation-only; no runtime or API behavior changes.