### PR TITLE
Harden RFC-0108 risk supportability metric labels

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -75,7 +75,10 @@ Boundary rules:
 7. RFC-0108 calculation supportability is source-owned in this repository across `risk/calculate`,
    drawdown, rolling metrics, historical attribution, and concentration through
    `metadata.calculation_supportability` plus bounded
-   `lotus_risk_calculation_supportability_total` labels.
+   `lotus_risk_calculation_supportability_total` labels. The supportability contract publishes
+   explicit `metric_labels`, and tests prove the Prometheus labels remain bounded to `operation`,
+   `supportability_state`, `reason`, and `freshness_bucket` without portfolio, client,
+   correlation, trace, security, request-body, or response-body label fields.
 
 Canonical direct local validation ports:
 

--- a/docs/domain-apis/risk-calculate.md
+++ b/docs/domain-apis/risk-calculate.md
@@ -102,6 +102,8 @@
       `insufficient_aligned_observations`, `insufficient_observations`,
       `no_return_observations`, or `stale_source_observations`
     - `freshness_bucket`: `current`, `same_day`, `stale`, or `unknown`
+    - `metric_labels`: bounded Prometheus label keys for
+      `lotus_risk_calculation_supportability_total`
     - `degraded_metric_count`, `empty_period_count`, `evaluated_period_count`
 - `results` map keyed by period name/type:
   - `start_date`
@@ -127,7 +129,10 @@
 - Cross-service integration posture: integrated with `lotus-performance` for stateful return sourcing.
 - Naming/vocabulary: aligned with canonical `client_id` naming and RFC-0067 guardrails.
 - Supportability posture: implemented for `risk/calculate` and mirrored in bounded Prometheus
-  metric labels through `lotus_risk_calculation_supportability_total`.
+  metric labels through `lotus_risk_calculation_supportability_total`. The metric labels are
+  limited to `operation`, `supportability_state`, `reason`, and `freshness_bucket`; portfolio,
+  client, trace, correlation, security, transaction, request-body, and response-body values must
+  not be labels.
 
 ## Gaps and Decisions Required
 

--- a/docs/domain-apis/risk-observability.md
+++ b/docs/domain-apis/risk-observability.md
@@ -41,18 +41,23 @@ from deterministic upstream error classification, for example:
 
 | Metric | Labels | Meaning |
 | --- | --- | --- |
-| `lotus_risk_calculation_supportability_total` | `operation`, `supportability_state`, `reason`, `freshness_bucket` | Count of risk calculation supportability outcomes using the same bounded posture emitted in `metadata.calculation_supportability`. |
+| `lotus_risk_calculation_supportability_total` | `operation`, `supportability_state`, `reason`, `freshness_bucket` | Count of risk calculation supportability outcomes using the same bounded posture emitted in `metadata.calculation_supportability.metric_labels`. |
 | `lotus_analytics_freshness_bucket_total` | `service`, `operation`, `freshness_bucket`, `supportability_state` | RFC-0108 cross-service backend freshness counter emitted from the same source-owned supportability posture. |
 
 The supported states are `ready`, `stale`, `degraded`, `empty`, `error`, `permission_blocked`, and
 `unsupported`. Implemented operations are `risk/calculate`, `risk/drawdown`,
 `risk/rolling-metrics`, `risk/historical-attribution`, and `risk/concentration`; the labels are
-bounded and intentionally exclude portfolio, client, account, position, transaction, trace,
-correlation, and request identifiers.
+bounded and intentionally exclude portfolio, client, account, position, transaction, security,
+trace, correlation, request-body, and response-body identifiers.
 
 The analytics responses include `metadata.calculation_supportability` so Gateway and Workbench can
 consume source-backed supportability posture without inferring it from individual metric errors,
 period errors, issuer coverage, or return-series recency. Current reason values include:
