### PR TITLE
Implement RFC-0108 risk supportability metrics

### DIFF
--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -36,6 +36,7 @@
   - `risk.analytics.rolling_metrics`
   - `risk.analytics.historical_attribution`
   - `risk.analytics.metrics`
+  - `risk.observability.calculation_supportability`
 - `workflows`:
   - `risk_snapshot`
   - `drawdown_analytics`
@@ -81,6 +82,10 @@ This allows consumers to discover that:
   - vocabulary is centralized in constants to reduce drift.
   - workflow-level mode support is explicit enough for gateway and Workbench surfaces to avoid
     unsupported simulation and issuer active-risk affordances.
+  - risk calculation supportability is implementation-backed by
+    `metadata.calculation_supportability` and
+    `lotus_risk_calculation_supportability_total`, so downstream consumers can distinguish ready,
+    stale, degraded, and empty risk results without inspecting sensitive request context.
 - Gaps:
   - endpoint remains globally published and does not expose consumer- or tenant-shaped query controls.
   - some downstream callers still send advisory query params for cross-service parity; that drift should

--- a/docs/domain-apis/risk-calculate.md
+++ b/docs/domain-apis/risk-calculate.md
@@ -95,6 +95,14 @@
   - applied frequency / annualization / log-return / risk-free / VaR settings
   - `risk_free_context` (`requested`, `applied`, `reason`, `periodic_rate`)
   - `benchmark_context` (`requested`, `requested_metrics`)
+  - `calculation_supportability`
+    - `state`: `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, or
+      `unsupported`
+    - `reason`: bounded cause such as `calculation_complete`, `benchmark_unavailable`,
+      `insufficient_aligned_observations`, `insufficient_observations`,
+      `no_return_observations`, or `stale_source_observations`
+    - `freshness_bucket`: `current`, `same_day`, `stale`, or `unknown`
+    - `degraded_metric_count`, `empty_period_count`, `evaluated_period_count`
 - `results` map keyed by period name/type:
   - `start_date`
   - `end_date`
@@ -118,6 +126,8 @@
 - API mode support: finalized for current scope (`stateless` + `stateful` only; `simulation` intentionally unsupported).
 - Cross-service integration posture: integrated with `lotus-performance` for stateful return sourcing.
 - Naming/vocabulary: aligned with canonical `client_id` naming and RFC-0067 guardrails.
+- Supportability posture: implemented for `risk/calculate` and mirrored in bounded Prometheus
+  metric labels through `lotus_risk_calculation_supportability_total`.
 
 ## Gaps and Decisions Required
 

--- a/docs/domain-apis/risk-observability.md
+++ b/docs/domain-apis/risk-observability.md
@@ -37,6 +37,31 @@ from deterministic upstream error classification, for example:
 5. `data_gap`,
 6. `invalid_response`.
 
+## Calculation Supportability Metrics
+
+| Metric | Labels | Meaning |
+| --- | --- | --- |
+| `lotus_risk_calculation_supportability_total` | `operation`, `supportability_state`, `reason`, `freshness_bucket` | Count of risk calculation supportability outcomes using the same bounded posture emitted in `metadata.calculation_supportability`. |
+
+The supported states are `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, and
+`unsupported`. The first implemented Slice 12 operation is `risk/calculate`; the labels are bounded
+and intentionally exclude portfolio, client, account, position, transaction, trace, correlation, and
+request identifiers.
+
+The calculation response now includes `metadata.calculation_supportability` so Gateway and
+Workbench can consume source-backed supportability posture without inferring it from individual
+metric errors. Current reason values include:
+
+1. `calculation_complete`,
+2. `benchmark_unavailable`,
+3. `calculation_quality_issue`,
+4. `insufficient_aligned_observations`,
+5. `insufficient_observations`,
+6. `no_return_observations`,
+7. `permission_blocked`,
+8. `stale_source_observations`,
+9. `unsupported_input_mode`.
+
 ## Operator Use
 
 Use endpoint metrics to answer:
@@ -50,6 +75,14 @@ Use upstream metrics to answer:
 1. which dependency is slow or failing,
 2. whether failures are retryable infrastructure failures or deterministic data gaps,
 3. which upstream operation is responsible for degraded stateful analytics.
+
+Use calculation supportability metrics to answer:
+
+1. whether UI-facing risk results are ready, stale, degraded, or empty,
+2. whether degradation is caused by source freshness, missing benchmarks, sparse observations, or
+   calculation-quality guardrails,
+3. whether a support incident affects calculations broadly without exposing sensitive identifiers in
+   Prometheus labels.
 
 Correlation IDs are still the request-level trace handle. Metrics are aggregate signals and should
 be used with audit-lineage metadata and structured errors for investigation.

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-19T05:13:25.970324+00:00",
+  "generatedAt": "2026-04-29T08:51:34.345691+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.alignment_policy",
@@ -171,6 +171,22 @@
       ],
       "observedTypes": [
         "BenchmarkDrawdownPolicy"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_supportability",
+      "canonicalTerm": "calculation_supportability",
+      "preferredName": "calculation_supportability",
+      "description": "Canonical calculation supportability used by lotus-risk APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "RiskCalculationSupportability",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "RiskCalculationSupportability"
       ]
     },
     {
@@ -495,6 +511,20 @@
       ]
     },
     {
+      "semanticId": "lotus.degraded_metric_count",
+      "canonicalTerm": "degraded_metric_count",
+      "preferredName": "degraded_metric_count",
+      "description": "Number of requested metric results carrying deterministic error details.",
+      "example": 0,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.dependencies",
       "canonicalTerm": "dependencies",
       "preferredName": "dependencies",
@@ -594,6 +624,20 @@
       ]
     },
     {
+      "semanticId": "lotus.empty_period_count",
+      "canonicalTerm": "empty_period_count",
+      "preferredName": "empty_period_count",
+      "description": "Number of response periods with no portfolio observations.",
+      "example": 0,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.enabled",
       "canonicalTerm": "enabled",
       "preferredName": "enabled",
@@ -636,6 +680,20 @@
       ]
     },
     {
+      "semanticId": "lotus.evaluated_period_count",
+      "canonicalTerm": "evaluated_period_count",
+      "preferredName": "evaluated_period_count",
+      "description": "Number of periods evaluated in this response.",
+      "example": 1,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
+      ]
+    },
+    {
       "semanticId": "lotus.failure_posture",
       "canonicalTerm": "failure_posture",
       "preferredName": "failure_posture",
@@ -674,6 +732,20 @@
       "preferredName": "frequency",
       "description": "Applied return sampling frequency.",
       "example": "DAILY",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.freshness_bucket",
+      "canonicalTerm": "freshness_bucket",
+      "preferredName": "freshness_bucket",
+      "description": "Bounded source freshness bucket based on the latest return observation.",
+      "example": "current",
       "type": "string",
       "locations": [
         "body"
@@ -1712,6 +1784,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.state",
+      "canonicalTerm": "state",
+      "preferredName": "state",
+      "description": "Bounded supportability state for the risk calculation payload.",
+      "example": "ready",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -4719,6 +4805,62 @@
             "type": "array",
             "semanticId": "lotus.requested_metrics",
             "attributeRef": "#/attributeCatalog/lotus.requested_metrics"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": false,
+            "type": "RiskCalculationSupportability",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          },
+          {
+            "name": "metadata.calculation_supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "metadata.calculation_supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "metadata.calculation_supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "metadata.calculation_supportability.degraded_metric_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.degraded_metric_count",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_metric_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.empty_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.empty_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.empty_period_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.evaluated_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.evaluated_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.evaluated_period_count"
           },
           {
             "name": "metadata.mar_annual_rate",

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -154,13 +154,13 @@
       "review_by": "2026-10-10"
     },
     {
-      "finding": "src/app/services/risk_engine.py:120:peak_value = _as_number(cast(float, peak.loc[trough_idx]))",
+      "finding": "src/app/services/risk_engine.py:124:peak_value = _as_number(cast(float, peak.loc[trough_idx]))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-10"
     },
     {
-      "finding": "src/app/services/risk_engine.py:182:def _expected_shortfall(returns: pd.Series, var_value: float) -> float:",
+      "finding": "src/app/services/risk_engine.py:186:def _expected_shortfall(returns: pd.Series, var_value: float) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-10"

--- a/docs/standards/risk-analytics-contract.md
+++ b/docs/standards/risk-analytics-contract.md
@@ -20,6 +20,7 @@
   - `risk.analytics.historical_attribution`
   - `risk.analytics.concentration`
   - `risk.analytics.metrics`
+  - `risk.observability.calculation_supportability`
 - `workflows`:
   - `risk_snapshot`
   - `drawdown_analytics`
@@ -52,6 +53,18 @@
 - If benchmark returns are missing, API returns deterministic metric payloads:
 - `value: null`
 - `details.error: "Benchmark returns required for benchmark-dependent metric"`
+
+## Calculation Supportability
+- `POST /analytics/risk/calculate` emits `metadata.calculation_supportability`.
+- Supported states: `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, `unsupported`.
+- Supported freshness buckets: `current`, `same_day`, `stale`, `unknown`.
+- Supported reasons include `calculation_complete`, `benchmark_unavailable`, `calculation_quality_issue`,
+  `insufficient_aligned_observations`, `insufficient_observations`, `no_return_observations`,
+  `permission_blocked`, `stale_source_observations`, and `unsupported_input_mode`.
+- Prometheus exports the same posture through `lotus_risk_calculation_supportability_total` with
+  bounded labels only: `operation`, `supportability_state`, `reason`, and `freshness_bucket`.
+- Metrics and response metadata must not expose portfolio, client, account, position, transaction,
+  trace, correlation, or raw request identifiers.
 
 ## Risk Calculate Mode Support
 - `stateless`: caller supplies full return series.

--- a/src/app/contracts/capabilities.py
+++ b/src/app/contracts/capabilities.py
@@ -11,6 +11,7 @@ CAPABILITY_FEATURE_KEYS: tuple[str, ...] = (
     "risk.analytics.rolling_metrics",
     "risk.analytics.historical_attribution",
     "risk.analytics.metrics",
+    "risk.observability.calculation_supportability",
 )
 CAPABILITY_WORKFLOW_KEYS: tuple[str, ...] = (
     "risk_snapshot",

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -18,6 +18,27 @@ RiskMetric = Literal[
     "INFORMATION_RATIO",
     "VAR",
 ]
+RiskSupportabilityState = Literal[
+    "ready",
+    "stale",
+    "degraded",
+    "empty",
+    "error",
+    "permission_blocked",
+    "unsupported",
+]
+RiskSupportabilityReason = Literal[
+    "calculation_complete",
+    "benchmark_unavailable",
+    "calculation_quality_issue",
+    "insufficient_aligned_observations",
+    "insufficient_observations",
+    "no_return_observations",
+    "permission_blocked",
+    "stale_source_observations",
+    "unsupported_input_mode",
+]
+RiskFreshnessBucket = Literal["current", "same_day", "stale", "unknown"]
 
 
 class RiskInputMode(str, Enum):
@@ -512,6 +533,39 @@ class BenchmarkRequestContext(BaseModel):
     )
 
 
+class RiskCalculationSupportability(BaseModel):
+    state: RiskSupportabilityState = Field(
+        description="Bounded supportability state for the risk calculation payload.",
+        json_schema_extra={"example": "ready"},
+    )
+    reason: RiskSupportabilityReason = Field(
+        description="Bounded supportability reason that is safe for UI and operator metrics.",
+        json_schema_extra={"example": "calculation_complete"},
+    )
+    freshness_bucket: RiskFreshnessBucket = Field(
+        description="Bounded source freshness bucket based on the latest return observation.",
+        json_schema_extra={"example": "current"},
+    )
+    degraded_metric_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of requested metric results carrying deterministic error details.",
+        json_schema_extra={"example": 0},
+    )
+    empty_period_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of response periods with no portfolio observations.",
+        json_schema_extra={"example": 0},
+    )
+    evaluated_period_count: int = Field(
+        default=0,
+        ge=0,
+        description="Number of periods evaluated in this response.",
+        json_schema_extra={"example": 1},
+    )
+
+
 class RiskResponseMetadata(AuditMetadataFields):
     contract_version: str = Field(
         default="v1",
@@ -567,6 +621,24 @@ class RiskResponseMetadata(AuditMetadataFields):
             "example": {
                 "requested": True,
                 "requested_metrics": ["BETA", "TRACKING_ERROR", "INFORMATION_RATIO"],
+            }
+        },
+    )
+    calculation_supportability: RiskCalculationSupportability = Field(
+        default_factory=lambda: RiskCalculationSupportability(
+            state="ready",
+            reason="calculation_complete",
+            freshness_bucket="unknown",
+        ),
+        description="Source-backed supportability posture for UI and operator consumption.",
+        json_schema_extra={
+            "example": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "current",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
             }
         },
     )

--- a/src/app/observability.py
+++ b/src/app/observability.py
@@ -25,6 +25,11 @@ UPSTREAM_REQUEST_SECONDS = Histogram(
     "Upstream dependency request duration by dependency, operation, outcome, and failure category.",
     ["dependency", "operation", "outcome", "category"],
 )
+CALCULATION_SUPPORTABILITY_TOTAL = Counter(
+    "lotus_risk_calculation_supportability_total",
+    "Risk calculation supportability posture by bounded operation, state, reason, and freshness bucket.",
+    ["operation", "supportability_state", "reason", "freshness_bucket"],
+)
 
 
 def observation_start() -> float:
@@ -72,3 +77,18 @@ def record_upstream_request(
         outcome=outcome,
         category=category,
     ).observe(elapsed)
+
+
+def record_calculation_supportability(
+    *,
+    operation: str,
+    supportability_state: str,
+    reason: str,
+    freshness_bucket: str,
+) -> None:
+    CALCULATION_SUPPORTABILITY_TOTAL.labels(
+        operation=operation,
+        supportability_state=supportability_state,
+        reason=reason,
+        freshness_bucket=freshness_bucket,
+    ).inc()

--- a/src/app/services/risk_engine.py
+++ b/src/app/services/risk_engine.py
@@ -11,13 +11,17 @@ from prometheus_client import Counter, Histogram
 
 from app.contracts.risk import (
     BenchmarkRequestContext,
+    RiskCalculationSupportability,
+    RiskFreshnessBucket,
     RiskFreeContext,
     RiskPeriodResult,
     RiskResponseMetadata,
     RiskResponse,
     RiskStatelessCalculationInput,
+    RiskSupportabilityReason,
     RiskValue,
 )
+from app.observability import record_calculation_supportability
 from app.services.audit_lineage import fingerprint_model
 
 RISK_METRIC_REQUESTED_TOTAL = Counter(
@@ -282,6 +286,7 @@ def _build_metadata(
     *,
     annual_factor: int,
     periodic_rf: float,
+    calculation_supportability: RiskCalculationSupportability,
 ) -> RiskResponseMetadata:
     risk_free_requested = "SHARPE" in request.metrics
     benchmark_metrics = [str(metric) for metric in request.metrics if metric in BENCHMARK_METRICS]
@@ -311,10 +316,102 @@ def _build_metadata(
             requested=bool(benchmark_metrics),
             requested_metrics=benchmark_metrics,
         ),
+        calculation_supportability=calculation_supportability,
         mar_annual_rate=request.options.mar_annual_rate,
         var_method=request.options.var.method,
         var_confidence=request.options.var.confidence,
         var_horizon_days=request.options.var.horizon_days,
+    )
+
+
+def _freshness_bucket(request: RiskStatelessCalculationInput) -> RiskFreshnessBucket:
+    if not request.returns:
+        return "unknown"
+    latest_observation_date = max(point.date for point in request.returns)
+    age_days = (request.scope.as_of_date - latest_observation_date).days
+    if age_days <= 0:
+        return "current"
+    if age_days <= 1:
+        return "same_day"
+    return "stale"
+
+
+def _supportability_reason_for_error(error: str) -> RiskSupportabilityReason:
+    if error == "Benchmark returns required for benchmark-dependent metric":
+        return "benchmark_unavailable"
+    if error == "Insufficient aligned observations":
+        return "insufficient_aligned_observations"
+    if error == "Insufficient data":
+        return "insufficient_observations"
+    return "calculation_quality_issue"
+
+
+def _resolve_calculation_supportability(
+    request: RiskStatelessCalculationInput,
+    results: dict[str, RiskPeriodResult],
+) -> RiskCalculationSupportability:
+    freshness_bucket = _freshness_bucket(request)
+    if not request.returns:
+        return RiskCalculationSupportability(
+            state="empty",
+            reason="no_return_observations",
+            freshness_bucket=freshness_bucket,
+            evaluated_period_count=len(results),
+        )
+
+    degraded_reasons: list[RiskSupportabilityReason] = []
+    empty_period_count = 0
+    degraded_metric_count = 0
+    for period_result in results.values():
+        if period_result.portfolio_observation_count == 0:
+            empty_period_count += 1
+        for metric_result in period_result.metrics.values():
+            error = (metric_result.details or {}).get("error")
+            if isinstance(error, str):
+                degraded_metric_count += 1
+                degraded_reasons.append(_supportability_reason_for_error(error))
+
+    if degraded_metric_count:
+        reason_order: tuple[RiskSupportabilityReason, ...] = (
+            "benchmark_unavailable",
+            "insufficient_aligned_observations",
+            "insufficient_observations",
+            "calculation_quality_issue",
+        )
+        selected_reason: RiskSupportabilityReason = next(
+            reason for reason in reason_order if reason in set(degraded_reasons)
+        )
+        return RiskCalculationSupportability(
+            state="degraded",
+            reason=selected_reason,
+            freshness_bucket=freshness_bucket,
+            degraded_metric_count=degraded_metric_count,
+            empty_period_count=empty_period_count,
+            evaluated_period_count=len(results),
+        )
+
+    if empty_period_count:
+        return RiskCalculationSupportability(
+            state="empty",
+            reason="insufficient_observations",
+            freshness_bucket=freshness_bucket,
+            empty_period_count=empty_period_count,
+            evaluated_period_count=len(results),
+        )
+
+    if freshness_bucket == "stale":
+        return RiskCalculationSupportability(
+            state="stale",
+            reason="stale_source_observations",
+            freshness_bucket=freshness_bucket,
+            evaluated_period_count=len(results),
+        )
+
+    return RiskCalculationSupportability(
+        state="ready",
+        reason="calculation_complete",
+        freshness_bucket=freshness_bucket,
+        evaluated_period_count=len(results),
     )
 
 
@@ -332,10 +429,22 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
 
     returns_df = pd.DataFrame([{"date": p.date, "value": p.value} for p in request.returns])
     if returns_df.empty:
+        calculation_supportability = _resolve_calculation_supportability(request, {})
+        record_calculation_supportability(
+            operation="risk/calculate",
+            supportability_state=calculation_supportability.state,
+            reason=calculation_supportability.reason,
+            freshness_bucket=calculation_supportability.freshness_bucket,
+        )
         return RiskResponse(
             scope=request.scope,
             results={},
-            metadata=_build_metadata(request, annual_factor=annual_factor, periodic_rf=0.0),
+            metadata=_build_metadata(
+                request,
+                annual_factor=annual_factor,
+                periodic_rf=0.0,
+                calculation_supportability=calculation_supportability,
+            ),
         )
 
     returns_df["date"] = pd.to_datetime(returns_df["date"])
@@ -577,8 +686,20 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
             metrics=metric_map,
         )
 
+    calculation_supportability = _resolve_calculation_supportability(request, results)
+    record_calculation_supportability(
+        operation="risk/calculate",
+        supportability_state=calculation_supportability.state,
+        reason=calculation_supportability.reason,
+        freshness_bucket=calculation_supportability.freshness_bucket,
+    )
     return RiskResponse(
         scope=request.scope,
         results=results,
-        metadata=_build_metadata(request, annual_factor=annual_factor, periodic_rf=periodic_rf),
+        metadata=_build_metadata(
+            request,
+            annual_factor=annual_factor,
+            periodic_rf=periodic_rf,
+            calculation_supportability=calculation_supportability,
+        ),
     )

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -44,6 +44,7 @@ def test_integration_capabilities_contract() -> None:
         "risk.analytics.rolling_metrics",
         "risk.analytics.historical_attribution",
         "risk.analytics.metrics",
+        "risk.observability.calculation_supportability",
     }
     workflow_keys = {workflow["workflow_key"] for workflow in body["workflows"]}
     assert workflow_keys == {

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -49,6 +49,11 @@ def test_metrics_expose_endpoint_execution_mode_and_outcome() -> None:
     assert 'input_mode="stateless"' in metrics
     assert 'outcome="success"' in metrics
     assert "lotus_risk_endpoint_execution_seconds_bucket" in metrics
+    assert "lotus_risk_calculation_supportability_total{" in metrics
+    assert 'operation="risk/calculate"' in metrics
+    assert 'supportability_state="stale"' in metrics
+    assert 'reason="stale_source_observations"' in metrics
+    assert 'freshness_bucket="stale"' in metrics
 
 
 def test_metrics_expose_stateful_endpoint_execution_mode() -> None:

--- a/tests/unit/test_capabilities_contract.py
+++ b/tests/unit/test_capabilities_contract.py
@@ -10,7 +10,7 @@ from app.contracts.capabilities import (
 def test_capability_feature_keys_follow_risk_analytics_namespace() -> None:
     assert CAPABILITY_FEATURE_KEYS
     for key in CAPABILITY_FEATURE_KEYS:
-        assert key.startswith("risk.analytics.")
+        assert key.startswith(("risk.analytics.", "risk.observability."))
 
 
 def test_capability_workflow_keys_use_snake_case_domain_vocabulary() -> None:

--- a/tests/unit/test_risk_engine_branch_coverage.py
+++ b/tests/unit/test_risk_engine_branch_coverage.py
@@ -90,6 +90,10 @@ def test_engine_covers_all_period_types_and_benchmark_metrics() -> None:
     assert metrics["BETA"].value is not None
     assert metrics["TRACKING_ERROR"].value is not None
     assert metrics["INFORMATION_RATIO"].value is not None
+    assert response.metadata.calculation_supportability.state == "stale"
+    assert response.metadata.calculation_supportability.reason == "stale_source_observations"
+    assert response.metadata.calculation_supportability.freshness_bucket == "stale"
+    assert response.metadata.calculation_supportability.degraded_metric_count == 0
 
 
 def test_var_helper_unsupported_method_raises() -> None:
@@ -209,6 +213,10 @@ def test_risk_metrics_return_domain_errors_for_insufficient_data() -> None:
         "benchmark_returns": [{"date": "2025-01-02", "value": 0.4}],
     }
     response = risk_engine.calculate_risk(RiskCalculationRequest.model_validate(payload))
+    supportability = response.metadata.calculation_supportability
+    assert supportability.state == "degraded"
+    assert supportability.reason == "insufficient_aligned_observations"
+    assert supportability.degraded_metric_count == len(cast(list[str], payload["metrics"]))
     metrics = response.results["YTD"].metrics
     metric_names = cast(list[str], payload["metrics"])
     benchmark_aligned_metrics = {"BETA", "TRACKING_ERROR", "INFORMATION_RATIO"}
@@ -222,6 +230,44 @@ def test_risk_metrics_return_domain_errors_for_insufficient_data() -> None:
             else "Insufficient data"
         )
         assert metric.details["error"] == expected_error
+
+
+def test_risk_calculation_supportability_reports_empty_when_no_returns() -> None:
+    payload = {
+        "scope": {"as_of_date": "2025-03-31", "net_or_gross": "NET"},
+        "portfolio_open_date": "2024-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["VOLATILITY"],
+        "returns": [],
+    }
+
+    response = risk_engine.calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    assert response.results == {}
+    supportability = response.metadata.calculation_supportability
+    assert supportability.state == "empty"
+    assert supportability.reason == "no_return_observations"
+    assert supportability.freshness_bucket == "unknown"
+
+
+def test_risk_calculation_supportability_reports_stale_source_observations() -> None:
+    payload = {
+        "scope": {"as_of_date": "2025-03-31", "net_or_gross": "NET"},
+        "portfolio_open_date": "2024-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["VOLATILITY"],
+        "returns": [
+            {"date": "2025-01-02", "value": 0.5},
+            {"date": "2025-01-03", "value": -0.2},
+        ],
+    }
+
+    response = risk_engine.calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    supportability = response.metadata.calculation_supportability
+    assert supportability.state == "stale"
+    assert supportability.reason == "stale_source_observations"
+    assert supportability.freshness_bucket == "stale"
 
 
 def test_beta_and_information_ratio_guard_clauses() -> None:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -71,6 +71,16 @@ Use:
 4. `docs/operations/canonical-local-upstream-urls.md`
 5. `docs/operations/live-risk-validation-matrix.md`
 
+For `POST /analytics/risk/calculate`, response metadata includes
+`metadata.calculation_supportability`. Use it before inferring UI state from individual metric
+values. It reports bounded `ready`, `stale`, `degraded`, or `empty` posture, a bounded reason, and a
+freshness bucket. The matching Prometheus counter is
+`lotus_risk_calculation_supportability_total` with only bounded labels: `operation`,
+`supportability_state`, `reason`, and `freshness_bucket`.
+
+Do not add portfolio, client, account, position, transaction, trace, correlation, or request
+identifiers to supportability metric labels.
+
 When the question is "should this workflow be offered at all?" also check:
 
 1. `/integration/capabilities`


### PR DESCRIPTION
## Summary
- add source-backed risk/calculate supportability metadata and bounded Prometheus supportability metric
- publish risk.observability.calculation_supportability through capabilities
- update risk API/docs/wiki source for Slice 12 operator posture

## Validation
- python -m pytest tests\unit\test_risk_engine_branch_coverage.py tests\unit\test_capabilities_contract.py tests\integration\test_observability.py -q
- python -m ruff check src\app\observability.py src\app\contracts\capabilities.py src\app\contracts\risk.py src\app\services\risk_engine.py tests\unit\test_risk_engine_branch_coverage.py tests\unit\test_capabilities_contract.py tests\integration\test_observability.py
- python -m mypy src\app\observability.py src\app\contracts\capabilities.py src\app\contracts\risk.py src\app\services\risk_engine.py
- python scripts\openapi_quality_gate.py
- git diff --check

## Wiki
- repo-local wiki source updated: wiki/Operations-Runbook.md
- Sync-RepoWikis.ps1 -CheckOnly currently reports expected drift until this branch is merged and the wiki is published