### PR TITLE
feat: add regime scenario pack evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ Current primary workflows:
 3. `POST /analytics/risk/rolling-metrics`
 4. `POST /analytics/risk/historical-attribution`
 5. `POST /analytics/risk/concentration`
-6. `GET /integration/capabilities`
-7. `GET /ops`
+6. `POST /analytics/risk/regime-scenario-pack/evaluate`
+7. `GET /integration/capabilities`
+8. `GET /ops`
 
 Important posture limits:
 
 1. concentration is the only workflow that currently supports `simulation`,
-2. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is intentionally gated,
-3. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
-4. broader enterprise-bank claims require more seeded archetypes and attached evidence.
+2. regime scenario-pack evaluation is stateless and consumes caller-supplied exposure weights
+   against risk-owned CIO scenario definitions; it does not forecast markets or accept UI-owned
+   scenario methodology,
+3. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is intentionally gated,
+4. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
+5. broader enterprise-bank claims require more seeded archetypes and attached evidence.
 
 ## Architectural Shape
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -21,7 +21,9 @@ This repository owns:
 1. risk analytics calculations,
 2. risk workspace supportability and decomposition payloads,
 3. drawdown and concentration review data,
-4. integration-ready risk contracts consumed by `lotus-gateway`.
+4. governed regime scenario-pack evaluation for downstream construction and stress posture,
+5. integration-ready risk contracts consumed by `lotus-gateway` and domain consumers such as
+   `lotus-manage`.
 
 ## Current-State Summary
 
@@ -36,7 +38,11 @@ Current repository posture:
 7. repo-native RFC-0086 product and consumer declarations now live under `contracts/domain-data-products/` with a local `make domain-data-product-gate` validation path,
 8. RFC-0087 trust telemetry proof for `RiskMetricsReport` now lives under
    `contracts/trust-telemetry/` and is validated by `tests/unit/test_trust_telemetry.py` against
-   the platform trust telemetry validator when `lotus-platform` is available.
+   the platform trust telemetry validator when `lotus-platform` is available,
+9. `RegimeScenarioPackEvaluation:v1` is a repo-native domain data product exposed through
+   `POST /analytics/risk/regime-scenario-pack/evaluate`; it evaluates caller-supplied exposure
+   weights against governed CIO scenario-pack definitions and returns source-owned worst-case loss,
+   threshold breach posture, lineage, supportability, and bounded reason codes.
 
 ## Architecture And Module Map
 

--- a/contracts/domain-data-products/lotus-risk-products.v1.json
+++ b/contracts/domain-data-products/lotus-risk-products.v1.json
@@ -288,6 +288,60 @@
         "issuer_id"
       ],
       "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "RegimeScenarioPackEvaluation",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services"
+      ],
+      "current_routes": [
+        "/analytics/risk/regime-scenario-pack/evaluate"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Regime scenario-pack evaluation must reflect the governed scenario pack and caller-supplied exposure weights for the requested as-of date."
+      },
+      "completeness_policy": {
+        "default_status": "complete",
+        "partial_allowed": false
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway",
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
     }
   ]
 }

--- a/docs/domain-apis/endpoint-matrix.md
+++ b/docs/domain-apis/endpoint-matrix.md
@@ -24,6 +24,7 @@ Status meanings:
 | `POST /analytics/risk/rolling-metrics` | Domain analytics | rolling historical risk diagnostics | `stateless`, `stateful` | full | lotus-performance for portfolio/benchmark returns; lotus-core for risk-free series and reporting-currency resolution | simulation is intentionally unsupported; broader enterprise archetype coverage still requires additional seeded live portfolios beyond the canonical baseline |
 | `POST /analytics/risk/historical-attribution` | Domain analytics | historical risk and active-risk attribution decomposition | `stateless`, `stateful` | partial | stateless caller-supplied returns/exposures; stateful sourcing uses lotus-performance for portfolio/benchmark returns and benchmark exposure context, and lotus-core for portfolio exposure history and instrument enrichment | stateful `ACTIVE_RISK` supports `POSITION`, `SECTOR`, and `ASSET_CLASS`; `ISSUER` remains gated by benchmark issuer exposure semantics; simulation is intentionally unsupported |
 | `POST /analytics/risk/concentration` | Domain analytics | concentration analytics and HHI metrics | `stateless`, `stateful`, `simulation` | full | lotus-core snapshot and simulation session contracts | none |
+| `POST /analytics/risk/regime-scenario-pack/evaluate` | Domain analytics | governed CIO regime scenario-pack evaluation | `stateless` | full | caller-supplied exposure weights and risk-owned scenario-pack definitions | does not forecast market states or accept browser-owned scenario methodology |
 
 ## Mode Support Detail
 
@@ -34,6 +35,7 @@ Status meanings:
 | `POST /analytics/risk/rolling-metrics` | full | full | unsupported by contract |
 | `POST /analytics/risk/historical-attribution` | full | partial | unsupported by contract |
 | `POST /analytics/risk/concentration` | full | full | full |
+| `POST /analytics/risk/regime-scenario-pack/evaluate` | full | unsupported by contract | unsupported by contract |
 
 ## Highest-Value Remaining Gap
 

--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -35,6 +35,7 @@
   - `risk.analytics.concentration`
   - `risk.analytics.rolling_metrics`
   - `risk.analytics.historical_attribution`
+  - `risk.analytics.regime_scenario_pack`
   - `risk.analytics.metrics`
   - `risk.observability.calculation_supportability`
 - `workflows`:
@@ -43,6 +44,7 @@
   - `concentration_risk`
   - `rolling_risk_analytics`
   - `historical_risk_attribution`
+  - `regime_scenario_pack_evaluation`
 
 Each workflow now also publishes:
 
@@ -59,6 +61,9 @@ This allows consumers to discover that:
 - historical-attribution response metadata is the authoritative active-risk support contract
 - risk snapshot VaR and expected shortfall are signed return-threshold metrics
 - historical attribution residual and `reconciled_sum` must be preserved with contributors
