### PR TITLE
Normalize risk period vocabulary

### DIFF
--- a/docs/domain-apis/risk-calculate.md
+++ b/docs/domain-apis/risk-calculate.md
@@ -45,10 +45,11 @@
   - `reporting_currency?: str`
   - `net_or_gross: "NET" | "GROSS"`
 - `stateless_input.periods[]`
-  - `type: EXPLICIT|YEAR|MTD|QTD|YTD|ONE_YEAR|THREE_YEAR|FIVE_YEAR|SI`
+  - `type: EXPLICIT|YEAR|MTD|QTD|YTD|1Y|3Y|5Y|SI`
   - `name?: str`
   - `from_date?/to_date?` (required for `EXPLICIT`)
   - `year?` (required for `YEAR`)
+  - legacy aliases `ONE_YEAR`, `THREE_YEAR`, `FIVE_YEAR`, and `ITD` are accepted and normalized at the API boundary
 - `stateless_input.metrics[]`
   - `VOLATILITY|DRAWDOWN|SHARPE|SORTINO|BETA|TRACKING_ERROR|INFORMATION_RATIO|VAR`
 - `stateless_input.options`

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -34,18 +34,6 @@
       "review_by": "2026-10-10"
     },
     {
-      "finding": "src/app/contracts/risk.py:177:value: float = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-10"
-    },
-    {
-      "finding": "src/app/contracts/risk.py:386:value: float | None = Field(",
-      "justification": "Temporary approved monetary float usage; migrate to Decimal.",
-      "owner": "platform-governance",
-      "review_by": "2026-10-20"
-    },
-    {
       "finding": "src/app/services/attribution_engine.py:103:total_value: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",

--- a/docs/standards/risk-analytics-contract.md
+++ b/docs/standards/risk-analytics-contract.md
@@ -30,14 +30,15 @@
 ## Supported Period Types
 - `EXPLICIT`: requires `from/to` (`fromDate` and `toDate` also supported).
 - `YEAR`: requires `year`.
-- Standard: `MTD`, `QTD`, `YTD`, `ONE_YEAR`, `THREE_YEAR`, `FIVE_YEAR`, `SI`.
+- Canonical: `MTD`, `QTD`, `YTD`, `1Y`, `3Y`, `5Y`, `SI`.
 
 ## Compatibility Normalization
 - Accepted aliases normalized internally:
 - `CUSTOM` -> `EXPLICIT`
-- `1Y` -> `ONE_YEAR`
-- `3Y` -> `THREE_YEAR`
-- `5Y` -> `FIVE_YEAR`
+- `ONE_YEAR` -> `1Y`
+- `THREE_YEAR` -> `3Y`
+- `FIVE_YEAR` -> `5Y`
+- `ITD` -> `SI`
 
 ## VaR Methods
 - `HISTORICAL`

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -199,9 +199,11 @@ class ReturnPoint(BaseModel):
         description="Date of return observation.",
         json_schema_extra={"example": "2025-01-02"},
     )
-    value: float = Field(  # monetary-float-allow: return observation in percentage points, not money.
-        description="Return value in percentage points.",
-        json_schema_extra={"example": 0.85},
+    value: float = (  # monetary-float-allow: return observation in percentage points, not money.
+        Field(
+            description="Return value in percentage points.",
+            json_schema_extra={"example": 0.85},
+        )
     )
 
 

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -199,7 +199,7 @@ class ReturnPoint(BaseModel):
         description="Date of return observation.",
         json_schema_extra={"example": "2025-01-02"},
     )
