### PR TITLE
Complete RFC-0108 risk supportability metadata

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -72,6 +72,10 @@ Boundary rules:
 4. supportability and evidence posture should remain truthful and data-backed,
 5. downstream consumers must preserve signed VaR semantics, attribution reconciliation fields, issuer active-risk gating, concentration-only simulation support, and audit lineage metadata as documented in `docs/domain-apis/risk-product-surface-alignment.md`,
 6. `lotus-core` must be consumed as a governed source-data, analytics-input, snapshot/simulation, and support-metadata authority, while `lotus-performance` remains the authority for performance return and benchmark exposure context inputs.
+7. RFC-0108 calculation supportability is source-owned in this repository across `risk/calculate`,
+   drawdown, rolling metrics, historical attribution, and concentration through
+   `metadata.calculation_supportability` plus bounded
+   `lotus_risk_calculation_supportability_total` labels.
 
 Canonical direct local validation ports:
 

--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -82,10 +82,11 @@ This allows consumers to discover that:
   - vocabulary is centralized in constants to reduce drift.
   - workflow-level mode support is explicit enough for gateway and Workbench surfaces to avoid
     unsupported simulation and issuer active-risk affordances.
-  - risk calculation supportability is implementation-backed by
-    `metadata.calculation_supportability` and
-    `lotus_risk_calculation_supportability_total`, so downstream consumers can distinguish ready,
-    stale, degraded, and empty risk results without inspecting sensitive request context.
+  - risk calculation supportability is implementation-backed across `risk/calculate`, drawdown,
+    rolling metrics, historical attribution, and concentration through
+    `metadata.calculation_supportability` and `lotus_risk_calculation_supportability_total`, so
+    downstream consumers can distinguish ready, stale, degraded, and empty risk results without
+    inspecting sensitive request context.
 - Gaps:
   - endpoint remains globally published and does not expose consumer- or tenant-shaped query controls.
   - some downstream callers still send advisory query params for cross-service parity; that drift should

