### PR TITLE
Pass benchmark override through stateful risk

### DIFF
--- a/docs/domain-apis/risk-calculate.md
+++ b/docs/domain-apis/risk-calculate.md
@@ -22,6 +22,9 @@
 - Status: implemented in lotus-risk.
 - Current behavior:
   - caller supplies identifiers plus risk metric specification (`periods`, `metrics`, `options`).
+  - caller may provide `stateful_input.benchmark_id` to force benchmark-dependent metrics
+    (`BETA`, `TRACKING_ERROR`, `INFORMATION_RATIO`) to use a specific governed benchmark; when
+    omitted, `lotus-performance` resolves the portfolio benchmark assignment.
   - lotus-risk sources canonical return series from `lotus-performance` using `input_mode=stateful` and `stateful_input is an empty envelope; consumer identity is stamped by lotus-performance server-side`.
   - when `SHARPE` is requested, the stateful returns-series request includes risk-free returns sourced from the `lotus-core` mastered risk-free series through `lotus-performance`.
   - sourced risk-free period returns are converted into the existing annual-rate risk-engine option so `metadata.risk_free_context.reason` becomes `ANNUAL_RATE_APPLIED`; missing sourced risk-free returns fail closed instead of silently using a zero-rate convention.
@@ -54,6 +57,24 @@
 - `stateless_input.returns[]: [{date, value}]`
 - `stateless_input.benchmark_returns[]: [{date, value}]` (required for benchmark-dependent metrics)
 
+## Stateful Inputs (Current)
+
+- `input_mode: "stateful"`
+- `stateful_input.portfolio_id: str`
+- `stateful_input.as_of_date: date`
+- `stateful_input.reporting_currency?: str`
+- `stateful_input.client_id?: str`
+- `stateful_input.benchmark_id?: str`
+  - optional benchmark override for benchmark-dependent metrics
+  - forwarded to `lotus-performance` as `benchmark.benchmark_id`
+  - if omitted, the upstream benchmark assignment is used
+- `stateful_input.net_or_gross: "NET" | "GROSS"`
+- `stateful_input.periods[]`
+- `stateful_input.metrics[]`
+  - benchmark metrics cause `series_selection.include_benchmark=true`
+  - `SHARPE` causes `series_selection.include_risk_free=true`
+- `stateful_input.options`
+
 ## Stateful/Simulation Input Source Mapping (Current + Target)
 
 | Input Needed | Preferred Source App | Availability | Notes |
@@ -61,8 +82,9 @@
 | Portfolio baseline snapshot (`portfolioId`, holdings, valuation context) | lotus-core (`/integration/portfolios/{id}/core-snapshot`) | Exists | Already used by other services. |
 | Raw valuation/performance input points | lotus-core (`/integration/portfolios/{id}/performance-input`) | Exists | Provides valuation points and metadata. |
 | Daily return series normalized for risk engine | lotus-performance (`/integration/returns/series` with `input_mode=stateful`) | Exists | Implemented stateful path in lotus-risk; upstream decimal returns are filtered to trading days and converted to percentage-point risk engine input. |
-| Benchmark return series | lotus-performance (`/integration/returns/series` with `include_benchmark=true`) | Exists | Used by stateful beta, tracking error, information ratio, and benchmark-relative drawdown paths; aligned by trading date inside lotus-risk. |
+| Benchmark return series | lotus-performance (`/integration/returns/series` with `include_benchmark=true` and optional `benchmark.benchmark_id`) | Exists | Used by stateful beta, tracking error, information ratio, and benchmark-relative drawdown paths; aligned by trading date inside lotus-risk. |
 | Risk-free return series | lotus-performance (`/integration/returns/series` with `include_risk_free=true`, sourced from lotus-core risk-free reference data) | Exists | Used by stateful Sharpe. Empty risk-free returns fail closed so downstream consumers do not certify zero-rate Sharpe as source-backed. |