+
+The same block includes `metric_labels`. It is the implementation-backed operator contract for
+`lotus_risk_calculation_supportability_total`; identifiers, correlation or trace values, security
+or transaction identifiers, and request or response payload fields are explicitly excluded from
+metric labels.
 
 1. `calculation_complete`,
 2. `benchmark_unavailable`,

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-04-30T06:24:23.286167+00:00",
+  "generatedAt": "2026-05-01T12:41:21.413246+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.alignment_policy",
@@ -1064,6 +1064,25 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.metric_labels",
+      "canonicalTerm": "metric_labels",
+      "preferredName": "metric_labels",
+      "description": "Bounded Prometheus label keys emitted by lotus_risk_calculation_supportability_total. Identifiers, trace or correlation values, and request or response payload fields must not be metric labels.",
+      "example": [
+        "operation",
+        "supportability_state",
+        "reason",
+        "freshness_bucket"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -3595,6 +3614,14 @@
             "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
           },
           {
+            "name": "metadata.calculation_supportability.metric_labels",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.metric_labels",
+            "attributeRef": "#/attributeCatalog/lotus.metric_labels"
+          },
+          {
             "name": "metadata.calculation_supportability.degraded_metric_count",
             "location": "body",
             "required": false,
@@ -4401,6 +4428,14 @@
             "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
           },
           {
+            "name": "metadata.calculation_supportability.metric_labels",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.metric_labels",
+            "attributeRef": "#/attributeCatalog/lotus.metric_labels"
+          },
+          {
             "name": "metadata.calculation_supportability.degraded_metric_count",
             "location": "body",
             "required": false,
@@ -4712,6 +4747,14 @@
             "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
           },
           {
+            "name": "metadata.calculation_supportability.metric_labels",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.metric_labels",
+            "attributeRef": "#/attributeCatalog/lotus.metric_labels"
+          },
+          {
             "name": "metadata.calculation_supportability.degraded_metric_count",
             "location": "body",
             "required": false,
@@ -5005,6 +5048,14 @@
             "type": "string",
             "semanticId": "lotus.freshness_bucket",
             "attributeRef": "#/attributeCatalog/lotus.freshness_bucket"
+          },
+          {
+            "name": "metadata.calculation_supportability.metric_labels",
+            "location": "body",
+            "required": false,
+            "type": "array",
+            "semanticId": "lotus.metric_labels",
+            "attributeRef": "#/attributeCatalog/lotus.metric_labels"
           },
           {
             "name": "metadata.calculation_supportability.degraded_metric_count",

--- a/docs/standards/risk-analytics-contract.md
+++ b/docs/standards/risk-analytics-contract.md
@@ -65,8 +65,10 @@
   `permission_blocked`, `stale_source_observations`, and `unsupported_input_mode`.
 - Prometheus exports the same posture through `lotus_risk_calculation_supportability_total` with
   bounded labels only: `operation`, `supportability_state`, `reason`, and `freshness_bucket`.
+- The response contract publishes these keys as `metric_labels` so operators, Gateway, Workbench,
+  and demos can inspect the supportability metric contract without inferring it from scrape output.
 - Metrics and response metadata must not expose portfolio, client, account, position, transaction,
-  trace, correlation, or raw request identifiers.
+  security, trace, correlation, request-body, response-body, or raw request identifiers.
 - Endpoint-specific supportability must be source-backed: return-series endpoints derive freshness
   and empty/degraded posture from period results, while concentration derives degraded posture from
   issuer coverage and empty universe support.

--- a/src/app/contracts/risk.py
+++ b/src/app/contracts/risk.py
@@ -7,6 +7,7 @@ from typing import Any, ClassVar, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.contracts.audit import AuditMetadataFields
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 
 RiskMetric = Literal[
     "VOLATILITY",
@@ -545,6 +546,23 @@ class RiskCalculationSupportability(BaseModel):
     freshness_bucket: RiskFreshnessBucket = Field(
         description="Bounded source freshness bucket based on the latest return observation.",
         json_schema_extra={"example": "current"},
+    )
+    metric_labels: tuple[str, ...] = Field(
+        default=RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+        description=(
+            "Bounded Prometheus label keys emitted by "
+            "lotus_risk_calculation_supportability_total. Identifiers, trace or "
+            "correlation values, and request or response payload fields must not be "
+            "metric labels."
+        ),
+        json_schema_extra={
+            "example": [
+                "operation",
+                "supportability_state",
+                "reason",
+                "freshness_bucket",
+            ]
+        },
     )
     degraded_metric_count: int = Field(
         default=0,

--- a/src/app/observability.py
+++ b/src/app/observability.py
@@ -4,6 +4,10 @@ from time import perf_counter
 
 from prometheus_client import Counter, Histogram
 
+from app.observability_contracts import (
+    RISK_ANALYTICS_FRESHNESS_METRIC_LABELS,
+    RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+)
 
 ENDPOINT_EXECUTIONS_TOTAL = Counter(
     "lotus_risk_endpoint_executions_total",
@@ -28,12 +32,12 @@ UPSTREAM_REQUEST_SECONDS = Histogram(
 CALCULATION_SUPPORTABILITY_TOTAL = Counter(
     "lotus_risk_calculation_supportability_total",
     "Risk calculation supportability posture by bounded operation, state, reason, and freshness bucket.",
-    ["operation", "supportability_state", "reason", "freshness_bucket"],
+    RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
 )
 ANALYTICS_FRESHNESS_BUCKET_TOTAL = Counter(
     "lotus_analytics_freshness_bucket_total",
     "Backend analytics freshness and supportability posture by service, operation, and bounded freshness bucket.",
-    ["service", "operation", "freshness_bucket", "supportability_state"],
+    RISK_ANALYTICS_FRESHNESS_METRIC_LABELS,
 )
 
 

--- a/src/app/observability_contracts.py
+++ b/src/app/observability_contracts.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS: tuple[str, ...] = (
+    "operation",
+    "supportability_state",
+    "reason",
+    "freshness_bucket",
+)
+
+RISK_ANALYTICS_FRESHNESS_METRIC_LABELS: tuple[str, ...] = (
+    "service",
+    "operation",
+    "freshness_bucket",
+    "supportability_state",
+)

--- a/tests/integration/test_drawdown_endpoint.py
+++ b/tests/integration/test_drawdown_endpoint.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from tests.support.app_runtime import override_app_runtime
 from tests.support.lotus_performance_fakes import (
     RecordingLotusPerformanceClient,
@@ -17,6 +18,7 @@ _AutoWiredLotusPerformanceClient = build_autowired_lotus_performance_client_clas
         portfolio_returns=JAN_2026_PORTFOLIO_RETURNS[:2],
     )
 )
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 def _stateless_payload() -> dict[str, object]:
@@ -53,6 +55,7 @@ def test_drawdown_endpoint_stateless_contract() -> None:
         "state": "ready",
         "reason": "calculation_complete",
         "freshness_bucket": "current",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 0,
         "empty_period_count": 0,
         "evaluated_period_count": 1,
@@ -131,6 +134,7 @@ def test_drawdown_endpoint_marks_benchmark_unavailable_when_requested_without_se
         "state": "degraded",
         "reason": "benchmark_unavailable",
         "freshness_bucket": "current",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 1,
         "empty_period_count": 0,
         "evaluated_period_count": 1,
@@ -154,6 +158,7 @@ def test_drawdown_endpoint_supportability_marks_empty_periods() -> None:
         "state": "degraded",
         "reason": "insufficient_observations",
         "freshness_bucket": "current",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 1,
         "empty_period_count": 1,
         "evaluated_period_count": 1,

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from app.upstream_errors import UpstreamServiceError
 from tests.support.app_runtime import override_app_runtime
 from tests.support.historical_attribution_fakes import (
@@ -10,6 +11,8 @@ from tests.support.historical_attribution_fakes import (
     build_sector_position_timeseries_rows,
     build_stateful_attribution_returns_client,
 )
+
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 def _stateless_attribution_payload() -> dict[str, object]:
@@ -214,6 +217,7 @@ def test_historical_attribution_stateless_happy_path() -> None:
         "state": "ready",
         "reason": "calculation_complete",
         "freshness_bucket": "current",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 0,
         "empty_period_count": 0,
         "evaluated_period_count": 1,
@@ -237,6 +241,7 @@ def test_historical_attribution_supportability_marks_empty_returns() -> None:
         "state": "empty",
         "reason": "no_return_observations",
         "freshness_bucket": "unknown",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 0,
         "empty_period_count": 0,
         "evaluated_period_count": 0,

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
 from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY, generate_latest
 
 from app.main import app
+from app.observability_contracts import (
+    RISK_ANALYTICS_FRESHNESS_METRIC_LABELS,
+    RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
+)
 from tests.support.app_runtime import override_app_runtime
 from tests.support.lotus_performance_fakes import RecordingLotusPerformanceClient
 from tests.support.returns_series_payloads import build_returns_series_response
 
 
 client = TestClient(app)
+FORBIDDEN_SUPPORTABILITY_METRIC_LABELS = {
+    "portfolio_id",
+    "account_id",
+    "client_id",
+    "correlation_id",
+    "trace_id",
+    "transaction_id",
+    "security_id",
+    "request_body",
+    "response_body",
+}
 
 
 def _risk_stateless_payload() -> dict[str, object]:
@@ -42,6 +58,8 @@ def _risk_stateful_payload() -> dict[str, object]:
 def test_metrics_expose_endpoint_execution_mode_and_outcome() -> None:
     response = client.post("/analytics/risk/calculate", json=_risk_stateless_payload())
     assert response.status_code == 200
+    supportability = response.json()["metadata"]["calculation_supportability"]
+    assert supportability["metric_labels"] == list(RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
     metrics = client.get("/metrics").text
 
@@ -59,6 +77,38 @@ def test_metrics_expose_endpoint_execution_mode_and_outcome() -> None:
         'lotus_analytics_freshness_bucket_total{freshness_bucket="stale",'
         'operation="risk/calculate",service="lotus-risk",supportability_state="stale"}'
     ) in metrics
+
+
+def test_supportability_metrics_use_only_bounded_labels() -> None:
+    response = client.post("/analytics/risk/calculate", json=_risk_stateless_payload())
+    assert response.status_code == 200
+
+    metrics = generate_latest(REGISTRY).decode("utf-8")
+    supportability_lines = [
+        line
+        for line in metrics.splitlines()
+        if line.startswith("lotus_risk_calculation_supportability_total{")
+        and 'operation="risk/calculate"' in line
+    ]
+    freshness_lines = [
+        line
+        for line in metrics.splitlines()
+        if line.startswith("lotus_analytics_freshness_bucket_total{")
+        and 'operation="risk/calculate"' in line
+    ]
+
+    assert supportability_lines
+    assert freshness_lines
+    supportability_line = supportability_lines[-1]
+    freshness_line = freshness_lines[-1]
+
+    for label in RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS:
+        assert f"{label}=" in supportability_line
+    for label in RISK_ANALYTICS_FRESHNESS_METRIC_LABELS:
+        assert f"{label}=" in freshness_line
+    for forbidden_label in FORBIDDEN_SUPPORTABILITY_METRIC_LABELS:
+        assert f"{forbidden_label}=" not in supportability_line
+        assert f"{forbidden_label}=" not in freshness_line
 
 
 def test_metrics_expose_stateful_endpoint_execution_mode() -> None:

--- a/tests/integration/test_rolling_metrics_endpoint.py
+++ b/tests/integration/test_rolling_metrics_endpoint.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from tests.support.app_runtime import override_app_runtime
 from tests.support.lotus_core_fakes import RecordingLotusCoreReferenceClient
 from tests.support.lotus_performance_fakes import (
@@ -23,6 +24,7 @@ _AutoWiredLotusPerformanceClient = build_autowired_lotus_performance_client_clas
         benchmark_returns=JAN_2026_ROLLING_BENCHMARK_RETURNS,
     )
 )
+_EXPECTED_SUPPORTABILITY_METRIC_LABELS = list(RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
 
 
 def _stateless_payload() -> dict[str, object]:
@@ -101,6 +103,7 @@ def test_rolling_metrics_endpoint_stateless_contract() -> None:
         "state": "stale",
         "reason": "stale_source_observations",
         "freshness_bucket": "stale",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 0,
         "empty_period_count": 0,
         "evaluated_period_count": 1,
@@ -165,6 +168,7 @@ def test_rolling_metrics_endpoint_supportability_marks_insufficient_period() -> 
         "state": "degraded",
         "reason": "insufficient_observations",
         "freshness_bucket": "stale",
+        "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 1,
         "empty_period_count": 0,
         "evaluated_period_count": 1,

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -1,4 +1,5 @@
 from app.contracts.concentration import ConcentrationRequest
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
 from app.services.concentration_engine import _compute_hhi, calculate_concentration
 import pytest
 from pydantic import ValidationError
@@ -111,6 +112,7 @@ async def test_calculate_concentration_stateless_uses_projected_values_when_prov
             "state": "ready",
             "reason": "calculation_complete",
             "freshness_bucket": "unknown",
+            "metric_labels": RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
             "degraded_metric_count": 0,
             "empty_period_count": 0,
             "evaluated_period_count": 1,
@@ -149,6 +151,7 @@ async def test_calculate_concentration_falls_back_to_current_when_no_projected()
         "state": "degraded",
         "reason": "calculation_quality_issue",
         "freshness_bucket": "unknown",
+        "metric_labels": RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS,
         "degraded_metric_count": 1,
         "empty_period_count": 0,
         "evaluated_period_count": 1,

--- a/tests/unit/test_rfc0108_supportability_contract.py
+++ b/tests/unit/test_rfc0108_supportability_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.main import app
+from app.observability_contracts import RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS
+
+
+def test_risk_supportability_openapi_documents_metric_labels() -> None:
+    schema = app.openapi()["components"]["schemas"]["RiskCalculationSupportability"]
+    metric_labels = schema["properties"]["metric_labels"]
+
+    assert metric_labels["default"] == list(RISK_CALCULATION_SUPPORTABILITY_METRIC_LABELS)
+    assert "lotus_risk_calculation_supportability_total" in metric_labels["description"]
+    assert (
+        "request or response payload fields must not be metric labels"
+        in (metric_labels["description"])
+    )

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -81,8 +81,19 @@ The matching Prometheus counter is
 The same source-owned posture also increments the RFC-0108 cross-service freshness counter
 `lotus_analytics_freshness_bucket_total{service="lotus-risk",operation,freshness_bucket,supportability_state}`.
 
-Do not add portfolio, client, account, position, transaction, trace, correlation, or request
-identifiers to supportability metric labels.
+The response contract publishes `metadata.calculation_supportability.metric_labels` so operators
+can verify the metric-label contract directly from the API response. Do not add portfolio, account,
+client, correlation, trace, transaction, request-body, response-body, or security identifiers to
+supportability metric labels.
+
+```mermaid
+flowchart LR
+    RiskEndpoint[Risk analytics endpoint] --> Supportability[metadata.calculation_supportability]
+    Supportability --> Gateway[Gateway source_supportability]
+    Supportability --> Metrics[lotus_risk_calculation_supportability_total]
+    Metrics --> Platform[Platform dashboards and alerts]
+    Gateway --> Workbench[Workbench risk panel support state]
+```
 
 When the question is "should this workflow be offered at all?" also check:
 


### PR DESCRIPTION
## Summary
- Adds a shared RFC-0108 risk observability label contract for `lotus_risk_calculation_supportability_total` and `lotus_analytics_freshness_bucket_total`.
- Publishes `metadata.calculation_supportability.metric_labels` in the risk API contract so Gateway, Workbench, operators, and demos can inspect bounded label truth directly from API responses.
- Adds implementation-backed tests proving API/OpenAPI contract behavior and real Prometheus exposition labels exclude sensitive or high-cardinality identifiers.
- Updates risk API docs, repository context, generated API vocabulary, and repo-local wiki runbook with the current supportability flow.

## Local Evidence
- `python -m pytest tests\integration\test_observability.py tests\unit\test_rfc0108_supportability_contract.py tests\unit\test_concentration_engine.py tests\integration\test_drawdown_endpoint.py tests\integration\test_historical_attribution_endpoint.py tests\integration\test_rolling_metrics_endpoint.py -q` -> 38 passed
- `make lint` -> passed
- `make typecheck` -> passed
- `make openapi-gate` -> passed
- `make api-vocabulary-gate` -> passed
- `make no-alias-gate` -> passed
- `make domain-data-product-gate` -> passed
- `make migration-smoke` -> passed
- `make test-unit` -> 297 passed
- `make test-integration` -> 80 passed, 14 skipped
- `make test-e2e` -> 21 passed
- `make test-pyramid-gate` -> unit 72.09%, integration 22.82%, e2e 5.10%
- `make test-coverage` -> 98% total coverage
- `make security-audit` -> 0 known vulnerabilities
- `make docker-build` -> passed
- `git diff --check` -> passed, with Git line-ending notices only
- `Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift on `Operations-Runbook.md` because repo-local wiki source changed and must be published after merge

## Wiki
- Repo-local `wiki/Operations-Runbook.md` was updated in this PR.
- After merge, publish with `lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-risk`.