### PR TITLE
Document rolling information ratio methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -44,9 +44,11 @@ Current repository posture:
    weights against governed CIO scenario-pack definitions and returns source-owned worst-case loss,
    threshold breach posture, lineage, supportability, and bounded reason codes.
 10. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
-    `ROLLING_TRACKING_ERROR`: the docs and tests pin inner date alignment, percentage-point to
-    decimal conversion, `ddof=1` sample standard deviation, annualized decimal-ratio output,
-    warm-up/null behavior, and no-aligned-benchmark supportability posture.
+    `ROLLING_TRACKING_ERROR` and `ROLLING_INFORMATION_RATIO`: the docs and tests pin inner date
+    alignment, percentage-point to decimal conversion, `ddof=1` sample standard deviation,
+    annualized decimal tracking-error output, dimensionless information-ratio output,
+    warm-up/null behavior, no-aligned-benchmark supportability posture, and zero-tracking-error
+    information-ratio flagging.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/rolling-information-ratio.md
+++ b/docs/methodologies/metrics/rolling-information-ratio.md
@@ -8,40 +8,78 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- Benchmark return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Annualization basis.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns` and `benchmark_returns`.
+- Stateful mode: `lotus-performance` portfolio and benchmark return series fetched through the governed rolling-metrics integration path.
+- `lotus-risk` owns the rolling information-ratio calculation after dated return series are resolved. It does not source benchmark returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio and benchmark returns to decimal before rolling math:
+  `r_decimal = r_pp / 100`.
+- Active returns are decimal differences.
+- `ROLLING_INFORMATION_RATIO` output is a dimensionless annualized ratio.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the same dimensionless ratio unit.
 
 ## Variable Dictionary
-- `a_t = r_port_t - r_bench_t`: active return series.
-- `W`: rolling window length.
-- `mu_a_t(W)`: rolling active mean.
-- `sigma_a_t(W)`: rolling active std.
-- `RIR_t(W) = (mu_a_t/sigma_a_t)*sqrt(AB)`.
+- `t`: aligned observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rb_t_pp`: benchmark return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `Rb_t`: benchmark return on date `t`, as decimal (`Rb_t_pp / 100`).
+- `a_t`: active return on date `t`, as decimal (`Rp_t - Rb_t`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `AF`: annualization basis.
+- `mu_a_t(W)`: arithmetic mean of active returns inside the window ending on date `t`.
+- `sigma_a_t(W)`: sample standard deviation of active returns inside the window ending on date `t`, with `ddof=1`.
+- `RIR_t(W)`: rolling information ratio for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. `a_t=r_port_t-r_bench_t`.
-2. `mu_t=mean_W(a_t)`, `sigma_t=std_W(a_t,ddof=1)`.
-3. `RIR_t=(mu_t/sigma_t)*sqrt(annualization_basis)`.
+1. Convert each portfolio and benchmark observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100` and `Rb_t = Rb_t_pp / 100`.
+2. Inner-align portfolio and benchmark series by date for the requested period.
+3. Compute the active return series:
+   `a_t = Rp_t - Rb_t`.
+4. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+5. For each date with at least `min_obs` observations in the rolling window, compute:
+   - `mu_a_t(W) = mean(a_{t-W+1} ... a_t)`;
+   - `sigma_a_t(W) = std(a_{t-W+1} ... a_t, ddof=1)`.
+6. Annualize the mean/std ratio:
+   `RIR_t(W) = (mu_a_t(W) / sigma_a_t(W)) * sqrt(AF)`.
+7. Replace infinite results with null before summaries are built.
+8. Build summary statistics from computed, non-null `RIR_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio and benchmark returns to the period.
+3. Convert both filtered series from percentage points to decimal.
+4. Inner-align the decimal series by date.
+5. If no aligned observations remain, emit no computed metric values and record the benchmark dependency as `NO_ALIGNED_OBSERVATIONS`.
+6. For each requested window length, compute rolling active-return mean and sample standard deviation using `ddof=1`.
+7. Annualize each non-zero-denominator point with `sqrt(rolling_options.annualization_basis)`.
+8. Convert infinite values to null so zero tracking-error windows do not become misleading ratios.
+9. Leave warm-up points as null until the configured minimum observation count is met.
+10. Populate `metric_summaries.ROLLING_INFORMATION_RATIO` from non-null annualized ratios.
+11. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_INFORMATION_RATIO` for every point in the rolling result, with warm-up and zero-denominator points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Stateless requests that include `ROLLING_INFORMATION_RATIO` without `benchmark_returns` fail request validation.
+- Stateful requests require benchmark-return sourcing from `lotus-performance`; unavailable upstream data is surfaced through dependency/supportability posture rather than local fallback data.
+- Fewer than two portfolio observations in the period returns period-level `error = "Insufficient data"` and no window results.
+- Benchmark series supplied but with no aligned dates returns `benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"` and emits no computed information-ratio values for the metric.
+- Window warm-up points are null until `min_obs` is met.
+- Zero rolling active-return standard deviation produces null metric points and quality flag `metric:ROLLING_INFORMATION_RATIO:zero_tracking_error_window`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
@@ -55,8 +93,28 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window active returns `[0.002,0.001,-0.001]`.
-| Window | Mean | Std | Annualization | Value |
-|---|---:|---:|---:|---:|
-| 1 | `0.000667` | `0.001528` | `sqrt(252)` | `6.928` |
-Output mapping: `metric_summaries.ROLLING_INFORMATION_RATIO.latest=6.928`.
+Assume daily annualization (`AF = 252`), `STRICT` minimum observations, `W = 3`, and aligned return observations:
+
+| Date | `Rp_t_pp` | `Rb_t_pp` | `Rp_t` | `Rb_t` | `a_t = Rp_t - Rb_t` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Day 1 | `-0.70` | `-0.60` | `-0.007` | `-0.006` | `-0.001` |
+| Day 2 | `0.40` | `0.20` | `0.004` | `0.002` | `0.002` |
+| Day 3 | `0.30` | `0.20` | `0.003` | `0.002` | `0.001` |
+
+Intermediate calculations for the first full window:
+
+| Step | Value |
+| --- | ---: |
+| Active mean | `(0.002) / 3 = 0.0006666667` |
+| Squared deviations sum | `0.0000046667` |
+| Sample variance (`ddof=1`) | `0.0000023333` |
+| `sigma_a_t(3)` | `0.0015275252` |
+| Mean/std ratio | `0.4364357805` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `RIR_t(3)` | `6.9282032303` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_INFORMATION_RATIO.latest = 6.9282032303`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_INFORMATION_RATIO = 6.9282032303`

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -1,4 +1,6 @@
 from fastapi.testclient import TestClient
+import pytest
+
 from app.main import app
 from tests.support.app_runtime import override_app_runtime
 from tests.support.historical_attribution_fakes import (
@@ -345,6 +347,39 @@ def test_e2e_rolling_metrics_stateless_happy_path() -> None:
     assert body["input_mode"] == "stateless"
     assert "YTD" in body["results"]
     assert body["results"]["YTD"]["window_results"][0]["window_length"] == 3
+
+
+def test_e2e_rolling_active_risk_metrics_follow_methodology_contract() -> None:
+    client = TestClient(app)
+    payload = _rolling_payload()
+    stateless_input = payload["stateless_input"]
+    assert isinstance(stateless_input, dict)
+    rolling_options = stateless_input["rolling_options"]
+    assert isinstance(rolling_options, dict)
+    rolling_options["metrics"] = ["ROLLING_TRACKING_ERROR", "ROLLING_INFORMATION_RATIO"]
+    rolling_options["annualization_basis"] = 252
+    rolling_options["include_time_series"] = True
+
+    response = client.post("/analytics/risk/rolling-metrics", json=payload)
+
+    assert response.status_code == 200
+    body = response.json()
+    period = body["results"]["YTD"]
+    assert period["benchmark_context"]["reason"] == "APPLIED"
+    assert period["quality_flags"] == []
+
+    window = period["window_results"][0]
+    summaries = window["metric_summaries"]
+    assert summaries["ROLLING_TRACKING_ERROR"]["latest"] == pytest.approx(0.23384610323886096)
+    assert summaries["ROLLING_INFORMATION_RATIO"]["latest"] == pytest.approx(10.776318121606494)
+
+    latest_point = window["metric_series"][-1]
+    assert latest_point["metric_values"]["ROLLING_TRACKING_ERROR"] == pytest.approx(
+        summaries["ROLLING_TRACKING_ERROR"]["latest"]
+    )
+    assert latest_point["metric_values"]["ROLLING_INFORMATION_RATIO"] == pytest.approx(
+        summaries["ROLLING_INFORMATION_RATIO"]["latest"]
+    )
 
 
 def test_e2e_historical_attribution_stateless_happy_path() -> None:

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -5,6 +5,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ROLLING_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-tracking-error.md"
 )
+ROLLING_INFORMATION_RATIO_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-information-ratio.md"
+)
 
 
 def test_rolling_tracking_error_methodology_is_auditable_against_engine_contract() -> None:
