### PR TITLE
Emit backend freshness supportability metric

### DIFF
--- a/docs/domain-apis/risk-observability.md
+++ b/docs/domain-apis/risk-observability.md
@@ -42,6 +42,7 @@ from deterministic upstream error classification, for example:
 | Metric | Labels | Meaning |
 | --- | --- | --- |
 | `lotus_risk_calculation_supportability_total` | `operation`, `supportability_state`, `reason`, `freshness_bucket` | Count of risk calculation supportability outcomes using the same bounded posture emitted in `metadata.calculation_supportability`. |
+| `lotus_analytics_freshness_bucket_total` | `service`, `operation`, `freshness_bucket`, `supportability_state` | RFC-0108 cross-service backend freshness counter emitted from the same source-owned supportability posture. |
 
 The supported states are `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, and
 `unsupported`. Implemented operations are `risk/calculate`, `risk/drawdown`,

--- a/src/app/observability.py
+++ b/src/app/observability.py
@@ -30,6 +30,11 @@ CALCULATION_SUPPORTABILITY_TOTAL = Counter(
     "Risk calculation supportability posture by bounded operation, state, reason, and freshness bucket.",
     ["operation", "supportability_state", "reason", "freshness_bucket"],
 )
+ANALYTICS_FRESHNESS_BUCKET_TOTAL = Counter(
+    "lotus_analytics_freshness_bucket_total",
+    "Backend analytics freshness and supportability posture by service, operation, and bounded freshness bucket.",
+    ["service", "operation", "freshness_bucket", "supportability_state"],
+)
 
 
 def observation_start() -> float:
@@ -91,4 +96,18 @@ def record_calculation_supportability(
         supportability_state=supportability_state,
         reason=reason,
         freshness_bucket=freshness_bucket,
+    ).inc()
+
+
+def record_analytics_freshness_bucket(
+    *,
+    operation: str,
+    freshness_bucket: str,
+    supportability_state: str,
+) -> None:
+    ANALYTICS_FRESHNESS_BUCKET_TOTAL.labels(
+        service="lotus-risk",
+        operation=operation,
+        freshness_bucket=freshness_bucket,
+        supportability_state=supportability_state,
     ).inc()

--- a/src/app/services/calculation_supportability.py
+++ b/src/app/services/calculation_supportability.py
@@ -10,7 +10,7 @@ from app.contracts.risk import (
     RiskFreshnessBucket,
     RiskSupportabilityReason,
 )
-from app.observability import record_calculation_supportability
+from app.observability import record_analytics_freshness_bucket, record_calculation_supportability
 
 
 def default_calculation_supportability() -> RiskCalculationSupportability:
@@ -245,4 +245,9 @@ def record_operation_supportability(
         supportability_state=supportability.state,
         reason=supportability.reason,
         freshness_bucket=supportability.freshness_bucket,
+    )
+    record_analytics_freshness_bucket(
+        operation=operation,
+        freshness_bucket=supportability.freshness_bucket,
+        supportability_state=supportability.state,
     )

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -54,6 +54,11 @@ def test_metrics_expose_endpoint_execution_mode_and_outcome() -> None:
     assert 'supportability_state="stale"' in metrics
     assert 'reason="stale_source_observations"' in metrics
     assert 'freshness_bucket="stale"' in metrics
+    assert "lotus_analytics_freshness_bucket_total" in metrics
+    assert (
+        'lotus_analytics_freshness_bucket_total{freshness_bucket="stale",'
+        'operation="risk/calculate",service="lotus-risk",supportability_state="stale"}'
+    ) in metrics
 
 
 def test_metrics_expose_stateful_endpoint_execution_mode() -> None:

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -78,6 +78,8 @@ bounded `ready`, `stale`, `degraded`, or `empty` posture, a bounded reason, and 
 The matching Prometheus counter is
 `lotus_risk_calculation_supportability_total` with only bounded labels: `operation`,
 `supportability_state`, `reason`, and `freshness_bucket`.
+The same source-owned posture also increments the RFC-0108 cross-service freshness counter
+`lotus_analytics_freshness_bucket_total{service="lotus-risk",operation,freshness_bucket,supportability_state}`.
 
 Do not add portfolio, client, account, position, transaction, trace, correlation, or request
 identifiers to supportability metric labels.


### PR DESCRIPTION
## Summary
- emit RFC-0108 `lotus_analytics_freshness_bucket_total` from the existing risk calculation supportability path
- keep labels bounded to `service`, `operation`, `freshness_bucket`, and `supportability_state`
- update risk observability docs and operations wiki source with the new backend freshness signal

## Local proof
- `make lint`
- `make typecheck`
- `python -m pytest tests\integration\test_observability.py tests\unit\test_calculation_supportability.py -q`
- `make check`
- `git diff --check`
- `powershell -NoProfile -ExecutionPolicy Bypass -File .\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reported expected branch-local drift in `Operations-Runbook.md`; publish is required after merge.