### PR TITLE
Document rolling tracking error methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,6 +43,10 @@ Current repository posture:
    `POST /analytics/risk/regime-scenario-pack/evaluate`; it evaluates caller-supplied exposure
    weights against governed CIO scenario-pack definitions and returns source-owned worst-case loss,
    threshold breach posture, lineage, supportability, and bounded reason codes.
+10. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
+    `ROLLING_TRACKING_ERROR`: the docs and tests pin inner date alignment, percentage-point to
+    decimal conversion, `ddof=1` sample standard deviation, annualized decimal-ratio output,
+    warm-up/null behavior, and no-aligned-benchmark supportability posture.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/rolling-tracking-error.md
+++ b/docs/methodologies/metrics/rolling-tracking-error.md
@@ -8,40 +8,74 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- Benchmark return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Annualization basis.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns` and `benchmark_returns`.
+- Stateful mode: `lotus-performance` portfolio and benchmark return series fetched through the governed rolling-metrics integration path.
+- `lotus-risk` owns the rolling tracking-error calculation after dated return series are resolved. It does not source benchmark returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio and benchmark returns to decimal before rolling math:
+  `r_decimal = r_pp / 100`.
+- Active returns are decimal differences.
+- `ROLLING_TRACKING_ERROR` output is an annualized decimal ratio: `0.0275` means `2.75%`.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the same annualized decimal ratio unit.
 
 ## Variable Dictionary
-- `a_t = r_port_t - r_bench_t`: active return series.
-- `W`: rolling window length.
-- `sigma_a_t(W)`: rolling active std.
-- `AB`: annualization basis.
-- `RTE_t(W) = sigma_a_t(W)*sqrt(AB)`.
+- `t`: aligned observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rb_t_pp`: benchmark return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `Rb_t`: benchmark return on date `t`, as decimal (`Rb_t_pp / 100`).
+- `a_t`: active return on date `t`, as decimal (`Rp_t - Rb_t`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `AF`: annualization basis.
+- `sigma_a_t(W)`: sample standard deviation of active returns inside the window ending on date `t`, with `ddof=1`.
+- `RTE_t(W)`: rolling tracking error for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. `a_t=r_port_t-r_bench_t`.
-2. `sigma_t=std_W(a_t,ddof=1)`.
-3. `RTE_t=sigma_t*sqrt(annualization_basis)`.
+1. Convert each portfolio and benchmark observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100` and `Rb_t = Rb_t_pp / 100`.
+2. Inner-align portfolio and benchmark series by date for the requested period.
+3. Compute the active return series:
+   `a_t = Rp_t - Rb_t`.
+4. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+5. For each date with at least `min_obs` observations in the rolling window, compute sample active-return standard deviation:
+   `sigma_a_t(W) = std(a_{t-W+1} ... a_t, ddof=1)`.
+6. Annualize:
+   `RTE_t(W) = sigma_a_t(W) * sqrt(AF)`.
+7. Build summary statistics from computed, non-null `RTE_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio and benchmark returns to the period.
+3. Convert both filtered series from percentage points to decimal.
+4. Inner-align the decimal series by date.
+5. If no aligned observations remain, emit no computed metric values and record the benchmark dependency as `NO_ALIGNED_OBSERVATIONS`.
+6. For each requested window length, compute the rolling active-return sample standard deviation using `ddof=1`.
+7. Annualize each computed point with `sqrt(rolling_options.annualization_basis)`.
+8. Leave warm-up points as null until the configured minimum observation count is met.
+9. Populate `metric_summaries.ROLLING_TRACKING_ERROR` from non-null annualized values.
+10. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_TRACKING_ERROR` for every point in the rolling result, with warm-up points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Stateless requests that include `ROLLING_TRACKING_ERROR` without `benchmark_returns` fail request validation.
+- Stateful requests require benchmark-return sourcing from `lotus-performance`; unavailable upstream data is surfaced through dependency/supportability posture rather than local fallback data.
+- Fewer than two portfolio observations in the period returns period-level `error = "Insufficient data"` and no window results.
+- Benchmark series supplied but with no aligned dates returns `benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"` and emits no computed tracking-error values for the metric.
+- Window warm-up points are null until `min_obs` is met.
+- Constant active returns are valid and produce `0.0`; there is no denominator and no zero-variance error for tracking error.
+- Non-numeric return values are rejected by request-contract validation before engine math.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
@@ -55,8 +89,27 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window active returns `[0.001,-0.002,0.001]`.
-| Window | Std | Annualization | Value |
-|---|---:|---:|---:|
-| 1 | `0.001732` | `sqrt(252)` | `0.02749` |
-Output mapping: `metric_summaries.ROLLING_TRACKING_ERROR.latest=0.02749`.
+Assume daily annualization (`AF = 252`), `STRICT` minimum observations, `W = 3`, and aligned return observations:
+
+| Date | `Rp_t_pp` | `Rb_t_pp` | `Rp_t` | `Rb_t` | `a_t = Rp_t - Rb_t` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Day 1 | `1.00` | `0.80` | `0.010` | `0.008` | `0.002` |
+| Day 2 | `-2.00` | `-1.50` | `-0.020` | `-0.015` | `-0.005` |
+| Day 3 | `0.50` | `0.40` | `0.005` | `0.004` | `0.001` |
+
+Intermediate calculations for the first full window:
+
+| Step | Value |
+| --- | ---: |
+| Active mean | `(-0.002) / 3 = -0.0006666667` |
+| Squared deviations sum | `0.0000286667` |
+| Sample variance (`ddof=1`) | `0.0000143333` |
+| `sigma_a_t(3)` | `0.0037859389` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `RTE_t(3)` | `0.0601026522` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_TRACKING_ERROR.latest = 0.0601026522`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_TRACKING_ERROR = 0.0601026522`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROLLING_TRACKING_ERROR_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-tracking-error.md"
+)
+
+
+def test_rolling_tracking_error_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_TRACKING_ERROR_DOC.read_text(encoding="utf-8")
+
+    expected_sections = [
+        "## Metric",
+        "## Endpoint and Mode Coverage",
+        "## Inputs",
+        "## Upstream Data Sources",
+        "## Unit Conventions",
+        "## Variable Dictionary",
+        "## Methodology and Formulas",
+        "## Step-by-Step Computation",
+        "## Validation and Failure Behavior",
+        "## Configuration Options",
+        "## Outputs",
+        "## Worked Example",
+    ]
+
+    section_positions = [text.index(section) for section in expected_sections]
+    assert section_positions == sorted(section_positions)
+
+    required_truth = [
+        "metric_id: ROLLING_TRACKING_ERROR",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "annualized decimal ratio",
+        "ddof=1",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        'benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"',
+        "Constant active returns are valid and produce `0.0`",
+        "metric_summaries.ROLLING_TRACKING_ERROR.latest",
+        "metric_series[].metric_values.ROLLING_TRACKING_ERROR",
+        "0.0601026522",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.contracts.rolling import RollingInputMode, RollingStatelessInput
 from app.services.rolling_engine import calculate_rolling_metrics
 
@@ -68,6 +70,25 @@ def test_rolling_engine_returns_window_results_and_metadata() -> None:
     assert window.metric_summaries["ROLLING_MAX_DRAWDOWN"].minimum is not None
     assert window.metric_series is not None
     assert len(window.metric_series) > 0
+
+
+def test_rolling_tracking_error_matches_documented_decimal_methodology() -> None:
+    response = calculate_rolling_metrics(_base_input(), input_mode=RollingInputMode.STATELESS)
+
+    window = response.results["YTD"].window_results[0]
+    summary = window.metric_summaries["ROLLING_TRACKING_ERROR"]
+
+    assert summary.latest == pytest.approx(0.02424871130596428)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-08"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 5
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-08"
+    assert latest_point.metric_values["ROLLING_TRACKING_ERROR"] == pytest.approx(summary.latest)
 
 
 def test_rolling_engine_returns_period_error_when_insufficient_period_data() -> None:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -18,6 +18,40 @@
 - Source declaration: `contracts/domain-data-products/`
 - Trust telemetry: `contracts/trust-telemetry/`
 
+## Implementation-backed methodology coverage
+
+`RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling tracking
+error. The methodology is tied to the implemented `/analytics/risk/rolling-metrics` engine and
+states the exact date-alignment rule, percentage-point to decimal conversion, `ddof=1` sample
+standard deviation, annualization basis, strict versus partial minimum-observation behavior,
+warm-up null handling, no-aligned-benchmark behavior, and decimal-ratio output mapping.
+
+```mermaid
+flowchart LR
+    PERF[lotus-performance<br/>portfolio + benchmark returns]
+    RISK[lotus-risk<br/>RollingRiskMetricsReport:v1]
+    GW[lotus-gateway<br/>risk composition]
+    WB[lotus-workbench<br/>risk workspace]
+    MANAGE[lotus-manage<br/>realized outcome source adapter]
+
+    PERF -->|dated return series| RISK
+    RISK -->|rolling tracking error + lineage| GW
+    GW --> WB
+    RISK -->|source-owned scalar evidence| MANAGE
+```
+
+Audience notes:
+
+- Business users can read rolling tracking error as annualized active-return volatility versus the
+  selected benchmark.
+- Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
+  issues from calculation failure.
+- Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
+  supportability metadata rather than recomputing rolling tracking error locally.
+- Sales and pre-sales can describe the canonical capability as implementation-backed for supported
+  seeded portfolios, while broader portfolio-archetype coverage still depends on live validation
+  evidence.
+
 ## Platform relationship
 
 `lotus-platform` aggregates the repo-native declaration, validates trust telemetry, applies mesh SLO/access/evidence policies, and includes this product in generated catalog, dependency graph, live certification, maturity matrix, evidence packs, and RFC-0092 operating reports.


### PR DESCRIPTION
## Summary
- upgrade the rolling tracking error methodology to implementation-backed v3 detail
- add regression coverage that pins the rolling tracking error decimal output and methodology doc contract
- update risk repo context and mesh wiki source with source-owner methodology coverage and downstream boundaries

## Validation
- python -m pytest tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py -q
- python -m ruff check tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- python -m ruff format --check tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- python -m mypy --config-file mypy.ini tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- git diff --check
- make check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk reports expected drift in Mesh-Data-Products.md until this PR merges and wiki is published

## WTBD
- Advances RFC42-WTBD-006 source-owner realized methodology depth for RollingRiskMetricsReport:v1 without claiming broader liquidity, tax, FX, cash movement, or execution methodology closure.