--- a/docs/domain-apis/risk-observability.md
+++ b/docs/domain-apis/risk-observability.md
@@ -44,13 +44,14 @@ from deterministic upstream error classification, for example:
 | `lotus_risk_calculation_supportability_total` | `operation`, `supportability_state`, `reason`, `freshness_bucket` | Count of risk calculation supportability outcomes using the same bounded posture emitted in `metadata.calculation_supportability`. |
 
 The supported states are `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, and
-`unsupported`. The first implemented Slice 12 operation is `risk/calculate`; the labels are bounded
-and intentionally exclude portfolio, client, account, position, transaction, trace, correlation, and
-request identifiers.
+`unsupported`. Implemented operations are `risk/calculate`, `risk/drawdown`,
+`risk/rolling-metrics`, `risk/historical-attribution`, and `risk/concentration`; the labels are
+bounded and intentionally exclude portfolio, client, account, position, transaction, trace,
+correlation, and request identifiers.
 
-The calculation response now includes `metadata.calculation_supportability` so Gateway and
-Workbench can consume source-backed supportability posture without inferring it from individual
-metric errors. Current reason values include:
+The analytics responses include `metadata.calculation_supportability` so Gateway and Workbench can
+consume source-backed supportability posture without inferring it from individual metric errors,
+period errors, issuer coverage, or return-series recency. Current reason values include:
 
 1. `calculation_complete`,
 2. `benchmark_unavailable`,

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-29T08:51:34.345691+00:00",
+  "generatedAt": "2026-04-30T06:24:23.286167+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.alignment_policy",
@@ -514,7 +514,7 @@
       "semanticId": "lotus.degraded_metric_count",
       "canonicalTerm": "degraded_metric_count",
       "preferredName": "degraded_metric_count",
-      "description": "Number of requested metric results carrying deterministic error details.",
+      "description": "Number of requested metric or period results carrying deterministic error details.",
       "example": 0,
       "type": "integer",
       "locations": [
@@ -1369,8 +1369,8 @@
       "semanticId": "lotus.reason",
       "canonicalTerm": "reason",
       "preferredName": "reason",
-      "description": "Deterministic explanation of how risk-free configuration affected this response.",
-      "example": "ANNUAL_RATE_APPLIED",
+      "description": "Bounded supportability reason that is safe for UI and operator metrics.",
+      "example": "calculation_complete",
       "type": "string",
       "locations": [
         "body"
@@ -3561,6 +3561,62 @@
             "type": "string",
             "semanticId": "lotus.stateful_active_risk_gate_reason",
             "attributeRef": "#/attributeCatalog/lotus.stateful_active_risk_gate_reason"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": false,
+            "type": "RiskCalculationSupportability",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          },
+          {
+            "name": "metadata.calculation_supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "metadata.calculation_supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "metadata.calculation_supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "metadata.calculation_supportability.degraded_metric_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.degraded_metric_count",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_metric_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.empty_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.empty_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.empty_period_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.evaluated_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.evaluated_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.evaluated_period_count"
           }
         ]
       }
@@ -4311,6 +4367,62 @@
             "type": "object",
             "semanticId": "lotus.missing_benchmark_policy",
             "attributeRef": "#/attributeCatalog/lotus.missing_benchmark_policy"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": false,
+            "type": "RiskCalculationSupportability",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          },
+          {
+            "name": "metadata.calculation_supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "metadata.calculation_supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "metadata.calculation_supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "metadata.calculation_supportability.degraded_metric_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.degraded_metric_count",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_metric_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.empty_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.empty_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.empty_period_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.evaluated_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.evaluated_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.evaluated_period_count"
           }
         ]
       }
@@ -4566,6 +4678,62 @@
             "type": "array",
             "semanticId": "lotus.requested_metrics",
             "attributeRef": "#/attributeCatalog/lotus.requested_metrics"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": false,
+            "type": "RiskCalculationSupportability",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          },
+          {
+            "name": "metadata.calculation_supportability.state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.state",
+            "attributeRef": "#/attributeCatalog/lotus.state"
+          },
+          {
+            "name": "metadata.calculation_supportability.reason",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.reason",
+            "attributeRef": "#/attributeCatalog/lotus.reason"
+          },
+          {
+            "name": "metadata.calculation_supportability.freshness_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.freshness_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "metadata.calculation_supportability.degraded_metric_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.degraded_metric_count",
+            "attributeRef": "#/attributeCatalog/lotus.degraded_metric_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.empty_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.empty_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.empty_period_count"
+          },
+          {
+            "name": "metadata.calculation_supportability.evaluated_period_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.evaluated_period_count",
+            "attributeRef": "#/attributeCatalog/lotus.evaluated_period_count"
           }
         ]
       }

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,67 +1,67 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-23T02:03:36Z",
+  "generated_at": "2026-04-30T06:29:12Z",
   "allowlist": [
     {
-      "finding": "src/app/contracts/attribution.py:404:total_value: float | None = Field(",
+      "finding": "src/app/contracts/attribution.py:409:total_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/concentration.py:214:price: float | None = Field(",
+      "finding": "src/app/contracts/concentration.py:215:price: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/concentration.py:219:amount: float | None = Field(",
+      "finding": "src/app/contracts/concentration.py:220:amount: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/concentration.py:43:market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/concentration.py:44:market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/contracts/concentration.py:80:projected_market_value_base: float | None = Field(",
+      "finding": "src/app/contracts/concentration.py:81:projected_market_value_base: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:103:total_value: float,",
+      "finding": "src/app/services/attribution_engine.py:107:total_value: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:124:percent = float(component / total_value) if not np.isclose(total_value, 0.0) else None",
+      "finding": "src/app/services/attribution_engine.py:128:percent = float(component / total_value) if not np.isclose(total_value, 0.0) else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:179:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
+      "finding": "src/app/services/attribution_engine.py:183:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:207:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
+      "finding": "src/app/services/attribution_engine.py:211:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:239:residual = float(total_value - reconciled_sum)",
+      "finding": "src/app/services/attribution_engine.py:243:residual = float(total_value - reconciled_sum)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/services/attribution_mode_adapter.py:178:weight=float(value / total),",
@@ -70,106 +70,106 @@
       "review_by": "2026-10-10"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:172:value=float(candidate),",
+      "finding": "src/app/services/concentration_engine.py:176:value=float(candidate),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:186:value=float(candidate),",
+      "finding": "src/app/services/concentration_engine.py:190:value=float(candidate),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:299:def _round(value: float) -> float:",
+      "finding": "src/app/services/concentration_engine.py:303:def _round(value: float) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:531:numeric_value = float(candidate)",
+      "finding": "src/app/services/concentration_engine.py:548:numeric_value = float(candidate)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:80:value: float",
+      "finding": "src/app/services/concentration_engine.py:84:value: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/concentration_engine.py:87:value: float",
+      "finding": "src/app/services/concentration_engine.py:91:value: float",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:153:dar_value: float | None = None",
+      "finding": "src/app/services/drawdown_engine.py:156:dar_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:154:cdar_value: float | None = None",
+      "finding": "src/app/services/drawdown_engine.py:157:cdar_value: float | None = None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:156:dar_value = float(np.quantile(np.array(depths), 1.0 - alpha, method=\"linear\"))",
+      "finding": "src/app/services/drawdown_engine.py:159:dar_value = float(np.quantile(np.array(depths), 1.0 - alpha, method=\"linear\"))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:159:cdar_value = float(np.mean(worst_tail))",
+      "finding": "src/app/services/drawdown_engine.py:162:cdar_value = float(np.mean(worst_tail))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:162:dd_values = [float(value) for value in drawdown if float(value) < 0]",
+      "finding": "src/app/services/drawdown_engine.py:165:dd_values = [float(value) for value in drawdown if float(value) < 0]",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:174:time_under_water_days=int(sum(1 for value in drawdown if float(value) < 0)),",
+      "finding": "src/app/services/drawdown_engine.py:177:time_under_water_days=int(sum(1 for value in drawdown if float(value) < 0)),",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:187:points.append(UnderwaterPoint(date=timestamp.date(), drawdown=float(value)))",
+      "finding": "src/app/services/drawdown_engine.py:190:points.append(UnderwaterPoint(date=timestamp.date(), drawdown=float(value)))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/drawdown_engine.py:68:values = [float(value) for value in drawdown]",
+      "finding": "src/app/services/drawdown_engine.py:71:values = [float(value) for value in drawdown]",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_engine.py:124:peak_value = _as_number(cast(float, peak.loc[trough_idx]))",
+      "finding": "src/app/services/risk_engine.py:125:peak_value = _as_number(cast(float, peak.loc[trough_idx]))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/risk_engine.py:186:def _expected_shortfall(returns: pd.Series, var_value: float) -> float:",
+      "finding": "src/app/services/risk_engine.py:187:def _expected_shortfall(returns: pd.Series, var_value: float) -> float:",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/rolling_engine.py:219:points_by_date[day][metric_name] = float(value) if pd.notna(value) else None",
+      "finding": "src/app/services/rolling_engine.py:223:points_by_date[day][metric_name] = float(value) if pd.notna(value) else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-10"
+      "review_by": "2026-10-27"
     },
     {
       "finding": "src/app/services/stateful_returns_series_parser.py:15:def decimal_return_to_percentage_points(value: Any) -> float:",

--- a/docs/standards/risk-analytics-contract.md
+++ b/docs/standards/risk-analytics-contract.md
@@ -55,7 +55,9 @@
 - `details.error: "Benchmark returns required for benchmark-dependent metric"`
 
 ## Calculation Supportability
-- `POST /analytics/risk/calculate` emits `metadata.calculation_supportability`.
+- `POST /analytics/risk/calculate`, `POST /analytics/risk/drawdown`,
+  `POST /analytics/risk/rolling-metrics`, `POST /analytics/risk/historical-attribution`, and
+  `POST /analytics/risk/concentration` emit `metadata.calculation_supportability`.
 - Supported states: `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, `unsupported`.
 - Supported freshness buckets: `current`, `same_day`, `stale`, `unknown`.
 - Supported reasons include `calculation_complete`, `benchmark_unavailable`, `calculation_quality_issue`,
@@ -65,6 +67,9 @@
   bounded labels only: `operation`, `supportability_state`, `reason`, and `freshness_bucket`.
 - Metrics and response metadata must not expose portfolio, client, account, position, transaction,
   trace, correlation, or raw request identifiers.