+
 ## Expected Output Structure
 
 - `scope` (echoed normalized request scope)

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-13T12:33:15Z",
+  "generated_at": "2026-04-23T02:03:36Z",
   "allowlist": [
     {
       "finding": "src/app/contracts/attribution.py:404:total_value: float | None = Field(",
@@ -40,10 +40,10 @@
       "review_by": "2026-10-10"
     },
     {
-      "finding": "src/app/contracts/risk.py:377:value: float | None = Field(",
+      "finding": "src/app/contracts/risk.py:386:value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-20"
     },
     {
       "finding": "src/app/services/attribution_engine.py:103:total_value: float,",

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -268,6 +268,14 @@ class StatefulRiskInput(BaseModel):
         description="Optional client identifier used for upstream data access policy controls.",
         json_schema_extra={"example": "CLIENT_1000123"},
     )
+    benchmark_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional benchmark override for benchmark-dependent stateful metrics. When omitted, "
+            "lotus-performance resolves the portfolio benchmark assignment."
+        ),
+        json_schema_extra={"example": "BMK_PB_GLOBAL_BALANCED_60_40"},
+    )
     net_or_gross: Literal["NET", "GROSS"] = Field(
         default="NET",
         description="Whether sourced returns are evaluated on net or gross basis.",
@@ -339,6 +347,7 @@ class RiskAnalyticsRequest(BaseModel):
                 "as_of_date": "2026-02-27",
                 "reporting_currency": "USD",
                 "client_id": "CLIENT_1000123",
+                "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                 "periods": [{"type": "YTD", "name": "YTD"}],
                 "metrics": ["VOLATILITY", "BETA", "TRACKING_ERROR", "INFORMATION_RATIO"],
                 "options": {

--- a/src/app/services/risk_mode_adapter.py
+++ b/src/app/services/risk_mode_adapter.py
@@ -50,6 +50,7 @@ def _build_stateful_source_request(stateful: StatefulRiskInput) -> dict[str, Any
         metric_basis=stateful.net_or_gross,
         reporting_currency=stateful.reporting_currency,
         include_benchmark=include_benchmark,
+        benchmark_id=stateful.benchmark_id,
         include_risk_free=include_risk_free,
         missing_data_policy="ALLOW_PARTIAL",
     )

--- a/src/app/services/stateful_returns_request.py
+++ b/src/app/services/stateful_returns_request.py
@@ -18,8 +18,9 @@ def build_stateful_returns_series_request(
     include_benchmark: bool,
     include_risk_free: bool,
     missing_data_policy: Literal["ALLOW_PARTIAL", "FAIL_FAST"],
+    benchmark_id: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    request: dict[str, Any] = {
         "portfolio_id": portfolio_id,
         "as_of_date": as_of_date.isoformat(),
         "window": build_returns_series_window(
@@ -42,3 +43,9 @@ def build_stateful_returns_series_request(
         "input_mode": "stateful",
         "stateful_input": {},
     }
+    if include_benchmark and benchmark_id:
+        request["benchmark"] = {
+            "benchmark_id": benchmark_id,
+            "return_source": "calculated",
+        }
+    return request

--- a/tests/integration/test_risk_calculate.py
+++ b/tests/integration/test_risk_calculate.py
@@ -313,6 +313,7 @@ def test_risk_calculate_stateful_mode_uses_lotus_performance_returns_series() ->
                 "stateful_input": {
                     "portfolio_id": "DEMO_DPM_EUR_001",
                     "as_of_date": "2025-01-07",
+                    "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
                     "net_or_gross": "NET",
                     "periods": [{"type": "YTD", "name": "YTD"}],
                     "metrics": ["VOLATILITY", "BETA"],
@@ -334,6 +335,10 @@ def test_risk_calculate_stateful_mode_uses_lotus_performance_returns_series() ->
         "include_portfolio": True,
         "include_benchmark": True,
         "include_risk_free": False,
+    }
+    assert payload["benchmark"] == {
+        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+        "return_source": "calculated",
     }
     assert performance_client.calls[0]["correlation_id"] == "corr-risk-stateful"
     body = response.json()

--- a/tests/unit/test_risk_mode_adapter_characterization.py
+++ b/tests/unit/test_risk_mode_adapter_characterization.py
@@ -58,6 +58,23 @@ def test_stateful_source_payload_requests_risk_free_for_sharpe() -> None:
     assert payload["series_selection"]["include_risk_free"] is True
 
 
+def test_stateful_source_payload_passes_benchmark_override_for_relative_metrics() -> None:
+    stateful = _stateful_input().model_copy(
+        update={
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+            "metrics": ["TRACKING_ERROR"],
+        }
+    )
+
+    payload = _build_stateful_source_request(stateful)
+
+    assert payload["series_selection"]["include_benchmark"] is True
+    assert payload["benchmark"] == {
+        "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+        "return_source": "calculated",
+    }
+
+
 def test_calculate_risk_stateful_characterization() -> None:
     performance_client = RecordingLotusPerformanceClient(
         response_payload=build_returns_series_response(

--- a/tests/unit/test_stateful_returns_request.py
+++ b/tests/unit/test_stateful_returns_request.py
@@ -18,6 +18,7 @@ def test_build_stateful_returns_series_request_shapes_common_contract() -> None:
         reporting_currency="USD",
         include_benchmark=True,
         include_risk_free=True,
+        benchmark_id="BMK_PB_GLOBAL_BALANCED_60_40",
         missing_data_policy="ALLOW_PARTIAL",
     )
 
@@ -36,6 +37,10 @@ def test_build_stateful_returns_series_request_shapes_common_contract() -> None:
             "include_portfolio": True,
             "include_benchmark": True,
             "include_risk_free": True,
+        },
+        "benchmark": {
+            "benchmark_id": "BMK_PB_GLOBAL_BALANCED_60_40",
+            "return_source": "calculated",
         },
         "data_policy": {
             "missing_data_policy": "ALLOW_PARTIAL",


### PR DESCRIPTION
## Summary
- adds stateful_input.benchmark_id to the risk calculate contract
- forwards benchmark overrides to lotus-performance returns-series when benchmark-dependent metrics are requested
- documents the stateful benchmark override and validates request shaping

## Validation
- make check
- make openapi-gate api-vocabulary-gate domain-data-product-gate
- live POST /analytics/risk/calculate on 127.0.0.1:8131 with PB_SG_GLOBAL_BAL_001 and BMK_PB_GLOBAL_BALANCED_60_40 returned 72 aligned benchmark observations plus beta, tracking error, and information ratio