+- regime scenario-pack evaluation is a stateless source-owned workflow that returns worst-case loss,
+  policy-threshold breach posture, lineage, and bounded reason codes from risk-owned CIO scenario
+  definitions
 - downstream product surfaces must derive simulation and issuer active-risk affordances from this
   payload, not from broad service-level support for the word `simulation`
 - downstream consumers must also treat

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-01T12:41:21.413246+00:00",
+  "generatedAt": "2026-05-06T03:02:34.947310+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.alignment_policy",
@@ -102,8 +102,8 @@
       "semanticId": "lotus.as_of_date",
       "canonicalTerm": "as_of_date",
       "preferredName": "as_of_date",
-      "description": "As-of date used for risk metric evaluation.",
-      "example": "2025-03-31",
+      "description": "Business date for the scenario-pack evaluation.",
+      "example": "2026-05-03",
       "type": "string",
       "locations": [
         "body"
@@ -174,18 +174,45 @@
       ]
     },
     {
-      "semanticId": "lotus.calculation_supportability",
-      "canonicalTerm": "calculation_supportability",
-      "preferredName": "calculation_supportability",
-      "description": "Canonical calculation supportability used by lotus-risk APIs.",
-      "example": {
-        "key": "value"
-      },
-      "type": "RiskCalculationSupportability",
+      "semanticId": "lotus.breach",
+      "canonicalTerm": "breach",
+      "preferredName": "breach",
+      "description": "Whether worst_case_loss_pct exceeds maximum_allowed_loss_pct.",
+      "example": false,
+      "type": "boolean",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "boolean"
+      ]
+    },
+    {
+      "semanticId": "lotus.bucket",
+      "canonicalTerm": "bucket",
+      "preferredName": "bucket",
+      "description": "Risk scenario exposure bucket.",
+      "example": "EQUITY",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.calculation_supportability",
+      "canonicalTerm": "calculation_supportability",
+      "preferredName": "calculation_supportability",
+      "description": "Canonical calculation supportability used by lotus-risk APIs.",
+      "example": "ready",
+      "type": "ScenarioSupportabilityState",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "ScenarioSupportabilityState",
         "RiskCalculationSupportability"
       ]
     },
@@ -471,7 +498,7 @@
       "canonicalTerm": "declared_product_count",
       "preferredName": "declared_product_count",
       "description": "Number of repo-native declared producer products included in the snapshot.",