+- Endpoint-specific supportability must be source-backed: return-series endpoints derive freshness
+  and empty/degraded posture from period results, while concentration derives degraded posture from
+  issuer coverage and empty universe support.
 
 ## Risk Calculate Mode Support
 - `stateless`: caller supplies full return series.

--- a/src/app/contracts/attribution.py
+++ b/src/app/contracts/attribution.py
@@ -7,7 +7,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.audit import AuditMetadataFields
-from app.contracts.risk import ReturnPoint, RiskRequestPeriod, RiskRequestScope
+from app.contracts.risk import (
+    ReturnPoint,
+    RiskCalculationSupportability,
+    RiskRequestPeriod,
+    RiskRequestScope,
+)
 
 
 class AttributionInputMode(str, Enum):
@@ -525,6 +530,24 @@ class HistoricalAttributionMetadata(AuditMetadataFields):
         default="benchmark issuer exposure semantics unavailable",
         description="Deterministic reason for any gated stateful ACTIVE_RISK grouping dimensions.",
         json_schema_extra={"example": "benchmark issuer exposure semantics unavailable"},
+    )
+    calculation_supportability: RiskCalculationSupportability = Field(
+        default_factory=lambda: RiskCalculationSupportability(
+            state="ready",
+            reason="calculation_complete",
+            freshness_bucket="unknown",
+        ),
+        description="Source-backed supportability posture for UI and operator consumption.",
+        json_schema_extra={
+            "example": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "current",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
+            }
+        },
     )
 
 

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -6,6 +6,7 @@ from enum import Enum
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.audit import AuditMetadataFields
+from app.contracts.risk import RiskCalculationSupportability
 
 
 class ConcentrationInputMode(str, Enum):
@@ -684,6 +685,24 @@ class ConcentrationMetadata(AuditMetadataFields):
         default=None,
         description="Whether zero-quantity positions were included in the evaluated concentration universe.",
         json_schema_extra={"example": False},
+    )
+    calculation_supportability: RiskCalculationSupportability = Field(
+        default_factory=lambda: RiskCalculationSupportability(
+            state="ready",
+            reason="calculation_complete",
+            freshness_bucket="unknown",
+        ),
+        description="Source-backed supportability posture for UI and operator consumption.",
+        json_schema_extra={
+            "example": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "unknown",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
+            }
+        },
     )
 
 

--- a/src/app/contracts/drawdown.py
+++ b/src/app/contracts/drawdown.py
@@ -7,7 +7,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.audit import AuditMetadataFields
-from app.contracts.risk import ReturnPoint, RiskRequestPeriod, RiskRequestScope
+from app.contracts.risk import (
+    ReturnPoint,
+    RiskCalculationSupportability,
+    RiskRequestPeriod,
+    RiskRequestScope,
+)
 
 
 class DrawdownInputMode(str, Enum):
@@ -623,6 +628,24 @@ class DrawdownMetadata(AuditMetadataFields):
         default=None,
         description="Behavior requested when benchmark series is unavailable.",
         json_schema_extra={"example": "IGNORE"},
+    )
+    calculation_supportability: RiskCalculationSupportability = Field(
+        default_factory=lambda: RiskCalculationSupportability(
+            state="ready",
+            reason="calculation_complete",
+            freshness_bucket="unknown",
+        ),
+        description="Source-backed supportability posture for UI and operator consumption.",
+        json_schema_extra={
+            "example": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "current",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
+            }
+        },
     )
 
 

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -549,7 +549,9 @@ class RiskCalculationSupportability(BaseModel):
     degraded_metric_count: int = Field(
         default=0,
         ge=0,
-        description="Number of requested metric results carrying deterministic error details.",
+        description=(
+            "Number of requested metric or period results carrying deterministic error details."
+        ),
         json_schema_extra={"example": 0},
     )
     empty_period_count: int = Field(

--- a/src/app/contracts/rolling.py
+++ b/src/app/contracts/rolling.py
@@ -7,7 +7,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.audit import AuditMetadataFields
-from app.contracts.risk import ReturnPoint, RiskRequestPeriod, RiskRequestScope
+from app.contracts.risk import (
+    ReturnPoint,
+    RiskCalculationSupportability,
+    RiskRequestPeriod,
+    RiskRequestScope,
+)
 
 
 class RollingInputMode(str, Enum):
@@ -661,6 +666,24 @@ class RollingMetadata(AuditMetadataFields):
             "example": {
                 "requested": True,
                 "requested_metrics": ["ROLLING_SHARPE"],
+            }
+        },
+    )
+    calculation_supportability: RiskCalculationSupportability = Field(
+        default_factory=lambda: RiskCalculationSupportability(
+            state="ready",
+            reason="calculation_complete",
+            freshness_bucket="unknown",
+        ),
+        description="Source-backed supportability posture for UI and operator consumption.",
+        json_schema_extra={
+            "example": {
+                "state": "ready",
+                "reason": "calculation_complete",
+                "freshness_bucket": "current",
+                "degraded_metric_count": 0,
+                "empty_period_count": 0,
+                "evaluated_period_count": 1,
             }
         },
     )

--- a/src/app/services/attribution_engine.py
+++ b/src/app/services/attribution_engine.py
@@ -21,6 +21,10 @@ from app.contracts.attribution import (
 )
 from app.contracts.risk import ReturnPoint, RiskRequestPeriod
 from app.services.audit_lineage import fingerprint_model
+from app.services.calculation_supportability import (
+    record_operation_supportability,
+    supportability_from_period_results,
+)
 from app.services.risk_engine import _resolve_period
 
 