-    value: float = Field(
+    value: float = Field(  # monetary-float-allow: return observation in percentage points, not money.
         description="Return value in percentage points.",
         json_schema_extra={"example": 0.85},
     )
@@ -408,7 +408,7 @@ RiskCalculationRequest = StatelessRiskInput
 
 
 class RiskValue(BaseModel):
-    value: float | None = Field(
+    value: float | None = Field(  # monetary-float-allow: risk metric value, not money.
         default=None,
         description="Computed metric value.",
         json_schema_extra={"example": 0.1234},

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 from enum import Enum
-from typing import Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -44,19 +44,33 @@ class RiskRequestScope(BaseModel):
 
 
 class RiskRequestPeriod(BaseModel):
+    PERIOD_ALIASES: ClassVar[dict[str, str]] = {
+        "ONE_YEAR": "1Y",
+        "THREE_YEAR": "3Y",
+        "FIVE_YEAR": "5Y",
+        "ITD": "SI",
+    }
+
     type: Literal[
         "EXPLICIT",
         "YEAR",
         "MTD",
         "QTD",
         "YTD",
+        "1Y",
+        "3Y",
+        "5Y",
         "ONE_YEAR",
         "THREE_YEAR",
         "FIVE_YEAR",
         "SI",
     ] = Field(
-        description="Period type used for metric aggregation.",
-        json_schema_extra={"example": "EXPLICIT"},
+        description=(
+            "Period type used for metric aggregation. Prefer canonical values "
+            "EXPLICIT, YEAR, MTD, QTD, YTD, 1Y, 3Y, 5Y, and SI. Legacy aliases "
+            "ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD are accepted and normalized."
+        ),
+        json_schema_extra={"example": "3Y"},
     )
     name: str | None = Field(
         default=None,
@@ -78,6 +92,17 @@ class RiskRequestPeriod(BaseModel):
         description="Calendar year (required when type=YEAR).",
         json_schema_extra={"example": 2025},
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_period_aliases(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            period_type = data.get("type")
+            if isinstance(period_type, str):
+                normalized_type = cls.PERIOD_ALIASES.get(period_type, period_type)
+                if normalized_type != period_type:
+                    return {**data, "type": normalized_type}
+        return data
 
     @model_validator(mode="after")
     def validate_semantics(self) -> "RiskRequestPeriod":

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -808,7 +808,8 @@ async def analytics_risk_rolling_metrics(
     tags=["risk-analytics"],
     description=(
         "Calculates risk metrics from provided return series using stateless or stateful input modes. "
-        "Supports EXPLICIT/YEAR/MTD/QTD/YTD/ONE_YEAR/THREE_YEAR/FIVE_YEAR/SI periods, "
+        "Supports EXPLICIT/YEAR/MTD/QTD/YTD/1Y/3Y/5Y/SI periods, with legacy "
+        "ONE_YEAR/THREE_YEAR/FIVE_YEAR aliases normalized at the boundary. "
         "all VaR methods (HISTORICAL/GAUSSIAN/CORNISH_FISHER), and benchmark-aware metrics."
     ),
 )

--- a/src/app/services/risk_engine.py
+++ b/src/app/services/risk_engine.py
@@ -63,11 +63,11 @@ def _resolve_period(
         start, end = date(as_of.year, quarter_start_month, 1), as_of
     elif period_type == "MTD":
         start, end = date(as_of.year, as_of.month, 1), as_of
-    elif period_type == "ONE_YEAR":
+    elif period_type == "1Y":
         start, end = as_of - timedelta(days=365) + timedelta(days=1), as_of
-    elif period_type == "THREE_YEAR":
+    elif period_type == "3Y":
         start, end = as_of - timedelta(days=365 * 3) + timedelta(days=1), as_of
-    elif period_type == "FIVE_YEAR":
+    elif period_type == "5Y":
         start, end = as_of - timedelta(days=365 * 5) + timedelta(days=1), as_of
     elif period_type == "SI":
         start, end = open_date, as_of

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -272,6 +272,22 @@ def test_e2e_risk_calculate_happy_path() -> None:
     assert metrics["VAR"]["value"] is not None
 
 
+def test_e2e_risk_calculate_accepts_canonical_rolling_periods() -> None:
+    client = TestClient(app)
+    payload = _risk_payload()
+    stateless_input = payload["stateless_input"]
+    assert isinstance(stateless_input, dict)
+    stateless_input["periods"] = [{"type": "1Y"}, {"type": "3Y"}]
+
+    response = client.post("/analytics/risk/calculate", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert set(body["results"]) == {"1Y", "3Y"}
+    assert body["results"]["1Y"]["metrics"]["VOLATILITY"]["value"] is not None
+    assert body["results"]["3Y"]["metrics"]["VAR"]["value"] is not None
+
+
 def test_e2e_risk_calculate_stateful_mode() -> None:
     performance_client = RecordingLotusPerformanceClient(
         response_payload=build_returns_series_response(

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -40,12 +40,16 @@ def test_period_explicit_canonical_fields() -> None:
     assert str(period.to_date) == "2025-01-31"
 
 
-def test_period_rejects_non_canonical_alias_type() -> None:
-    try:
-        RiskRequestPeriod.model_validate({"type": "1Y"})
-        assert False, "Expected validation error"
-    except Exception as exc:
-        assert "Input should be" in str(exc)
+def test_period_accepts_canonical_trailing_year_type() -> None:
+    period = RiskRequestPeriod.model_validate({"type": "1Y"})
+
+    assert period.type == "1Y"
+
+
+def test_period_normalizes_legacy_trailing_year_alias_type() -> None:
+    period = RiskRequestPeriod.model_validate({"type": "THREE_YEAR"})
+
+    assert period.type == "3Y"
 
 
 def test_period_validation_rejects_missing_explicit_bounds() -> None:

--- a/tests/unit/test_risk_engine_branch_coverage.py
+++ b/tests/unit/test_risk_engine_branch_coverage.py
@@ -17,9 +17,9 @@ def _payload_all_metrics() -> dict[str, object]:
             {"type": "MTD", "name": "MTD"},
             {"type": "QTD", "name": "QTD"},
             {"type": "YTD", "name": "YTD"},
-            {"type": "ONE_YEAR", "name": "1Y"},
-            {"type": "THREE_YEAR", "name": "3Y"},
-            {"type": "FIVE_YEAR", "name": "5Y"},
+            {"type": "1Y", "name": "1Y"},
+            {"type": "3Y", "name": "3Y"},
+            {"type": "5Y", "name": "5Y"},
             {"type": "SI", "name": "SI"},
             {"type": "YEAR", "name": "Y2025", "year": 2025},
             {

--- a/tests/unit/test_stateful_returns_request.py
+++ b/tests/unit/test_stateful_returns_request.py
@@ -141,3 +141,25 @@ def test_build_stateful_returns_series_request_uses_longest_explicit_window_acro
         "from_date": "2026-01-01",
         "to_date": "2026-03-31",
     }
+
+
+def test_build_stateful_returns_series_request_resolves_canonical_three_year_period() -> None:
+    periods = [RiskRequestPeriod.model_validate({"type": "3Y", "name": "3Y"})]
+
+    payload = build_stateful_returns_series_request(
+        portfolio_id="PB_SG_GLOBAL_BAL_001",
+        as_of_date=date(2026, 3, 31),
+        periods=periods,
+        frequency="DAILY",
+        metric_basis="NET",
+        reporting_currency="USD",
+        include_benchmark=True,
+        include_risk_free=True,
+        missing_data_policy="ALLOW_PARTIAL",
+    )
+
+    assert payload["window"] == {
+        "mode": "EXPLICIT",
+        "from_date": "2023-04-02",
+        "to_date": "2026-03-31",
+    }


### PR DESCRIPTION
## Summary
- accept canonical 1Y, 3Y, 5Y, and SI period values in risk contracts
- normalize legacy ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD aliases at the API model boundary
- calculate risk windows using canonical period values and update live-facing docs
- clarify non-monetary analytics `value` fields so monetary-float governance is stable and truthful
- add e2e coverage for canonical rolling-period vocabulary through the public risk calculation endpoint

## Validation
- make lint
- make typecheck
- make monetary-float-guard
- make test-pyramid-gate
- python -m pytest tests/e2e/test_smoke.py::test_e2e_risk_calculate_accepts_canonical_rolling_periods -q
- python -m pytest tests/unit/test_risk_engine.py tests/unit/test_risk_engine_branch_coverage.py tests/unit/test_stateful_returns_request.py tests/unit/test_source_window.py -q
- python -m pytest tests/unit/test_risk_engine.py tests/unit/test_stateful_returns_request.py -q
- python scripts/openapi_quality_gate.py
- python scripts/no_alias_contract_guard.py
- python -m mypy --config-file mypy.ini src/app/contracts/risk.py src/app/services/risk_engine.py tests/unit/test_risk_engine.py tests/unit/test_stateful_returns_request.py
- python -m mypy --config-file mypy.ini src/app/contracts/risk.py src/app/services/risk_engine.py tests/unit/test_risk_engine.py tests/unit/test_risk_engine_branch_coverage.py tests/unit/test_stateful_returns_request.py