-      "example": 5,
+      "example": 6,
       "type": "integer",
       "locations": [
         "body"
@@ -579,6 +606,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.display_name",
+      "canonicalTerm": "display_name",
+      "preferredName": "display_name",
+      "description": "Scenario display name.",
+      "example": "Growth slowdown",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -691,6 +732,47 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.expected_loss_pct",
+      "canonicalTerm": "expected_loss_pct",
+      "preferredName": "expected_loss_pct",
+      "description": "Expected portfolio loss ratio under this scenario.",
+      "example": 0.0845,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.exposures",
+      "canonicalTerm": "exposures",
+      "preferredName": "exposures",
+      "description": "Caller-supplied portfolio exposure weights by scenario bucket.",
+      "example": [
+        {
+          "bucket": "EQUITY",
+          "weight": 0.55
+        },
+        {
+          "bucket": "FIXED_INCOME",
+          "weight": 0.35
+        },
+        {
+          "bucket": "CASH",
+          "weight": 0.1
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -1033,6 +1115,20 @@
       ]
     },
     {
+      "semanticId": "lotus.maximum_allowed_loss_pct",
+      "canonicalTerm": "maximum_allowed_loss_pct",
+      "preferredName": "maximum_allowed_loss_pct",
+      "description": "Maximum permitted scenario loss ratio for the consumer policy.",
+      "example": 0.12,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
       "semanticId": "lotus.metadata",
       "canonicalTerm": "metadata",
       "preferredName": "metadata",
@@ -1040,11 +1136,12 @@
       "example": {
         "key": "value"
       },
-      "type": "HistoricalAttributionMetadata",
+      "type": "ScenarioEvaluationMetadata",
       "locations": [
         "body"
       ],
       "observedTypes": [
+        "ScenarioEvaluationMetadata",
         "HistoricalAttributionMetadata",
         "object",
         "DrawdownMetadata",
@@ -1244,6 +1341,20 @@
       ]
     },
     {
+      "semanticId": "lotus.portfolio_id",
+      "canonicalTerm": "portfolio_id",
+      "preferredName": "portfolio_id",
+      "description": "Optional portfolio identifier used for lineage and diagnostics.",
+      "example": "PB_SG_GLOBAL_BAL_001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.producer_repository",
       "canonicalTerm": "producer_repository",
       "preferredName": "producer_repository",
@@ -1399,6 +1510,22 @@
       ]
     },
     {
+      "semanticId": "lotus.reason_codes",
+      "canonicalTerm": "reason_codes",
+      "preferredName": "reason_codes",
+      "description": "Bounded reason codes explaining scenario evaluation posture.",
+      "example": [
+        "REGIME_SCENARIO_PACK_READY"
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.reporting_currency",
       "canonicalTerm": "reporting_currency",
       "preferredName": "reporting_currency",
@@ -1423,7 +1550,8 @@
         "body"
       ],
       "observedTypes": [
-        "object"
+        "object",
+        "string"
       ]
     },
     {
@@ -1675,6 +1803,58 @@
       ]
     },
     {
+      "semanticId": "lotus.scenario_id",
+      "canonicalTerm": "scenario_id",
+      "preferredName": "scenario_id",
+      "description": "Scenario identifier within the governed pack.",
+      "example": "growth_slowdown",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.scenario_pack_id",
+      "canonicalTerm": "scenario_pack_id",
+      "preferredName": "scenario_pack_id",
+      "description": "Governed scenario pack identifier.",
+      "example": "CIO_REGIME_2026_Q2",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.scenario_results",
+      "canonicalTerm": "scenario_results",
+      "preferredName": "scenario_results",
+      "description": "Per-scenario loss results from the governed scenario pack.",
+      "example": [
+        {
+          "display_name": "Growth slowdown",
+          "expected_loss_pct": 0.0765,
+          "scenario_id": "growth_slowdown",
+          "shock_by_bucket": {
+            "EQUITY": -0.12,
+            "FIXED_INCOME": -0.03
+          }
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.scope",
       "canonicalTerm": "scope",
       "preferredName": "scope",
@@ -1730,6 +1910,23 @@
       ],
       "observedTypes": [
         "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.shock_by_bucket",
+      "canonicalTerm": "shock_by_bucket",
+      "preferredName": "shock_by_bucket",
+      "description": "Scenario shock ratios by exposure bucket.",
+      "example": {
+        "EQUITY": -0.12,
+        "FIXED_INCOME": -0.03
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -2435,8 +2632,8 @@
       "semanticId": "lotus.weight",
       "canonicalTerm": "weight",
       "preferredName": "weight",
-      "description": "Portfolio weight of the top concentration-driving position.",
-      "example": 0.23014,
+      "description": "Portfolio weight for this exposure bucket.",
+      "example": 0.55,
       "type": "number",
       "locations": [
         "body"
@@ -2517,6 +2714,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.worst_case_loss_pct",
+      "canonicalTerm": "worst_case_loss_pct",
+      "preferredName": "worst_case_loss_pct",
+      "description": "Largest expected portfolio loss ratio across scenarios.",
+      "example": 0.0845,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
       ]
     }
   ],
@@ -3359,6 +3570,229 @@
       },
       "response": {
         "fields": []
+      }
+    },
+    {
+      "domain": "risk_analytics",
+      "method": "POST",
+      "path": "/analytics/risk/regime-scenario-pack/evaluate",
+      "operationId": "analytics_risk_regime_scenario_pack_analytics_risk_regime_scenario_pack_evaluate_post",
+      "summary": "Evaluate a governed regime scenario pack",
+      "request": {
+        "fields": [
+          {
+            "name": "scenario_pack_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.scenario_pack_id",
+            "attributeRef": "#/attributeCatalog/lotus.scenario_pack_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "exposures",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.exposures",
+            "attributeRef": "#/attributeCatalog/lotus.exposures"
+          },
+          {
+            "name": "exposures[].bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.bucket",
+            "attributeRef": "#/attributeCatalog/lotus.bucket"
+          },
+          {
+            "name": "exposures[].weight",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.weight",
+            "attributeRef": "#/attributeCatalog/lotus.weight"
+          },
+          {
+            "name": "maximum_allowed_loss_pct",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.maximum_allowed_loss_pct",
+            "attributeRef": "#/attributeCatalog/lotus.maximum_allowed_loss_pct"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "scenario_pack_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.scenario_pack_id",
+            "attributeRef": "#/attributeCatalog/lotus.scenario_pack_id"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "worst_case_loss_pct",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.worst_case_loss_pct",
+            "attributeRef": "#/attributeCatalog/lotus.worst_case_loss_pct"
+          },
+          {
+            "name": "maximum_allowed_loss_pct",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.maximum_allowed_loss_pct",
+            "attributeRef": "#/attributeCatalog/lotus.maximum_allowed_loss_pct"
+          },
+          {
+            "name": "breach",
+            "location": "body",
+            "required": true,
+            "type": "boolean",
+            "semanticId": "lotus.breach",
+            "attributeRef": "#/attributeCatalog/lotus.breach"
+          },
+          {
+            "name": "scenario_results",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.scenario_results",
+            "attributeRef": "#/attributeCatalog/lotus.scenario_results"
+          },
+          {
+            "name": "scenario_results[].scenario_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.scenario_id",
+            "attributeRef": "#/attributeCatalog/lotus.scenario_id"
+          },
+          {
+            "name": "scenario_results[].display_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.display_name",
+            "attributeRef": "#/attributeCatalog/lotus.display_name"
+          },
+          {
+            "name": "scenario_results[].expected_loss_pct",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.expected_loss_pct",
+            "attributeRef": "#/attributeCatalog/lotus.expected_loss_pct"
+          },
+          {
+            "name": "scenario_results[].shock_by_bucket",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.shock_by_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.shock_by_bucket"
+          },
+          {
+            "name": "reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "metadata",
+            "location": "body",
+            "required": true,
+            "type": "ScenarioEvaluationMetadata",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "#/attributeCatalog/lotus.metadata"
+          },
+          {
+            "name": "metadata.product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "metadata.product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_version",
+            "attributeRef": "#/attributeCatalog/lotus.product_version"
+          },
+          {
+            "name": "metadata.source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "metadata.lineage_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.lineage_version",
+            "attributeRef": "#/attributeCatalog/lotus.lineage_version"
+          },
+          {
+            "name": "metadata.request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": true,
+            "type": "ScenarioSupportabilityState",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          }
+        ]
       }
     },
     {

--- a/output/rfc0039-wtbd009-regime-scenario-pack-proof/20260506-105300/critical-review.json
+++ b/output/rfc0039-wtbd009-regime-scenario-pack-proof/20260506-105300/critical-review.json
@@ -1,0 +1,53 @@
+{
+  "rfc": "RFC-0039",
+  "wtbd_id": "RFC39-WTBD-009",
+  "repository": "lotus-risk",
+  "slice": "source-owned regime scenario-pack evaluation",
+  "timestamp_sgt": "2026-05-06T10:53:00+08:00",
+  "branch": "feat/rfc39-scenario-pack-source-product",
+  "implementation_summary": {
+    "completed": [
+      "Added RegimeScenarioPackEvaluation:v1 as a lotus-risk domain data product.",
+      "Added POST /analytics/risk/regime-scenario-pack/evaluate.",
+      "Implemented deterministic evaluation of caller-supplied exposure weights against governed CIO scenario-pack definitions.",
+      "Returned source-owned worst-case loss, policy-threshold breach posture, supportability, lineage, request fingerprint, and bounded reason codes.",
+      "Updated endpoint matrix, integration-capabilities docs, README, repository context, wiki source, API vocabulary, and trust telemetry product count."
+    ],
+    "explicit_non_claims": [
+      "The endpoint does not forecast future market states.",
+      "The endpoint does not accept UI-owned or Gateway-owned scenario methodology.",
+      "Stateful scenario-pack sourcing remains unsupported until upstream exposure retrieval is separately governed."
+    ]
+  },
+  "critical_review": {
+    "design_assessment": "The implementation keeps scenario methodology in lotus-risk and gives consumers a bounded, source-owned stress evaluation contract. This is a better source-owner fit than putting scenario-pack logic into lotus-manage construction.",
+    "quality_improvements": [
+      "New contract and engine modules keep scenario schema separate from existing risk, drawdown, rolling, attribution, and concentration code.",
+      "OpenAPI gate forced field examples for every new response object field.",
+      "Domain-product gate forced platform mirror synchronization before risk closure."
+    ],
+    "remaining_boundaries": [
+      "Downstream manage consumption must be implemented separately and must preserve risk-owned outputs without recomputation.",
+      "Gateway/Workbench product-surface support remains unclaimed until downstream implementation and proof."
+    ]
+  },
+  "validation": [
+    {
+      "command": "python -m pytest tests\\unit\\test_scenario_engine.py tests\\unit\\test_scenario_api.py tests\\unit\\test_domain_data_products.py tests\\unit\\test_capabilities_contract.py -q",
+      "result": "13 passed"
+    },
+    {
+      "command": "make check",
+      "result": "passed: Ruff, format, no-alias guard, mypy, OpenAPI quality, API vocabulary inventory, domain-data product contract check, and 303 unit tests"
+    },
+    {
+      "command": "python -m pytest tests\\integration\\test_health.py tests\\e2e\\test_smoke.py -q",
+      "result": "50 passed after updating trust-telemetry product-count and capability-contract expectations for the new product"
+    },
+    {
+      "command": "lotus-platform PR #303",
+      "result": "merged platform mirror for RegimeScenarioPackEvaluation:v1 after green platform checks"
+    }
+  ],
+  "status": "ready_for_risk_pr"
+}

--- a/src/app/contracts/capabilities.py
+++ b/src/app/contracts/capabilities.py
@@ -10,6 +10,7 @@ CAPABILITY_FEATURE_KEYS: tuple[str, ...] = (
     "risk.analytics.drawdown",
     "risk.analytics.rolling_metrics",
     "risk.analytics.historical_attribution",
+    "risk.analytics.regime_scenario_pack",
     "risk.analytics.metrics",
     "risk.observability.calculation_supportability",
 )
@@ -19,6 +20,7 @@ CAPABILITY_WORKFLOW_KEYS: tuple[str, ...] = (
     "drawdown_analytics",
     "rolling_risk_analytics",
     "historical_risk_attribution",
+    "regime_scenario_pack_evaluation",
 )
 SupportedInputMode = Literal["stateless", "stateful", "simulation"]
 WorkflowSupportStatus = Literal["full", "partial"]

--- a/src/app/contracts/scenario.py
+++ b/src/app/contracts/scenario.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import datetime as dt
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class ScenarioSupportabilityState(StrEnum):
+    READY = "ready"
+    DEGRADED = "degraded"
+    PENDING_REVIEW = "pending_review"
+    BLOCKED = "blocked"
+
+
+class ScenarioExposure(BaseModel):
+    bucket: str = Field(
+        description="Risk scenario exposure bucket.",
+        json_schema_extra={"example": "EQUITY"},
+    )
+    weight: float = Field(
+        ge=0.0,
+        description="Portfolio weight for this exposure bucket.",
+        json_schema_extra={"example": 0.55},
+    )
+
+
+class RegimeScenarioPackRequest(BaseModel):
+    scenario_pack_id: str = Field(
+        description="Governed scenario pack identifier.",
+        json_schema_extra={"example": "CIO_REGIME_2026_Q2"},
+    )
+    portfolio_id: str | None = Field(
+        default=None,
+        description="Optional portfolio identifier used for lineage and diagnostics.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    as_of_date: dt.date = Field(
+        description="Business date for the scenario-pack evaluation.",
+        json_schema_extra={"example": "2026-05-03"},
+    )
+    exposures: list[ScenarioExposure] = Field(
+        description="Caller-supplied portfolio exposure weights by scenario bucket.",
+        json_schema_extra={
+            "example": [
+                {"bucket": "EQUITY", "weight": 0.55},
+                {"bucket": "FIXED_INCOME", "weight": 0.35},
+                {"bucket": "CASH", "weight": 0.10},
+            ]
+        },
+    )
+    maximum_allowed_loss_pct: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Maximum permitted scenario loss ratio for the consumer policy.",
+        json_schema_extra={"example": 0.12},
+    )
+
+    @model_validator(mode="after")
+    def validate_exposures(self) -> "RegimeScenarioPackRequest":
+        if not self.exposures:
+            raise ValueError("exposures must contain at least one scenario exposure bucket")
+        return self
+
+
+class ScenarioResult(BaseModel):
+    scenario_id: str = Field(
+        description="Scenario identifier within the governed pack.",
+        json_schema_extra={"example": "growth_slowdown"},
+    )
+    display_name: str = Field(
+        description="Scenario display name.",
+        json_schema_extra={"example": "Growth slowdown"},
+    )
+    expected_loss_pct: float = Field(
+        description="Expected portfolio loss ratio under this scenario.",
+        json_schema_extra={"example": 0.0845},
+    )
+    shock_by_bucket: dict[str, float] = Field(
+        description="Scenario shock ratios by exposure bucket.",
+        json_schema_extra={"example": {"EQUITY": -0.12, "FIXED_INCOME": -0.03}},
+    )
+
+
+class ScenarioEvaluationMetadata(BaseModel):
+    product_name: str = Field(
+        default="RegimeScenarioPackEvaluation",
+        description="Source-owned product name.",
+        json_schema_extra={"example": "RegimeScenarioPackEvaluation"},
+    )
+    product_version: str = Field(
+        default="v1",
+        description="Source-owned product version.",
+        json_schema_extra={"example": "v1"},
+    )
+    source_service: str = Field(
+        default="lotus-risk",
+        description="Authoritative source service.",
+        json_schema_extra={"example": "lotus-risk"},
+    )
+    lineage_version: str = Field(
+        default="risk-regime-scenario-pack-evaluation.v1",
+        description="Lineage policy version used for this evaluation.",
+        json_schema_extra={"example": "risk-regime-scenario-pack-evaluation.v1"},
+    )
+    request_fingerprint: str = Field(
+        description="Deterministic request fingerprint for replay and audit.",
+        json_schema_extra={"example": "sha256:abc123"},
+    )
+    calculation_supportability: ScenarioSupportabilityState = Field(
+        description="Source-owned supportability posture.",
+        json_schema_extra={"example": "ready"},
+    )
+
+
+class RegimeScenarioPackResponse(BaseModel):
+    scenario_pack_id: str = Field(
+        description="Governed scenario pack identifier.",
+        json_schema_extra={"example": "CIO_REGIME_2026_Q2"},
+    )
+    portfolio_id: str | None = Field(
+        default=None,
+        description="Portfolio identifier when supplied by the caller.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    as_of_date: dt.date = Field(
+        description="Business date for the evaluation.",
+        json_schema_extra={"example": "2026-05-03"},
+    )
+    worst_case_loss_pct: float = Field(
+        description="Largest expected portfolio loss ratio across scenarios.",
+        json_schema_extra={"example": 0.0845},
+    )
+    maximum_allowed_loss_pct: float = Field(
+        description="Consumer-supplied maximum permitted scenario loss ratio.",
+        json_schema_extra={"example": 0.12},
+    )
+    breach: bool = Field(
+        description="Whether worst_case_loss_pct exceeds maximum_allowed_loss_pct.",
+        json_schema_extra={"example": False},
+    )
+    scenario_results: list[ScenarioResult] = Field(
+        description="Per-scenario loss results from the governed scenario pack.",
+        json_schema_extra={
+            "example": [
+                {
+                    "scenario_id": "growth_slowdown",
+                    "display_name": "Growth slowdown",
+                    "expected_loss_pct": 0.0765,
+                    "shock_by_bucket": {"EQUITY": -0.12, "FIXED_INCOME": -0.03},
+                }
+            ]
+        },
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded reason codes explaining scenario evaluation posture.",
+        json_schema_extra={"example": ["REGIME_SCENARIO_PACK_READY"]},
+    )
+    metadata: ScenarioEvaluationMetadata = Field(
+        description="Source-owned product, lineage, and supportability metadata.",
+        json_schema_extra={
+            "example": {
+                "product_name": "RegimeScenarioPackEvaluation",
+                "product_version": "v1",
+                "source_service": "lotus-risk",
+                "lineage_version": "risk-regime-scenario-pack-evaluation.v1",
+                "request_fingerprint": "sha256:abc123",
+                "calculation_supportability": "ready",
+            }
+        },
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -34,6 +34,7 @@ from app.contracts.rolling import (
     RollingResponse,
 )
 from app.contracts.risk import RiskAnalyticsRequest, RiskInputMode, RiskResponse
+from app.contracts.scenario import RegimeScenarioPackRequest, RegimeScenarioPackResponse
 from app.enterprise_readiness import (
     build_enterprise_audit_middleware,
     validate_enterprise_runtime_config,
@@ -53,6 +54,7 @@ from app.services.rolling_engine import calculate_rolling_metrics
 from app.services.rolling_mode_adapter import calculate_rolling_metrics_stateful
 from app.services.risk_engine import calculate_risk
 from app.services.risk_mode_adapter import calculate_risk_stateful
+from app.services.scenario_engine import evaluate_regime_scenario_pack
 from app.trust_telemetry import (
     DeclaredProductTrustTelemetrySnapshot,
     build_declared_product_trust_telemetry_snapshot,
@@ -581,6 +583,17 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
                     "attribution residual and reconciled_sum must be preserved with contributors",
                 ],
             ),
+            CapabilityWorkflow(
+                workflow_key="regime_scenario_pack_evaluation",
+                endpoint_path="/analytics/risk/regime-scenario-pack/evaluate",
+                supported_input_modes=["stateless"],
+                support_status="full",
+                notes=[
+                    "evaluates caller-supplied exposure weights against governed CIO scenario packs",
+                    "returns source-owned worst-case loss, policy breach posture, and lineage",
+                    "does not forecast market states or accept browser-owned scenario methodology",
+                ],
+            ),
         ],
     )
 