@@ -261,6 +265,15 @@ def calculate_historical_attribution(
     benchmark_exposure_df = _exposure_df(request.benchmark_exposure_history)
 
     if returns_df.empty:
+        calculation_supportability = supportability_from_period_results(
+            returns=request.returns,
+            as_of_date=request.scope.as_of_date,
+            results={},
+        )
+        record_operation_supportability(
+            operation="risk/historical-attribution",
+            supportability=calculation_supportability,
+        )
         return HistoricalAttributionResponse(
             input_mode=input_mode,
             scope=request.scope,
@@ -273,6 +286,7 @@ def calculate_historical_attribution(
                 requested_metrics=list(request.attribution_options.metrics),
                 requested_grouping_dimensions=list(request.attribution_options.grouping_dimensions),
                 min_observations_policy=request.attribution_options.min_observations_policy,
+                calculation_supportability=calculation_supportability,
             ),
         )
 
@@ -355,6 +369,15 @@ def calculate_historical_attribution(
             error=None,
         )
 
+    calculation_supportability = supportability_from_period_results(
+        returns=request.returns,
+        as_of_date=request.scope.as_of_date,
+        results=results,
+    )
+    record_operation_supportability(
+        operation="risk/historical-attribution",
+        supportability=calculation_supportability,
+    )
     return HistoricalAttributionResponse(
         input_mode=input_mode,
         scope=request.scope,
@@ -367,5 +390,6 @@ def calculate_historical_attribution(
             requested_metrics=list(options.metrics),
             requested_grouping_dimensions=list(options.grouping_dimensions),
             min_observations_policy=options.min_observations_policy,
+            calculation_supportability=calculation_supportability,
         ),
     )

--- a/src/app/services/calculation_supportability.py
+++ b/src/app/services/calculation_supportability.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from app.contracts.risk import (
+    ReturnPoint,
+    RiskCalculationSupportability,
+    RiskFreshnessBucket,
+    RiskSupportabilityReason,
+)
+from app.observability import record_calculation_supportability
+
+
+def default_calculation_supportability() -> RiskCalculationSupportability:
+    return RiskCalculationSupportability(
+        state="ready",
+        reason="calculation_complete",
+        freshness_bucket="unknown",
+    )
+
+
+def freshness_bucket_from_returns(
+    returns: Sequence[ReturnPoint],
+    *,
+    as_of_date: dt.date,
+) -> RiskFreshnessBucket:
+    if not returns:
+        return "unknown"
+    latest_observation_date = max(point.date for point in returns)
+    age_days = (as_of_date - latest_observation_date).days
+    if age_days <= 0:
+        return "current"
+    if age_days <= 1:
+        return "same_day"
+    return "stale"
+
+
+def _supportability_reason_for_error(error: str) -> RiskSupportabilityReason:
+    if error in {
+        "Benchmark returns required for benchmark-dependent metric",
+        "BENCHMARK_UNAVAILABLE",
+    }:
+        return "benchmark_unavailable"
+    if error in {"Insufficient aligned observations", "NO_ALIGNED_OBSERVATIONS"}:
+        return "insufficient_aligned_observations"
+    if error == "Insufficient data":
+        return "insufficient_observations"
+    return "calculation_quality_issue"
+
+
+def _select_reason(reasons: Sequence[RiskSupportabilityReason]) -> RiskSupportabilityReason:
+    reason_order: tuple[RiskSupportabilityReason, ...] = (
+        "benchmark_unavailable",
+        "insufficient_aligned_observations",
+        "insufficient_observations",
+        "calculation_quality_issue",
+    )
+    return next(reason for reason in reason_order if reason in set(reasons))
+
+
+def _observation_count(period_result: Any) -> int | None:
+    for attribute_name in ("portfolio_observation_count", "series_count"):
+        value = getattr(period_result, attribute_name, None)
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _dependency_degradation_reason(period_result: Any) -> RiskSupportabilityReason | None:
+    for attribute_name in (
+        "relative_to_benchmark_context",
+        "benchmark_context",
+        "risk_free_context",
+    ):
+        context = getattr(period_result, attribute_name, None)
+        if context is None or getattr(context, "requested", False) is not True:
+            continue
+        reason = getattr(context, "reason", None)
+        applied = getattr(context, "applied", None)
+        available = getattr(context, "available", None)
+        aligned = getattr(context, "aligned", None)
+        if applied is False or available is False:
+            return _supportability_reason_for_error(str(reason))
+        if aligned is False:
+            return "insufficient_aligned_observations"
+    return None
+
+
+def supportability_from_period_results(
+    *,
+    returns: Sequence[ReturnPoint],
+    as_of_date: dt.date,
+    results: Mapping[str, Any],
+) -> RiskCalculationSupportability:
+    freshness_bucket = freshness_bucket_from_returns(returns, as_of_date=as_of_date)
+    if not returns:
+        return RiskCalculationSupportability(
+            state="empty",
+            reason="no_return_observations",
+            freshness_bucket=freshness_bucket,
+            evaluated_period_count=len(results),
+        )
+
+    degraded_reasons: list[RiskSupportabilityReason] = []
+    empty_period_count = 0
+    degraded_result_count = 0
+    for period_result in results.values():
+        observation_count = _observation_count(period_result)
+        if observation_count == 0:
+            empty_period_count += 1
+
+        error = getattr(period_result, "error", None)
+        if isinstance(error, str):
+            degraded_result_count += 1
+            degraded_reasons.append(_supportability_reason_for_error(error))
+            continue
+        dependency_reason = _dependency_degradation_reason(period_result)
+        if dependency_reason is not None:
+            degraded_result_count += 1
+            degraded_reasons.append(dependency_reason)
+
+    if degraded_result_count:
+        return RiskCalculationSupportability(
+            state="degraded",
+            reason=_select_reason(degraded_reasons),
+            freshness_bucket=freshness_bucket,
+            degraded_metric_count=degraded_result_count,
+            empty_period_count=empty_period_count,
+            evaluated_period_count=len(results),
+        )
+
+    if empty_period_count:
+        return RiskCalculationSupportability(
+            state="empty",
+            reason="insufficient_observations",
+            freshness_bucket=freshness_bucket,
+            empty_period_count=empty_period_count,
+            evaluated_period_count=len(results),
+        )
+
+    if freshness_bucket == "stale":
+        return RiskCalculationSupportability(
+            state="stale",
+            reason="stale_source_observations",
+            freshness_bucket=freshness_bucket,
+            evaluated_period_count=len(results),
+        )
+
+    return RiskCalculationSupportability(
+        state="ready",
+        reason="calculation_complete",
+        freshness_bucket=freshness_bucket,
+        evaluated_period_count=len(results),
+    )
+
+
+def supportability_from_risk_metric_results(
+    *,
+    returns: Sequence[ReturnPoint],
+    as_of_date: dt.date,
+    results: Mapping[str, Any],
+) -> RiskCalculationSupportability:
+    supportability = supportability_from_period_results(
+        returns=returns,
+        as_of_date=as_of_date,
+        results=results,
+    )
+    if supportability.state == "empty":
+        return supportability
+
+    degraded_reasons: list[RiskSupportabilityReason] = []
+    empty_period_count = 0
+    degraded_metric_count = 0
+    for period_result in results.values():
+        if getattr(period_result, "portfolio_observation_count", None) == 0:
+            empty_period_count += 1
+        metrics = getattr(period_result, "metrics", {})
+        if not isinstance(metrics, Mapping):
+            continue
+        for metric_result in metrics.values():
+            details = getattr(metric_result, "details", None)
+            if not isinstance(details, Mapping):
+                continue
+            error = details.get("error")
+            if isinstance(error, str):
+                degraded_metric_count += 1
+                degraded_reasons.append(_supportability_reason_for_error(error))
+
+    if degraded_metric_count:
+        freshness_bucket = freshness_bucket_from_returns(returns, as_of_date=as_of_date)
+        return RiskCalculationSupportability(
+            state="degraded",
+            reason=_select_reason(degraded_reasons),
+            freshness_bucket=freshness_bucket,
+            degraded_metric_count=degraded_metric_count,
+            empty_period_count=empty_period_count,
+            evaluated_period_count=len(results),
+        )
+    return supportability
+
+
+def supportability_from_concentration_response(
+    *,
+    covered_position_count_current: int,
+    covered_position_count_proposed: int,
+    total_position_count_current: int,
+    total_position_count_proposed: int,
+    issuer_note: str | None,
+) -> RiskCalculationSupportability:
+    total_positions = total_position_count_current + total_position_count_proposed
+    covered_positions = covered_position_count_current + covered_position_count_proposed
+    if total_positions == 0:
+        return RiskCalculationSupportability(
+            state="empty",
+            reason="insufficient_observations",
+            freshness_bucket="unknown",
+            empty_period_count=1,
+            evaluated_period_count=1,
+        )
+    if covered_positions == 0 or issuer_note:
+        return RiskCalculationSupportability(
+            state="degraded",
+            reason="calculation_quality_issue",
+            freshness_bucket="unknown",
+            degraded_metric_count=1,
+            evaluated_period_count=1,
+        )
+    return RiskCalculationSupportability(
+        state="ready",
+        reason="calculation_complete",
+        freshness_bucket="unknown",
+        evaluated_period_count=1,
+    )
+
+
+def record_operation_supportability(
+    *,
+    operation: str,
+    supportability: RiskCalculationSupportability,
+) -> None:
+    record_calculation_supportability(
+        operation=operation,
+        supportability_state=supportability.state,
+        reason=supportability.reason,
+        freshness_bucket=supportability.freshness_bucket,
+    )

--- a/src/app/services/concentration_engine.py
+++ b/src/app/services/concentration_engine.py
@@ -28,6 +28,10 @@ from app.services.audit_lineage import (
     ordered_source_services,
     upstream_request_fingerprint,
 )
+from app.services.calculation_supportability import (
+    record_operation_supportability,
+    supportability_from_concentration_response,
+)
 
 SERVICE_NAME = "lotus-risk"
 _ROUND_PRECISION = 6
@@ -363,6 +367,19 @@ def _build_response(payload: ConcentrationComputationInput) -> ConcentrationResp
             or payload.covered_position_count_proposed > 0
         ):
             coverage_status = IssuerCoverageStatus.PARTIAL