@@ -42,6 +45,47 @@ def test_rolling_tracking_error_methodology_is_auditable_against_engine_contract
         "metric_summaries.ROLLING_TRACKING_ERROR.latest",
         "metric_series[].metric_values.ROLLING_TRACKING_ERROR",
         "0.0601026522",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_rolling_information_ratio_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_INFORMATION_RATIO_DOC.read_text(encoding="utf-8")
+
+    expected_sections = [
+        "## Metric",
+        "## Endpoint and Mode Coverage",
+        "## Inputs",
+        "## Upstream Data Sources",
+        "## Unit Conventions",
+        "## Variable Dictionary",
+        "## Methodology and Formulas",
+        "## Step-by-Step Computation",
+        "## Validation and Failure Behavior",
+        "## Configuration Options",
+        "## Outputs",
+        "## Worked Example",
+    ]
+
+    section_positions = [text.index(section) for section in expected_sections]
+    assert section_positions == sorted(section_positions)
+
+    required_truth = [
+        "metric_id: ROLLING_INFORMATION_RATIO",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "dimensionless annualized ratio",
+        "ddof=1",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        'benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"',
+        "metric:ROLLING_INFORMATION_RATIO:zero_tracking_error_window",
+        "metric_summaries.ROLLING_INFORMATION_RATIO.latest",
+        "metric_series[].metric_values.ROLLING_INFORMATION_RATIO",
+        "6.9282032303",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -91,6 +91,27 @@ def test_rolling_tracking_error_matches_documented_decimal_methodology() -> None
     assert latest_point.metric_values["ROLLING_TRACKING_ERROR"] == pytest.approx(summary.latest)
 
 
+def test_rolling_information_ratio_matches_documented_decimal_methodology() -> None:
+    response = calculate_rolling_metrics(_base_input(), input_mode=RollingInputMode.STATELESS)
+
+    period = response.results["YTD"]
+    window = period.window_results[0]
+    summary = window.metric_summaries["ROLLING_INFORMATION_RATIO"]
+
+    assert period.quality_flags == []
+    assert summary.latest == pytest.approx(6.928203230275508)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-08"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 5
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-08"
+    assert latest_point.metric_values["ROLLING_INFORMATION_RATIO"] == pytest.approx(summary.latest)
+
+
 def test_rolling_engine_returns_period_error_when_insufficient_period_data() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-08", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -21,10 +21,12 @@
 ## Implementation-backed methodology coverage
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling tracking
-error. The methodology is tied to the implemented `/analytics/risk/rolling-metrics` engine and
-states the exact date-alignment rule, percentage-point to decimal conversion, `ddof=1` sample
-standard deviation, annualization basis, strict versus partial minimum-observation behavior,
-warm-up null handling, no-aligned-benchmark behavior, and decimal-ratio output mapping.
+error and rolling information ratio. The methodologies are tied to the implemented
+`/analytics/risk/rolling-metrics` engine and state the exact date-alignment rule, percentage-point
+to decimal conversion, `ddof=1` sample standard deviation, annualization basis, strict versus
+partial minimum-observation behavior, warm-up null handling, no-aligned-benchmark behavior,
+zero-tracking-error information-ratio flagging, decimal-ratio tracking-error output, and
+dimensionless information-ratio output.
 
 ```mermaid
 flowchart LR
@@ -35,7 +37,7 @@ flowchart LR
     MANAGE[lotus-manage<br/>realized outcome source adapter]
 
     PERF -->|dated return series| RISK
-    RISK -->|rolling tracking error + lineage| GW
+    RISK -->|rolling active-risk metrics + lineage| GW
     GW --> WB
     RISK -->|source-owned scalar evidence| MANAGE
 ```
@@ -43,9 +45,11 @@ flowchart LR
 Audience notes:
 
 - Business users can read rolling tracking error as annualized active-return volatility versus the
-  selected benchmark.
+  selected benchmark, and rolling information ratio as annualized active return per unit of that
+  active risk.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
-  issues from calculation failure.
+  issues from calculation failure; zero-tracking-error windows are flagged rather than promoted as
+  valid ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling tracking error locally.
 - Sales and pre-sales can describe the canonical capability as implementation-backed for supported


### PR DESCRIPTION
## Summary
- upgrade the rolling information ratio methodology to implementation-backed v3 detail
- add regression coverage that pins the decimal active-return calculation, dimensionless output, and doc contract
- update risk repo context and mesh wiki source with rolling active-risk methodology coverage and zero-tracking-error boundaries

## Validation
- python -m pytest tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py -q
- python -m ruff check tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- python -m ruff format --check tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- python -m mypy --config-file mypy.ini tests\\unit\\test_rolling_engine.py tests\\unit\\test_methodology_docs.py
- git diff --check
- make check
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk reports expected drift in Mesh-Data-Products.md until this PR merges and wiki is published

## WTBD
- Advances RFC42-WTBD-006 source-owner realized methodology depth for RollingRiskMetricsReport:v1 without claiming broader liquidity, tax, FX, cash movement, or execution methodology closure.