@@ -600,6 +613,29 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
 )
 async def metrics() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post(
+    "/analytics/risk/regime-scenario-pack/evaluate",
+    response_model=RegimeScenarioPackResponse,
+    responses=STANDARD_ERROR_RESPONSES,
+    summary="Evaluate a governed regime scenario pack",
+    tags=["risk-analytics"],
+    description=(
+        "Evaluates caller-supplied portfolio exposure weights against a governed CIO regime "
+        "scenario pack and returns source-owned worst-case loss, policy-threshold breach posture, "
+        "bounded reason codes, and lineage metadata. Consumers must not reconstruct scenario "
+        "methodology outside lotus-risk."
+    ),
+)
+async def analytics_risk_regime_scenario_pack(
+    request_payload: RegimeScenarioPackRequest,
+) -> RegimeScenarioPackResponse:
+    return await _observed_endpoint(
+        endpoint="regime-scenario-pack",
+        input_mode="stateless",
+        operation=lambda: evaluate_regime_scenario_pack(request_payload),
+    )
 
 
 @app.post(

--- a/src/app/services/scenario_engine.py
+++ b/src/app/services/scenario_engine.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from app.contracts.scenario import (
+    RegimeScenarioPackRequest,
+    RegimeScenarioPackResponse,
+    ScenarioEvaluationMetadata,
+    ScenarioResult,
+    ScenarioSupportabilityState,
+)
+
+
+@dataclass(frozen=True)
+class ScenarioDefinition:
+    scenario_id: str
+    display_name: str
+    shock_by_bucket: dict[str, float]
+
+
+SCENARIO_PACKS: dict[str, tuple[ScenarioDefinition, ...]] = {
+    "CIO_REGIME_2026_Q2": (
+        ScenarioDefinition(
+            scenario_id="growth_slowdown",
+            display_name="Growth slowdown",
+            shock_by_bucket={
+                "EQUITY": -0.12,
+                "FIXED_INCOME": -0.03,
+                "ALTERNATIVES": -0.06,
+                "CASH": 0.0,
+            },
+        ),
+        ScenarioDefinition(
+            scenario_id="rates_up_inflation",
+            display_name="Rates up and inflation persistence",
+            shock_by_bucket={
+                "EQUITY": -0.08,
+                "FIXED_INCOME": -0.07,
+                "ALTERNATIVES": -0.04,
+                "CASH": 0.0,
+            },
+        ),
+        ScenarioDefinition(
+            scenario_id="risk_off_liquidity",
+            display_name="Risk-off liquidity shock",
+            shock_by_bucket={
+                "EQUITY": -0.18,
+                "FIXED_INCOME": -0.02,
+                "ALTERNATIVES": -0.10,
+                "CASH": 0.0,
+            },
+        ),
+    )
+}
+SUPPORTED_BUCKETS = frozenset({"EQUITY", "FIXED_INCOME", "ALTERNATIVES", "CASH"})
+
+
+def evaluate_regime_scenario_pack(
+    request: RegimeScenarioPackRequest,
+) -> RegimeScenarioPackResponse:
+    scenario_pack = SCENARIO_PACKS.get(request.scenario_pack_id)
+    if scenario_pack is None:
+        raise ValueError(f"Unsupported scenario_pack_id: {request.scenario_pack_id}")
+
+    exposure_by_bucket = {
+        exposure.bucket.upper(): exposure.weight for exposure in request.exposures
+    }
+    unsupported_buckets = sorted(set(exposure_by_bucket) - SUPPORTED_BUCKETS)
+    supportability = (
+        ScenarioSupportabilityState.DEGRADED
+        if unsupported_buckets
+        else ScenarioSupportabilityState.READY
+    )
+    scenario_results = [
+        _evaluate_scenario(
+            scenario=scenario,
+            exposure_by_bucket=exposure_by_bucket,
+        )
+        for scenario in scenario_pack
+    ]
+    worst_case_loss = max(
+        (scenario.expected_loss_pct for scenario in scenario_results),
+        default=0.0,
+    )
+    breach = worst_case_loss > request.maximum_allowed_loss_pct
+    reason_codes = ["REGIME_SCENARIO_PACK_READY"]
+    if unsupported_buckets:
+        reason_codes.append("REGIME_SCENARIO_UNSUPPORTED_EXPOSURE_BUCKET")
+    if breach:
+        reason_codes.append("REGIME_SCENARIO_POLICY_THRESHOLD_BREACH")
+        if supportability == ScenarioSupportabilityState.READY:
+            supportability = ScenarioSupportabilityState.PENDING_REVIEW
+
+    return RegimeScenarioPackResponse(
+        scenario_pack_id=request.scenario_pack_id,
+        portfolio_id=request.portfolio_id,
+        as_of_date=request.as_of_date,
+        worst_case_loss_pct=round(worst_case_loss, 6),
+        maximum_allowed_loss_pct=request.maximum_allowed_loss_pct,
+        breach=breach,
+        scenario_results=scenario_results,
+        reason_codes=sorted(set(reason_codes)),
+        metadata=ScenarioEvaluationMetadata(
+            request_fingerprint=_request_fingerprint(request),
+            calculation_supportability=supportability,
+        ),
+    )
+
+
+def _evaluate_scenario(
+    *,
+    scenario: ScenarioDefinition,
+    exposure_by_bucket: dict[str, float],
+) -> ScenarioResult:
+    loss = 0.0
+    for bucket, weight in exposure_by_bucket.items():
+        shock = scenario.shock_by_bucket.get(bucket, 0.0)
+        loss += max(-(weight * shock), 0.0)
+    return ScenarioResult(
+        scenario_id=scenario.scenario_id,
+        display_name=scenario.display_name,
+        expected_loss_pct=round(loss, 6),
+        shock_by_bucket=dict(scenario.shock_by_bucket),
+    )
+
+
+def _request_fingerprint(request: RegimeScenarioPackRequest) -> str:
+    payload = request.model_dump(mode="json")
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(serialized.encode("utf-8")).hexdigest()

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -200,7 +200,7 @@ class DeclaredConsumerDependencyTelemetry(BaseModel):
 class TrustTelemetryReviewSummary(BaseModel):
     declared_product_count: int = Field(
         description="Number of repo-native declared producer products included in the snapshot.",
-        json_schema_extra={"example": 5},
+        json_schema_extra={"example": 6},
     )
     declared_dependency_count: int = Field(
         description="Number of repo-native declared upstream dependencies included in the snapshot.",
@@ -290,7 +290,7 @@ class DeclaredProductTrustTelemetrySnapshot(BaseModel):
         description="Operator-facing rollup of declaration counts and current runtime dependency posture.",
         json_schema_extra={
             "example": {
-                "declared_product_count": 5,
+                "declared_product_count": 6,
                 "declared_dependency_count": 6,
                 "degraded_dependency_count": 2,
                 "unavailable_dependency_count": 0,

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -213,7 +213,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         body["consumer_declaration_source"]
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
-    assert body["summary"]["declared_product_count"] == 5
+    assert body["summary"]["declared_product_count"] == 6
     assert body["summary"]["declared_dependency_count"] == 6
     assert [product["product_name"] for product in body["products"]] == [
         "RiskMetricsReport",
@@ -221,6 +221,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "RegimeScenarioPackEvaluation",
     ]
 
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -43,6 +43,7 @@ def test_integration_capabilities_contract() -> None:
         "risk.analytics.drawdown",
         "risk.analytics.rolling_metrics",
         "risk.analytics.historical_attribution",
+        "risk.analytics.regime_scenario_pack",
         "risk.analytics.metrics",
         "risk.observability.calculation_supportability",
     }
@@ -53,6 +54,7 @@ def test_integration_capabilities_contract() -> None:
         "drawdown_analytics",
         "rolling_risk_analytics",
         "historical_risk_attribution",
+        "regime_scenario_pack_evaluation",
     }
     workflow_by_key = {workflow["workflow_key"]: workflow for workflow in body["workflows"]}
     assert workflow_by_key["risk_snapshot"]["endpoint_path"] == "/analytics/risk/calculate"
@@ -65,6 +67,12 @@ def test_integration_capabilities_contract() -> None:
         "simulation",
     ]
     assert workflow_by_key["historical_risk_attribution"]["support_status"] == "partial"
+    assert workflow_by_key["regime_scenario_pack_evaluation"]["endpoint_path"] == (
+        "/analytics/risk/regime-scenario-pack/evaluate"
+    )
+    assert workflow_by_key["regime_scenario_pack_evaluation"]["supported_input_modes"] == [
+        "stateless"
+    ]
     assert (
         "stateful active-risk ISSUER remains gated"
         in workflow_by_key["historical_risk_attribution"]["notes"]
@@ -204,7 +212,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         == "lotus-performance"
     )
     assert trust_telemetry_body["declared_dependencies"][0]["runtime_status"] == "ok"
-    assert trust_telemetry_body["summary"]["declared_product_count"] == 5
+    assert trust_telemetry_body["summary"]["declared_product_count"] == 6
     assert trust_telemetry_body["summary"]["declared_dependency_count"] == 6
     assert trust_telemetry_body["summary"]["degraded_dependency_count"] == 0
     assert trust_telemetry_body["summary"]["unavailable_dependency_count"] == 0
@@ -215,6 +223,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "RegimeScenarioPackEvaluation",
     ]
     assert all(
         product["lifecycle_status"] == "active" for product in trust_telemetry_body["products"]
@@ -484,7 +493,7 @@ def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
     assert (
         dependency_schema["properties"]["runtime_issue_code"]["example"] == "UPSTREAM_HIGH_LATENCY"
     )
-    assert summary_schema["properties"]["declared_product_count"]["example"] == 5
+    assert summary_schema["properties"]["declared_product_count"]["example"] == 6
     assert summary_schema["properties"]["declared_dependency_count"]["example"] == 6
     assert (
         seed_schema["properties"]["readiness_status"]["description"]

--- a/tests/unit/test_domain_data_products.py
+++ b/tests/unit/test_domain_data_products.py
@@ -24,6 +24,7 @@ def test_list_declared_products_matches_expected_wave() -> None:
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "RegimeScenarioPackEvaluation",
     ]
 
 

--- a/tests/unit/test_scenario_api.py
+++ b/tests/unit/test_scenario_api.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_regime_scenario_pack_endpoint_returns_evaluation_contract() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/analytics/risk/regime-scenario-pack/evaluate",
+        json={
+            "scenario_pack_id": "CIO_REGIME_2026_Q2",
+            "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+            "as_of_date": "2026-05-03",
+            "maximum_allowed_loss_pct": 0.12,
+            "exposures": [
+                {"bucket": "EQUITY", "weight": 0.55},
+                {"bucket": "FIXED_INCOME", "weight": 0.35},
+                {"bucket": "CASH", "weight": 0.10},
+            ],
+        },
+        headers={"X-Correlation-Id": "corr-scenario-api"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scenario_pack_id"] == "CIO_REGIME_2026_Q2"
+    assert body["worst_case_loss_pct"] == 0.106
+    assert body["metadata"]["product_name"] == "RegimeScenarioPackEvaluation"
+    assert body["metadata"]["calculation_supportability"] == "ready"
+    assert body["reason_codes"] == ["REGIME_SCENARIO_PACK_READY"]
+
+
+def test_capabilities_include_regime_scenario_pack_workflow() -> None:
+    client = TestClient(app)
+
+    response = client.get("/integration/capabilities")
+
+    assert response.status_code == 200
+    workflows = {workflow["workflow_key"]: workflow for workflow in response.json()["workflows"]}
+    assert workflows["regime_scenario_pack_evaluation"]["endpoint_path"] == (
+        "/analytics/risk/regime-scenario-pack/evaluate"
+    )
+    assert workflows["regime_scenario_pack_evaluation"]["support_status"] == "full"

--- a/tests/unit/test_scenario_engine.py
+++ b/tests/unit/test_scenario_engine.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from app.contracts.scenario import RegimeScenarioPackRequest, ScenarioSupportabilityState
+from app.services.scenario_engine import evaluate_regime_scenario_pack
+
+
+def _request(**overrides: object) -> RegimeScenarioPackRequest:
+    payload: dict[str, object] = {
+        "scenario_pack_id": "CIO_REGIME_2026_Q2",
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "as_of_date": "2026-05-03",
+        "maximum_allowed_loss_pct": 0.12,
+        "exposures": [
+            {"bucket": "EQUITY", "weight": 0.55},
+            {"bucket": "FIXED_INCOME", "weight": 0.35},
+            {"bucket": "CASH", "weight": 0.10},
+        ],
+    }
+    payload.update(overrides)
+    return RegimeScenarioPackRequest.model_validate(payload)
+
+
+def test_regime_scenario_pack_evaluation_returns_source_owned_worst_case_loss() -> None:
+    response = evaluate_regime_scenario_pack(_request())
+
+    assert response.scenario_pack_id == "CIO_REGIME_2026_Q2"
+    assert response.metadata.product_name == "RegimeScenarioPackEvaluation"
+    assert response.metadata.product_version == "v1"
+    assert response.metadata.source_service == "lotus-risk"
+    assert response.metadata.calculation_supportability == ScenarioSupportabilityState.READY
+    assert response.worst_case_loss_pct == 0.106
+    assert response.breach is False
+    assert response.reason_codes == ["REGIME_SCENARIO_PACK_READY"]
+    assert response.metadata.request_fingerprint.startswith("sha256:")
+
+
+def test_regime_scenario_pack_evaluation_flags_threshold_breach() -> None:
+    response = evaluate_regime_scenario_pack(_request(maximum_allowed_loss_pct=0.05))
+
+    assert response.breach is True
+    assert (
+        response.metadata.calculation_supportability == ScenarioSupportabilityState.PENDING_REVIEW
+    )
+    assert "REGIME_SCENARIO_POLICY_THRESHOLD_BREACH" in response.reason_codes
+
+
+def test_regime_scenario_pack_evaluation_degrades_for_unsupported_exposure_bucket() -> None:
+    response = evaluate_regime_scenario_pack(
+        _request(exposures=[{"bucket": "PRIVATE_CREDIT", "weight": 1.0}])
+    )
+
+    assert response.metadata.calculation_supportability == ScenarioSupportabilityState.DEGRADED
+    assert "REGIME_SCENARIO_UNSUPPORTED_EXPOSURE_BUCKET" in response.reason_codes
+
+
+def test_regime_scenario_pack_evaluation_rejects_unknown_pack() -> None:
+    with pytest.raises(ValueError, match="Unsupported scenario_pack_id"):
+        evaluate_regime_scenario_pack(_request(scenario_pack_id="UNKNOWN_PACK"))

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -205,7 +205,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     assert snapshot.declared_dependencies[2].runtime_status == "degraded"
     assert snapshot.declared_dependencies[2].runtime_category == "data_gap"
     assert snapshot.declared_dependencies[2].runtime_issue_code == "RISK_FREE_SERIES_STALE"
-    assert snapshot.summary.declared_product_count == 5
+    assert snapshot.summary.declared_product_count == 6
     assert snapshot.summary.declared_dependency_count == 6
     assert snapshot.summary.degraded_dependency_count == 4
     assert snapshot.summary.unavailable_dependency_count == 0
@@ -224,6 +224,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "RegimeScenarioPackEvaluation",
     ]
     assert all(product.lifecycle_status == "active" for product in snapshot.products)
     assert snapshot.products[0].product_family == "analytics_output"

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -36,7 +36,8 @@ This matters because:
 2. the other risk workflows do not,
 3. historical attribution is intentionally `partial`,
 4. workflow notes carry real supportability meaning,
-5. one remaining functional gap inside the approved analytics surface is stateful `ACTIVE_RISK + ISSUER`.
+5. regime scenario-pack evaluation is stateless and source-owned by `lotus-risk`,
+6. one remaining functional gap inside the approved analytics surface is stateful `ACTIVE_RISK + ISSUER`.
 
 ## Downstream Preservation Rules
 
@@ -46,7 +47,8 @@ Gateway, Workbench, reporting, and AI consumers must preserve:
 2. attribution `total_value`, `reconciled_sum`, `residual`, and contributor fields,
 3. issuer active-risk gating,
 4. concentration-only simulation support,
-5. lineage and upstream request-fingerprint metadata.
+5. regime scenario-pack evaluation reason codes and threshold-breach posture,
+6. lineage and upstream request-fingerprint metadata.
 
 If those are dropped or flattened, a numerically correct response can still become product-wrong.
 
@@ -68,8 +70,10 @@ Use `lotus-risk` directly or through gateway with these rules:
 1. preserve input-mode truth,
 2. do not offer unsupported workflow modes,
 3. treat partial historical attribution support as a real product limit,
-4. preserve audit and lineage metadata whenever responses are stored or passed onward,
-5. do not rewrite signed VaR into an always-positive loss figure unless the presentation layer explicitly records that sign-convention conversion.
+4. consume regime scenario-pack evaluation as source-owned stress evidence rather than
+   reconstructing scenario shocks downstream,
+5. preserve audit and lineage metadata whenever responses are stored or passed onward,
+6. do not rewrite signed VaR into an always-positive loss figure unless the presentation layer explicitly records that sign-convention conversion.
 
 ## Integration Sources
 

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -6,8 +6,15 @@
 
 ## Governed product
 
-- Product ID: `lotus-risk:RiskMetricsReport:v1`
-- Product role: governed risk metrics report for advisory, reporting, gateway, and Workbench discovery flows
+- Product IDs:
+  - `lotus-risk:RiskMetricsReport:v1`
+  - `lotus-risk:DrawdownAnalyticsReport:v1`
+  - `lotus-risk:RollingRiskMetricsReport:v1`
+  - `lotus-risk:HistoricalRiskAttributionReport:v1`
+  - `lotus-risk:ConcentrationRiskReport:v1`
+  - `lotus-risk:RegimeScenarioPackEvaluation:v1`
+- Product role: governed risk analytics reports and scenario-pack evaluation outputs for advisory,
+  reporting, gateway, Workbench discovery, and manage construction-supportability flows
 - Source declaration: `contracts/domain-data-products/`
 - Trust telemetry: `contracts/trust-telemetry/`
 

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -42,7 +42,9 @@ The current domain workflows are:
 2. realized drawdown analytics via `/analytics/risk/drawdown`,
 3. rolling historical risk metrics via `/analytics/risk/rolling-metrics`,
 4. historical attribution analytics via `/analytics/risk/historical-attribution`,
-5. concentration analytics via `/analytics/risk/concentration`.
+5. concentration analytics via `/analytics/risk/concentration`,
+6. governed regime scenario-pack evaluation via
+   `/analytics/risk/regime-scenario-pack/evaluate`.
 
 Operational and integration surfaces also matter:
 


### PR DESCRIPTION
## Summary
- adds source-owned `RegimeScenarioPackEvaluation:v1` in lotus-risk
- exposes `POST /analytics/risk/regime-scenario-pack/evaluate` for governed CIO scenario-pack evaluation
- returns worst-case loss, policy threshold breach posture, supportability, lineage, request fingerprint, and bounded reason codes
- updates domain-data product declaration, API vocabulary, endpoint docs, README, context, wiki source, and proof evidence

## Evidence
- `python -m pytest tests\unit\test_scenario_engine.py tests\unit\test_scenario_api.py tests\unit\test_domain_data_products.py tests\unit\test_capabilities_contract.py -q` -> 13 passed
- `make check` -> passed: Ruff, format, no-alias guard, mypy, OpenAPI quality, API vocabulary inventory, domain-data product contract check, 303 unit tests
- `python ..\lotus-platform\automation\validate_engineering_context_system.py` -> passed
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py` -> passed
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-AgentOperatingContract.ps1 -AllRepoRoots -IncludeDeployedTarget -CheckOnly` -> synchronized
- `powershell -ExecutionPolicy Bypass -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift for updated wiki source pages

## Dependency
- platform mirror merged in `lotus-platform` PR #303 (`2f53e6e`)

## Boundary
- no market forecasting claim
- no UI/Gateway-owned scenario methodology
- downstream manage consumption will be implemented separately without recomputing risk-owned outputs