+    calculation_supportability = supportability_from_concentration_response(
+        covered_position_count_current=payload.covered_position_count_current,
+        covered_position_count_proposed=payload.covered_position_count_proposed,
+        total_position_count_current=payload.total_position_count_current,
+        total_position_count_proposed=payload.total_position_count_proposed,
+        issuer_note=payload.issuer_note,
+    )
+    if payload.metadata is not None:
+        payload.metadata.calculation_supportability = calculation_supportability
+    record_operation_supportability(
+        operation="risk/concentration",
+        supportability=calculation_supportability,
+    )
 
     return ConcentrationResponse(
         source_service=SERVICE_NAME,

--- a/src/app/services/drawdown_engine.py
+++ b/src/app/services/drawdown_engine.py
@@ -22,9 +22,12 @@ from app.contracts.drawdown import (
     RelativeDrawdownSummary,
     UnderwaterPoint,
 )
-from app.contracts.risk import RiskRequestPeriod
-from app.contracts.risk import ReturnPoint
+from app.contracts.risk import ReturnPoint, RiskCalculationSupportability, RiskRequestPeriod
 from app.services.audit_lineage import fingerprint_model
+from app.services.calculation_supportability import (
+    record_operation_supportability,
+    supportability_from_period_results,
+)
 from app.services.risk_engine import _resolve_period
 
 
@@ -198,6 +201,7 @@ def _build_metadata(
     analysis_options: DrawdownAnalysisOptions,
     include_benchmark: bool | None,
     missing_benchmark_policy: Literal["IGNORE", "REQUIRE"] | None,
+    calculation_supportability: RiskCalculationSupportability,
 ) -> DrawdownMetadata:
     return DrawdownMetadata(
         request_fingerprint=fingerprint_model(request),
@@ -209,6 +213,7 @@ def _build_metadata(
         duration_unit=analysis_options.duration_unit,
         include_benchmark=include_benchmark,
         missing_benchmark_policy=missing_benchmark_policy,
+        calculation_supportability=calculation_supportability,
     )
 
 
@@ -223,6 +228,15 @@ def calculate_drawdown(
     returns_df = _build_returns_df(request.returns)
     benchmark_df = _build_returns_df(request.benchmark_returns)
     if returns_df.empty:
+        calculation_supportability = supportability_from_period_results(
+            returns=request.returns,
+            as_of_date=request.scope.as_of_date,
+            results={},
+        )
+        record_operation_supportability(
+            operation="risk/drawdown",
+            supportability=calculation_supportability,
+        )
         return DrawdownResponse(
             input_mode=input_mode,
             scope=request.scope,
@@ -232,6 +246,7 @@ def calculate_drawdown(
                 analysis_options=analysis_options,
                 include_benchmark=include_benchmark,
                 missing_benchmark_policy=missing_benchmark_policy,
+                calculation_supportability=calculation_supportability,
             ),
         )
 
@@ -362,6 +377,15 @@ def calculate_drawdown(
             error=None,
         )
 
+    calculation_supportability = supportability_from_period_results(
+        returns=request.returns,
+        as_of_date=request.scope.as_of_date,
+        results=results,
+    )
+    record_operation_supportability(
+        operation="risk/drawdown",
+        supportability=calculation_supportability,
+    )
     return DrawdownResponse(
         input_mode=input_mode,
         scope=request.scope,
@@ -371,5 +395,6 @@ def calculate_drawdown(
             analysis_options=analysis_options,
             include_benchmark=include_benchmark,
             missing_benchmark_policy=missing_benchmark_policy,
+            calculation_supportability=calculation_supportability,
         ),
     )

--- a/src/app/services/risk_engine.py
+++ b/src/app/services/risk_engine.py
@@ -12,17 +12,18 @@ from prometheus_client import Counter, Histogram
 from app.contracts.risk import (
     BenchmarkRequestContext,
     RiskCalculationSupportability,
-    RiskFreshnessBucket,
     RiskFreeContext,
     RiskPeriodResult,
     RiskResponseMetadata,
     RiskResponse,
     RiskStatelessCalculationInput,
-    RiskSupportabilityReason,
     RiskValue,
 )
-from app.observability import record_calculation_supportability
 from app.services.audit_lineage import fingerprint_model
+from app.services.calculation_supportability import (
+    record_operation_supportability,
+    supportability_from_risk_metric_results,
+)
 
 RISK_METRIC_REQUESTED_TOTAL = Counter(
     "risk_metric_requested_total",
@@ -324,94 +325,14 @@ def _build_metadata(
     )
 
 
-def _freshness_bucket(request: RiskStatelessCalculationInput) -> RiskFreshnessBucket:
-    if not request.returns:
-        return "unknown"
-    latest_observation_date = max(point.date for point in request.returns)
-    age_days = (request.scope.as_of_date - latest_observation_date).days
-    if age_days <= 0:
-        return "current"
-    if age_days <= 1:
-        return "same_day"
-    return "stale"
-
-
-def _supportability_reason_for_error(error: str) -> RiskSupportabilityReason:
-    if error == "Benchmark returns required for benchmark-dependent metric":
-        return "benchmark_unavailable"
-    if error == "Insufficient aligned observations":
-        return "insufficient_aligned_observations"
-    if error == "Insufficient data":
-        return "insufficient_observations"
-    return "calculation_quality_issue"
-
-
 def _resolve_calculation_supportability(
     request: RiskStatelessCalculationInput,
     results: dict[str, RiskPeriodResult],
 ) -> RiskCalculationSupportability:
-    freshness_bucket = _freshness_bucket(request)
-    if not request.returns:
-        return RiskCalculationSupportability(
-            state="empty",
-            reason="no_return_observations",
-            freshness_bucket=freshness_bucket,
-            evaluated_period_count=len(results),
-        )
-
-    degraded_reasons: list[RiskSupportabilityReason] = []
-    empty_period_count = 0
-    degraded_metric_count = 0
-    for period_result in results.values():
-        if period_result.portfolio_observation_count == 0:
-            empty_period_count += 1
-        for metric_result in period_result.metrics.values():
-            error = (metric_result.details or {}).get("error")
-            if isinstance(error, str):
-                degraded_metric_count += 1
-                degraded_reasons.append(_supportability_reason_for_error(error))
-
-    if degraded_metric_count:
-        reason_order: tuple[RiskSupportabilityReason, ...] = (
-            "benchmark_unavailable",
-            "insufficient_aligned_observations",
-            "insufficient_observations",
-            "calculation_quality_issue",
-        )
-        selected_reason: RiskSupportabilityReason = next(
-            reason for reason in reason_order if reason in set(degraded_reasons)
-        )
-        return RiskCalculationSupportability(
-            state="degraded",
-            reason=selected_reason,
-            freshness_bucket=freshness_bucket,
-            degraded_metric_count=degraded_metric_count,
-            empty_period_count=empty_period_count,
-            evaluated_period_count=len(results),
-        )
-
-    if empty_period_count:
-        return RiskCalculationSupportability(
-            state="empty",
-            reason="insufficient_observations",
-            freshness_bucket=freshness_bucket,
-            empty_period_count=empty_period_count,
-            evaluated_period_count=len(results),
-        )
-
-    if freshness_bucket == "stale":
-        return RiskCalculationSupportability(
-            state="stale",
-            reason="stale_source_observations",
-            freshness_bucket=freshness_bucket,
-            evaluated_period_count=len(results),
-        )
-
-    return RiskCalculationSupportability(
-        state="ready",
-        reason="calculation_complete",
-        freshness_bucket=freshness_bucket,
-        evaluated_period_count=len(results),
+    return supportability_from_risk_metric_results(
+        returns=request.returns,
+        as_of_date=request.scope.as_of_date,
+        results=results,
     )
 
 
@@ -430,11 +351,9 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
     returns_df = pd.DataFrame([{"date": p.date, "value": p.value} for p in request.returns])
     if returns_df.empty:
         calculation_supportability = _resolve_calculation_supportability(request, {})
-        record_calculation_supportability(
+        record_operation_supportability(
             operation="risk/calculate",
-            supportability_state=calculation_supportability.state,
-            reason=calculation_supportability.reason,
-            freshness_bucket=calculation_supportability.freshness_bucket,
+            supportability=calculation_supportability,
         )
         return RiskResponse(
             scope=request.scope,
@@ -687,11 +606,9 @@ def calculate_risk(request: RiskStatelessCalculationInput) -> RiskResponse:
         )
 
     calculation_supportability = _resolve_calculation_supportability(request, results)
-    record_calculation_supportability(
+    record_operation_supportability(
         operation="risk/calculate",
-        supportability_state=calculation_supportability.state,
-        reason=calculation_supportability.reason,
-        freshness_bucket=calculation_supportability.freshness_bucket,
+        supportability=calculation_supportability,
     )
     return RiskResponse(
         scope=request.scope,

--- a/src/app/services/rolling_engine.py
+++ b/src/app/services/rolling_engine.py
@@ -25,6 +25,10 @@ from app.contracts.rolling import (
 )
 from app.contracts.risk import ReturnPoint, RiskRequestPeriod
 from app.services.audit_lineage import fingerprint_model
+from app.services.calculation_supportability import (
+    record_operation_supportability,
+    supportability_from_period_results,
+)
 from app.services.risk_engine import _resolve_period
 
 
@@ -343,6 +347,15 @@ def calculate_rolling_metrics(
     risk_free_df = _build_returns_df(request.risk_free_returns)
 
     if portfolio_df.empty:
+        calculation_supportability = supportability_from_period_results(
+            returns=request.returns,
+            as_of_date=request.scope.as_of_date,
+            results={},
+        )
+        record_operation_supportability(
+            operation="risk/rolling-metrics",
+            supportability=calculation_supportability,
+        )
         return RollingResponse(
             input_mode=input_mode,
             scope=request.scope,
@@ -364,6 +377,7 @@ def calculate_rolling_metrics(
                     request.rolling_options.metrics,
                     {ROLLING_SHARPE_METRIC},
                 ),
+                calculation_supportability=calculation_supportability,
             ),
         )
 
@@ -520,6 +534,15 @@ def calculate_rolling_metrics(
             error=None,
         )
 
+    calculation_supportability = supportability_from_period_results(
+        returns=request.returns,
+        as_of_date=request.scope.as_of_date,
+        results=results,
+    )
+    record_operation_supportability(
+        operation="risk/rolling-metrics",
+        supportability=calculation_supportability,
+    )
     return RollingResponse(
         input_mode=input_mode,
         scope=request.scope,
@@ -541,5 +564,6 @@ def calculate_rolling_metrics(
                 requested_metrics,
                 {ROLLING_SHARPE_METRIC},
             ),
+            calculation_supportability=calculation_supportability,
         ),
     )

--- a/tests/integration/test_drawdown_endpoint.py
+++ b/tests/integration/test_drawdown_endpoint.py
@@ -49,6 +49,14 @@ def test_drawdown_endpoint_stateless_contract() -> None:
     assert body["metadata"]["include_episode_list"] is True
     assert body["metadata"]["include_benchmark"] is False
     assert body["metadata"]["missing_benchmark_policy"] == "IGNORE"
+    assert body["metadata"]["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "degraded_metric_count": 0,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }
 
 
 def test_drawdown_endpoint_stateful_uses_lotus_performance() -> None:
@@ -118,6 +126,37 @@ def test_drawdown_endpoint_marks_benchmark_unavailable_when_requested_without_se
         "applied": False,
         "reason": "BENCHMARK_UNAVAILABLE",
         "aligned_observation_count": 0,
+    }
+    assert response.json()["metadata"]["calculation_supportability"] == {
+        "state": "degraded",
+        "reason": "benchmark_unavailable",
+        "freshness_bucket": "current",
+        "degraded_metric_count": 1,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }
+
+
+def test_drawdown_endpoint_supportability_marks_empty_periods() -> None:
+    client = TestClient(app)
+    payload = _stateless_payload()
+    payload["stateless_input"]["periods"] = [  # type: ignore[index]
+        {
+            "type": "EXPLICIT",
+            "name": "EMPTY",
+            "from_date": "2025-12-01",
+            "to_date": "2025-12-31",
+        }
+    ]
+    response = client.post("/analytics/risk/drawdown", json=payload)
+    assert response.status_code == 200
+    assert response.json()["metadata"]["calculation_supportability"] == {
+        "state": "degraded",
+        "reason": "insufficient_observations",
+        "freshness_bucket": "current",
+        "degraded_metric_count": 1,
+        "empty_period_count": 1,
+        "evaluated_period_count": 1,
     }
 
 

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -210,10 +210,37 @@ def test_historical_attribution_stateless_happy_path() -> None:
         body["metadata"]["stateful_active_risk_gate_reason"]
         == "benchmark issuer exposure semantics unavailable"
     )
+    assert body["metadata"]["calculation_supportability"] == {
+        "state": "ready",
+        "reason": "calculation_complete",
+        "freshness_bucket": "current",
+        "degraded_metric_count": 0,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }
     assert "YTD" in body["results"]
     ytd = body["results"]["YTD"]
     assert ytd["error"] is None
     assert len(ytd["attribution_sets"]) == 4
+
+
+def test_historical_attribution_supportability_marks_empty_returns() -> None:
+    client = TestClient(app)
+    payload = _stateless_attribution_payload()
+    payload["stateless_input"]["returns"] = []  # type: ignore[index]
+    response = client.post(
+        "/analytics/risk/historical-attribution",
+        json=payload,
+    )
+    assert response.status_code == 200
+    assert response.json()["metadata"]["calculation_supportability"] == {
+        "state": "empty",
+        "reason": "no_return_observations",
+        "freshness_bucket": "unknown",
+        "degraded_metric_count": 0,
+        "empty_period_count": 0,
+        "evaluated_period_count": 0,
+    }
 
 
 def test_historical_attribution_stateful_total_risk_happy_path() -> None:

--- a/tests/integration/test_rolling_metrics_endpoint.py
+++ b/tests/integration/test_rolling_metrics_endpoint.py
@@ -97,6 +97,14 @@ def test_rolling_metrics_endpoint_stateless_contract() -> None:
         "requested": True,
         "requested_metrics": ["ROLLING_SHARPE"],
     }
+    assert body["metadata"]["calculation_supportability"] == {
+        "state": "stale",
+        "reason": "stale_source_observations",
+        "freshness_bucket": "stale",
+        "degraded_metric_count": 0,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }
     assert "YTD" in body["results"]
     assert body["results"]["YTD"]["benchmark_series_count"] == 4
     assert body["results"]["YTD"]["aligned_benchmark_series_count"] == 4
@@ -138,6 +146,29 @@ def test_rolling_metrics_endpoint_stateless_contract() -> None:
     assert summary["non_computed_point_count"] == 2
     assert summary["post_warmup_gap_point_count"] == 0
     assert summary["latest_observation_date"] == "2026-01-05"
+
+
+def test_rolling_metrics_endpoint_supportability_marks_insufficient_period() -> None:
+    client = TestClient(app)
+    payload = _stateless_payload()
+    payload["stateless_input"]["periods"] = [  # type: ignore[index]
+        {
+            "type": "EXPLICIT",
+            "name": "SHORT",
+            "from_date": "2026-01-02",
+            "to_date": "2026-01-02",
+        }
+    ]
+    response = client.post("/analytics/risk/rolling-metrics", json=payload)
+    assert response.status_code == 200
+    assert response.json()["metadata"]["calculation_supportability"] == {
+        "state": "degraded",
+        "reason": "insufficient_observations",
+        "freshness_bucket": "stale",
+        "degraded_metric_count": 1,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }
 
 
 def test_rolling_metrics_endpoint_stateful_uses_lotus_performance() -> None:

--- a/tests/unit/test_calculation_supportability.py
+++ b/tests/unit/test_calculation_supportability.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from pydantic import BaseModel
+
+from app.contracts.risk import ReturnPoint
+from app.services.calculation_supportability import (
+    supportability_from_concentration_response,
+    supportability_from_period_results,
+)
+
+
+class _PeriodResult(BaseModel):
+    portfolio_observation_count: int
+    error: str | None = None
+
+
+def test_period_supportability_reports_stale_ready_payload() -> None:
+    supportability = supportability_from_period_results(
+        returns=[ReturnPoint(date=dt.date(2026, 1, 2), value=1.2)],
+        as_of_date=dt.date(2026, 1, 5),
+        results={"YTD": _PeriodResult(portfolio_observation_count=1)},
+    )
+
+    assert supportability.state == "stale"
+    assert supportability.reason == "stale_source_observations"
+    assert supportability.freshness_bucket == "stale"
+    assert supportability.evaluated_period_count == 1
+
+
+def test_period_supportability_prioritizes_benchmark_degradation() -> None:
+    supportability = supportability_from_period_results(
+        returns=[ReturnPoint(date=dt.date(2026, 1, 5), value=1.2)],
+        as_of_date=dt.date(2026, 1, 5),
+        results={
+            "YTD": _PeriodResult(
+                portfolio_observation_count=3,
+                error="BENCHMARK_UNAVAILABLE",
+            )
+        },
+    )
+
+    assert supportability.state == "degraded"
+    assert supportability.reason == "benchmark_unavailable"
+    assert supportability.freshness_bucket == "current"
+    assert supportability.degraded_metric_count == 1
+
+
+def test_concentration_supportability_reports_uncovered_issuer_mapping() -> None:
+    supportability = supportability_from_concentration_response(
+        covered_position_count_current=0,
+        covered_position_count_proposed=0,
+        total_position_count_current=2,
+        total_position_count_proposed=2,
+        issuer_note="issuer mapping unavailable for stateless payload",
+    )
+
+    assert supportability.state == "degraded"
+    assert supportability.reason == "calculation_quality_issue"
+    assert supportability.freshness_bucket == "unknown"
+    assert supportability.degraded_metric_count == 1

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -107,6 +107,14 @@ async def test_calculate_concentration_stateless_uses_projected_values_when_prov
         "enrichment_policy": "merge_caller_then_core",
         "include_cash_positions": None,
         "include_zero_quantity_positions": None,
+        "calculation_supportability": {
+            "state": "ready",
+            "reason": "calculation_complete",
+            "freshness_bucket": "unknown",
+            "degraded_metric_count": 0,
+            "empty_period_count": 0,
+            "evaluated_period_count": 1,
+        },
     }
 
 
@@ -137,3 +145,11 @@ async def test_calculate_concentration_falls_back_to_current_when_no_projected()
     assert response["issuer_concentration"]["uncovered_position_count_proposed"] == 1
     assert response["metadata"]["issuer_grouping_level"] == "ultimate_parent"
     assert response["metadata"]["enrichment_policy"] == "merge_caller_then_core"
+    assert response["metadata"]["calculation_supportability"] == {
+        "state": "degraded",
+        "reason": "calculation_quality_issue",
+        "freshness_bucket": "unknown",
+        "degraded_metric_count": 1,
+        "empty_period_count": 0,
+        "evaluated_period_count": 1,
+    }

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -71,10 +71,11 @@ Use:
 4. `docs/operations/canonical-local-upstream-urls.md`
 5. `docs/operations/live-risk-validation-matrix.md`
 
-For `POST /analytics/risk/calculate`, response metadata includes
-`metadata.calculation_supportability`. Use it before inferring UI state from individual metric
-values. It reports bounded `ready`, `stale`, `degraded`, or `empty` posture, a bounded reason, and a
-freshness bucket. The matching Prometheus counter is
+For risk analytics responses, `metadata.calculation_supportability` is emitted by `risk/calculate`,
+drawdown, rolling metrics, historical attribution, and concentration. Use it before inferring UI
+state from individual metric values, period errors, issuer coverage, or stale returns. It reports
+bounded `ready`, `stale`, `degraded`, or `empty` posture, a bounded reason, and a freshness bucket.
+The matching Prometheus counter is
 `lotus_risk_calculation_supportability_total` with only bounded labels: `operation`,
 `supportability_state`, `reason`, and `freshness_bucket`.
 


### PR DESCRIPTION
## Summary
- Adds shared source-backed calculation supportability resolution across risk/calculate, drawdown, rolling metrics, historical attribution, and concentration.
- Emits bounded lotus_risk_calculation_supportability_total labels for each implemented risk operation.
- Updates OpenAPI/vocabulary docs, repo context, and wiki operations guidance for the expanded risk supportability contract.

## Evidence
- python -m pytest tests/unit/test_calculation_supportability.py tests/unit/test_concentration_engine.py tests/integration/test_drawdown_endpoint.py tests/integration/test_rolling_metrics_endpoint.py tests/integration/test_historical_attribution_endpoint.py: 37 passed
- python -m ruff check targeted changed files: passed
- python -m mypy --config-file mypy.ini: passed
- python scripts/openapi_quality_gate.py: passed
- python scripts/api_vocabulary_inventory.py --validate-only: passed
- python scripts/no_alias_contract_guard.py: passed
- make check: passed (lint, format check, no-alias, mypy, OpenAPI, vocabulary, domain-product gate, 296 unit tests)

## Tiering
- Domain API change. Local Feature Lane proof is complete via make check; GitHub PR Merge Gate is required before merge.
- Gateway/Workbench reconciliation is intentionally out of scope for this backend slice.