### PR TITLE
Add risk-event affected cohort source product

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Current primary workflows:
 4. `POST /analytics/risk/historical-attribution`
 5. `POST /analytics/risk/concentration`
 6. `POST /analytics/risk/regime-scenario-pack/evaluate`
-7. `GET /integration/capabilities`
-8. `GET /ops`
+7. `POST /analytics/risk/risk-event-cohorts/evaluate`
+8. `GET /integration/capabilities`
+9. `GET /ops`
 
 Important posture limits:
 
@@ -49,9 +50,12 @@ Important posture limits:
 2. regime scenario-pack evaluation is stateless and consumes caller-supplied exposure weights
    against risk-owned CIO scenario definitions; it does not forecast markets or accept UI-owned
    scenario methodology,
-3. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is intentionally gated,
-4. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
-5. broader enterprise-bank claims require more seeded archetypes and attached evidence.
+3. risk-event affected-cohort evaluation is stateless and consumes caller-supplied candidate
+   portfolios and source-supplied exposure weights against risk-owned event definitions; it does
+   not create rebalance waves or own campaign approval workflow,
+4. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is intentionally gated,
+5. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
+6. broader enterprise-bank claims require more seeded archetypes and attached evidence.
 
 ## Architectural Shape
 

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,7 +43,12 @@ Current repository posture:
    `POST /analytics/risk/regime-scenario-pack/evaluate`; it evaluates caller-supplied exposure
    weights against governed CIO scenario-pack definitions and returns source-owned worst-case loss,
    threshold breach posture, lineage, supportability, and bounded reason codes.
-10. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
+10. `RiskEventAffectedCohort:v1` is a repo-native domain data product exposed through
+    `POST /analytics/risk/risk-event-cohorts/evaluate`; it evaluates candidate portfolios and
+    source-supplied exposure weights against governed risk-event definitions and returns affected
+    membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
+    for future manage wave-trigger consumption without creating waves or campaign approvals.
+11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_TRACKING_ERROR` and `ROLLING_INFORMATION_RATIO`: the docs and tests pin inner date
     alignment, percentage-point to decimal conversion, `ddof=1` sample standard deviation,
     annualized decimal tracking-error output, dimensionless information-ratio output,

--- a/contracts/domain-data-products/lotus-risk-products.v1.json
+++ b/contracts/domain-data-products/lotus-risk-products.v1.json
@@ -342,6 +342,59 @@
         "portfolio_id"
       ],
       "temporal_semantics_ref": "as_of_date"
+    },
+    {
+      "product_name": "RiskEventAffectedCohort",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "cohort_membership",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio_set",
+        "supports_bulk": true
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services"
+      ],
+      "current_routes": [
+        "/analytics/risk/risk-event-cohorts/evaluate"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Risk-event affected cohorts must reflect the governed risk-event definition, supplied candidate portfolios, and source-supplied exposure weights for the requested as-of date."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
     }
   ]
 }

--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -36,6 +36,7 @@
   - `risk.analytics.rolling_metrics`
   - `risk.analytics.historical_attribution`
   - `risk.analytics.regime_scenario_pack`
+  - `risk.analytics.risk_event_affected_cohort`
   - `risk.analytics.metrics`
   - `risk.observability.calculation_supportability`
 - `workflows`:
@@ -45,6 +46,7 @@
   - `rolling_risk_analytics`
   - `historical_risk_attribution`
   - `regime_scenario_pack_evaluation`
+  - `risk_event_affected_cohort`
 
 Each workflow now also publishes:
 
@@ -64,6 +66,9 @@ This allows consumers to discover that:
 - regime scenario-pack evaluation is a stateless source-owned workflow that returns worst-case loss,
   policy-threshold breach posture, lineage, and bounded reason codes from risk-owned CIO scenario
   definitions
+- risk-event affected-cohort evaluation is a stateless source-owned workflow that returns affected
+  portfolio membership, exclusions, source refs, impact scores, supportability posture, and bounded
+  reason codes from risk-owned event definitions
 - downstream product surfaces must derive simulation and issuer active-risk affordances from this
   payload, not from broad service-level support for the word `simulation`
 - downstream consumers must also treat
@@ -75,6 +80,7 @@ This allows consumers to discover that:
 
 - Downstream consumers:
   - `lotus-gateway` capability aggregation (`/api/v1/platform/capabilities`).
+  - `lotus-manage` future RFC41-WTBD-003 wave trigger consumption for risk-event cohorts.
   - downstream cleanup for undeclared risk capability query params is tracked in
     `sgajbi/lotus-gateway#113`.
 - Upstream dependencies:

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,8 +8,39 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-06T03:02:34.947310+00:00",
+  "generatedAt": "2026-05-10T03:43:10.709088+00:00",
   "attributeCatalog": [
+    {
+      "semanticId": "lotus.affected_portfolios",
+      "canonicalTerm": "affected_portfolios",
+      "preferredName": "affected_portfolios",
+      "description": "Portfolios whose source-owned risk-event impact meets the inclusion threshold.",
+      "example": [
+        {
+          "bucket_impacts": {
+            "CASH": 0.0,
+            "EQUITY": -0.022,
+            "FIXED_INCOME": -0.0525
+          },
+          "dominant_bucket": "FIXED_INCOME",
+          "impact_score": 0.0745,
+          "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+          "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+          "portfolio_manager_id": "pm-singapore-01",
+          "reason_codes": [
+            "RISK_EVENT_THRESHOLD_BREACHED"
+          ],
+          "source_ref": "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:2026-05-10:PB_SG_GLOBAL_BAL_001"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
     {
       "semanticId": "lotus.alignment_policy",
       "canonicalTerm": "alignment_policy",
@@ -202,6 +233,23 @@
       ]
     },
     {
+      "semanticId": "lotus.bucket_impacts",
+      "canonicalTerm": "bucket_impacts",
+      "preferredName": "bucket_impacts",
+      "description": "Signed event-impact contribution by exposure bucket.",
+      "example": {
+        "EQUITY": -0.022,
+        "FIXED_INCOME": -0.0525
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.calculation_supportability",
       "canonicalTerm": "calculation_supportability",
       "preferredName": "calculation_supportability",
@@ -213,6 +261,7 @@
       ],
       "observedTypes": [
         "ScenarioSupportabilityState",
+        "RiskEventCohortSupportabilityState",
         "RiskCalculationSupportability"
       ]
     },
@@ -258,6 +307,20 @@
       ],
       "observedTypes": [
         "OpsChecks"
+      ]
+    },
+    {
+      "semanticId": "lotus.cohort_id",
+      "canonicalTerm": "cohort_id",
+      "preferredName": "cohort_id",
+      "description": "Deterministic affected-cohort identifier.",
+      "example": "risk_event_cohort_7f4d2a1c",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -498,7 +561,7 @@
       "canonicalTerm": "declared_product_count",
       "preferredName": "declared_product_count",
       "description": "Number of repo-native declared producer products included in the snapshot.",
-      "example": 6,
+      "example": 7,
       "type": "integer",
       "locations": [
         "body"
@@ -623,6 +686,20 @@
       ]
     },
     {
+      "semanticId": "lotus.dominant_bucket",
+      "canonicalTerm": "dominant_bucket",
+      "preferredName": "dominant_bucket",
+      "description": "Exposure bucket contributing the largest absolute event impact.",
+      "example": "FIXED_INCOME",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.draining",
       "canonicalTerm": "draining",
       "preferredName": "draining",
@@ -735,6 +812,28 @@
       ]
     },
     {
+      "semanticId": "lotus.excluded_portfolios",
+      "canonicalTerm": "excluded_portfolios",
+      "preferredName": "excluded_portfolios",
+      "description": "Candidate portfolios excluded with explicit source-owner reason codes.",
+      "example": [
+        {
+          "impact_score": 0.015,
+          "portfolio_id": "PB_SG_LOW_RISK_002",
+          "reason_codes": [
+            "RISK_EVENT_BELOW_THRESHOLD"
+          ]
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
+      ]
+    },
+    {
       "semanticId": "lotus.expected_loss_pct",
       "canonicalTerm": "expected_loss_pct",
       "preferredName": "expected_loss_pct",
@@ -746,6 +845,24 @@
       ],
       "observedTypes": [
         "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.exposure_weights",
+      "canonicalTerm": "exposure_weights",
+      "preferredName": "exposure_weights",
+      "description": "Portfolio exposure weights by risk-event exposure bucket.",
+      "example": {
+        "CASH": 0.1,
+        "EQUITY": 0.55,
+        "FIXED_INCOME": 0.35
+      },
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -870,6 +987,20 @@
       "preferredName": "hhi_proposed",
       "description": "Proposed Herfindahl-Hirschman Index after applying projected positions.",
       "example": 2710.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.impact_score",
+      "canonicalTerm": "impact_score",
+      "preferredName": "impact_score",
+      "description": "Source-owned absolute risk-event impact score.",
+      "example": 0.073,
       "type": "number",
       "locations": [
         "body"
@@ -1101,6 +1232,20 @@
       ]
     },
     {
+      "semanticId": "lotus.mandate_id",
+      "canonicalTerm": "mandate_id",
+      "preferredName": "mandate_id",
+      "description": "Optional mandate identifier preserved for downstream wave lineage.",
+      "example": "MANDATE-PB-SG-GLOBAL-BAL-001",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.mar_annual_rate",
       "canonicalTerm": "mar_annual_rate",
       "preferredName": "mar_annual_rate",
@@ -1142,6 +1287,7 @@
       ],
       "observedTypes": [
         "ScenarioEvaluationMetadata",
+        "RiskEventCohortMetadata",
         "HistoricalAttributionMetadata",
         "object",
         "DrawdownMetadata",
@@ -1202,6 +1348,20 @@
       "preferredName": "minimum_episode_depth_bps",
       "description": "Minimum episode depth (in basis points) required to include an episode in the list.",
       "example": 25.0,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.minimum_impact_score",
+      "canonicalTerm": "minimum_impact_score",
+      "preferredName": "minimum_impact_score",
+      "description": "Minimum absolute event-impact score required for cohort inclusion.",
+      "example": 0.05,
       "type": "number",
       "locations": [
         "body"
@@ -1351,7 +1511,47 @@
         "body"
       ],
       "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_manager_id",
+      "canonicalTerm": "portfolio_manager_id",
+      "preferredName": "portfolio_manager_id",
+      "description": "Optional portfolio-manager identifier preserved for downstream review routing.",
+      "example": "pm-singapore-01",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolios",
+      "canonicalTerm": "portfolios",
+      "preferredName": "portfolios",
+      "description": "Candidate portfolios with source-supplied exposure weights.",
+      "example": [
+        {
+          "exposure_weights": {
+            "CASH": 0.1,
+            "EQUITY": 0.55,
+            "FIXED_INCOME": 0.35
+          },
+          "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+          "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+          "portfolio_manager_id": "pm-singapore-01"
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -1672,6 +1872,20 @@
       ]
     },
     {
+      "semanticId": "lotus.risk_event_id",
+      "canonicalTerm": "risk_event_id",
+      "preferredName": "risk_event_id",
+      "description": "Governed risk-event identifier.",
+      "example": "RISK_EVENT_2026_Q2_RATES_UP",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.risk_free_annual_rate",
       "canonicalTerm": "risk_free_annual_rate",
       "preferredName": "risk_free_annual_rate",
@@ -1969,6 +2183,20 @@
       ],
       "observedTypes": [
         "SinglePositionConcentration"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_ref",
+      "canonicalTerm": "source_ref",
+      "preferredName": "source_ref",
+      "description": "Stable source reference for downstream wave lineage.",
+      "example": "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:PB_SG_GLOBAL_BAL_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -3789,6 +4017,285 @@
             "location": "body",
             "required": true,
             "type": "ScenarioSupportabilityState",
+            "semanticId": "lotus.calculation_supportability",
+            "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
+          }
+        ]
+      }
+    },
+    {
+      "domain": "risk_analytics",
+      "method": "POST",
+      "path": "/analytics/risk/risk-event-cohorts/evaluate",
+      "operationId": "analytics_risk_event_affected_cohort_analytics_risk_risk_event_cohorts_evaluate_post",
+      "summary": "Evaluate a governed risk-event affected cohort",
+      "request": {
+        "fields": [
+          {
+            "name": "risk_event_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_event_id",
+            "attributeRef": "#/attributeCatalog/lotus.risk_event_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "portfolios",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.portfolios",
+            "attributeRef": "#/attributeCatalog/lotus.portfolios"
+          },
+          {
+            "name": "portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "portfolios[].exposure_weights",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.exposure_weights",
+            "attributeRef": "#/attributeCatalog/lotus.exposure_weights"
+          },
+          {
+            "name": "portfolios[].mandate_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.mandate_id",
+            "attributeRef": "#/attributeCatalog/lotus.mandate_id"
+          },
+          {
+            "name": "portfolios[].portfolio_manager_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_manager_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_manager_id"
+          },
+          {
+            "name": "minimum_impact_score",
+            "location": "body",
+            "required": false,
+            "type": "number",
+            "semanticId": "lotus.minimum_impact_score",
+            "attributeRef": "#/attributeCatalog/lotus.minimum_impact_score"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "cohort_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.cohort_id",
+            "attributeRef": "#/attributeCatalog/lotus.cohort_id"
+          },
+          {
+            "name": "risk_event_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.risk_event_id",
+            "attributeRef": "#/attributeCatalog/lotus.risk_event_id"
+          },
+          {
+            "name": "display_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.display_name",
+            "attributeRef": "#/attributeCatalog/lotus.display_name"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "affected_portfolios",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.affected_portfolios",
+            "attributeRef": "#/attributeCatalog/lotus.affected_portfolios"
+          },
+          {
+            "name": "affected_portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "affected_portfolios[].mandate_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.mandate_id",
+            "attributeRef": "#/attributeCatalog/lotus.mandate_id"
+          },
+          {
+            "name": "affected_portfolios[].portfolio_manager_id",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.portfolio_manager_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_manager_id"
+          },
+          {
+            "name": "affected_portfolios[].impact_score",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.impact_score",
+            "attributeRef": "#/attributeCatalog/lotus.impact_score"
+          },
+          {
+            "name": "affected_portfolios[].dominant_bucket",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.dominant_bucket",
+            "attributeRef": "#/attributeCatalog/lotus.dominant_bucket"
+          },
+          {
+            "name": "affected_portfolios[].bucket_impacts",
+            "location": "body",
+            "required": true,
+            "type": "object",
+            "semanticId": "lotus.bucket_impacts",
+            "attributeRef": "#/attributeCatalog/lotus.bucket_impacts"
+          },
+          {
+            "name": "affected_portfolios[].source_ref",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_ref",
+            "attributeRef": "#/attributeCatalog/lotus.source_ref"
+          },
+          {
+            "name": "affected_portfolios[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "excluded_portfolios",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.excluded_portfolios",
+            "attributeRef": "#/attributeCatalog/lotus.excluded_portfolios"
+          },
+          {
+            "name": "excluded_portfolios[].portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "excluded_portfolios[].impact_score",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.impact_score",
+            "attributeRef": "#/attributeCatalog/lotus.impact_score"
+          },
+          {
+            "name": "excluded_portfolios[].reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          },
+          {
+            "name": "metadata",
+            "location": "body",
+            "required": true,
+            "type": "RiskEventCohortMetadata",
+            "semanticId": "lotus.metadata",
+            "attributeRef": "#/attributeCatalog/lotus.metadata"
+          },
+          {
+            "name": "metadata.product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "metadata.product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_version",
+            "attributeRef": "#/attributeCatalog/lotus.product_version"
+          },
+          {
+            "name": "metadata.source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "metadata.lineage_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.lineage_version",
+            "attributeRef": "#/attributeCatalog/lotus.lineage_version"
+          },
+          {
+            "name": "metadata.request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
+            "name": "metadata.calculation_supportability",
+            "location": "body",
+            "required": true,
+            "type": "RiskEventCohortSupportabilityState",
             "semanticId": "lotus.calculation_supportability",
             "attributeRef": "#/attributeCatalog/lotus.calculation_supportability"
           }

--- a/src/app/contracts/capabilities.py
+++ b/src/app/contracts/capabilities.py
@@ -11,6 +11,7 @@ CAPABILITY_FEATURE_KEYS: tuple[str, ...] = (
     "risk.analytics.rolling_metrics",
     "risk.analytics.historical_attribution",
     "risk.analytics.regime_scenario_pack",
+    "risk.analytics.risk_event_affected_cohort",
     "risk.analytics.metrics",
     "risk.observability.calculation_supportability",
 )
@@ -21,6 +22,7 @@ CAPABILITY_WORKFLOW_KEYS: tuple[str, ...] = (
     "rolling_risk_analytics",
     "historical_risk_attribution",
     "regime_scenario_pack_evaluation",
+    "risk_event_affected_cohort",
 )
 SupportedInputMode = Literal["stateless", "stateful", "simulation"]
 WorkflowSupportStatus = Literal["full", "partial"]

--- a/src/app/contracts/risk_event_cohort.py
+++ b/src/app/contracts/risk_event_cohort.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import datetime as dt
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class RiskEventCohortSupportabilityState(StrEnum):
+    READY = "ready"
+    DEGRADED = "degraded"
+    PENDING_REVIEW = "pending_review"
+    BLOCKED = "blocked"
+
+
+class RiskEventPortfolioExposure(BaseModel):
+    portfolio_id: str = Field(
+        description="Portfolio identifier to evaluate for risk-event impact.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    exposure_weights: dict[str, float] = Field(
+        description="Portfolio exposure weights by risk-event exposure bucket.",
+        json_schema_extra={"example": {"EQUITY": 0.55, "FIXED_INCOME": 0.35, "CASH": 0.10}},
+    )
+    mandate_id: str | None = Field(
+        default=None,
+        description="Optional mandate identifier preserved for downstream wave lineage.",
+        json_schema_extra={"example": "MANDATE-PB-SG-GLOBAL-BAL-001"},
+    )
+    portfolio_manager_id: str | None = Field(
+        default=None,
+        description="Optional portfolio-manager identifier preserved for downstream review routing.",
+        json_schema_extra={"example": "pm-singapore-01"},
+    )
+
+    @model_validator(mode="after")
+    def validate_exposure_weights(self) -> "RiskEventPortfolioExposure":
+        if not self.exposure_weights:
+            raise ValueError("exposure_weights must contain at least one exposure bucket")
+        if any(weight < 0 for weight in self.exposure_weights.values()):
+            raise ValueError("exposure_weights must be non-negative")
+        return self
+
+
+class RiskEventAffectedCohortRequest(BaseModel):
+    risk_event_id: str = Field(
+        description="Governed risk-event identifier.",
+        json_schema_extra={"example": "RISK_EVENT_2026_Q2_RATES_UP"},
+    )
+    as_of_date: dt.date = Field(
+        description="Business date for the cohort evaluation.",
+        json_schema_extra={"example": "2026-05-10"},
+    )
+    portfolios: list[RiskEventPortfolioExposure] = Field(
+        description="Candidate portfolios with source-supplied exposure weights.",
+        json_schema_extra={
+            "example": [
+                {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+                    "portfolio_manager_id": "pm-singapore-01",
+                    "exposure_weights": {"EQUITY": 0.55, "FIXED_INCOME": 0.35, "CASH": 0.10},
+                }
+            ]
+        },
+    )
+    minimum_impact_score: float = Field(
+        default=0.05,
+        ge=0.0,
+        description="Minimum absolute event-impact score required for cohort inclusion.",
+        json_schema_extra={"example": 0.05},
+    )
+
+    @model_validator(mode="after")
+    def validate_candidate_portfolios(self) -> "RiskEventAffectedCohortRequest":
+        if not self.portfolios:
+            raise ValueError("portfolios must contain at least one candidate portfolio")
+        return self
+
+
+class RiskEventAffectedPortfolio(BaseModel):
+    portfolio_id: str = Field(
+        description="Affected portfolio identifier.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    mandate_id: str | None = Field(
+        default=None,
+        description="Mandate identifier when supplied by the caller.",
+        json_schema_extra={"example": "MANDATE-PB-SG-GLOBAL-BAL-001"},
+    )
+    portfolio_manager_id: str | None = Field(
+        default=None,
+        description="Portfolio-manager identifier when supplied by the caller.",
+        json_schema_extra={"example": "pm-singapore-01"},
+    )
+    impact_score: float = Field(
+        description="Source-owned absolute risk-event impact score.",
+        json_schema_extra={"example": 0.073},
+    )
+    dominant_bucket: str = Field(
+        description="Exposure bucket contributing the largest absolute event impact.",
+        json_schema_extra={"example": "FIXED_INCOME"},
+    )
+    bucket_impacts: dict[str, float] = Field(
+        description="Signed event-impact contribution by exposure bucket.",
+        json_schema_extra={"example": {"FIXED_INCOME": -0.0525, "EQUITY": -0.022}},
+    )
+    source_ref: str = Field(
+        description="Stable source reference for downstream wave lineage.",
+        json_schema_extra={
+            "example": "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:PB_SG_GLOBAL_BAL_001"
+        },
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded source-owner reason codes for this affected portfolio.",
+        json_schema_extra={"example": ["RISK_EVENT_THRESHOLD_BREACHED"]},
+    )
+
+
+class RiskEventExcludedPortfolio(BaseModel):
+    portfolio_id: str = Field(
+        description="Candidate portfolio excluded from the affected cohort.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_INC_002"},
+    )
+    impact_score: float = Field(
+        description="Source-owned absolute impact score used for exclusion.",
+        json_schema_extra={"example": 0.013},
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded source-owner reason codes explaining exclusion.",
+        json_schema_extra={"example": ["RISK_EVENT_BELOW_THRESHOLD"]},
+    )
+
+
+class RiskEventCohortMetadata(BaseModel):
+    product_name: str = Field(
+        default="RiskEventAffectedCohort",
+        description="Source-owned product name.",
+        json_schema_extra={"example": "RiskEventAffectedCohort"},
+    )
+    product_version: str = Field(
+        default="v1",
+        description="Source-owned product version.",
+        json_schema_extra={"example": "v1"},
+    )
+    source_service: str = Field(
+        default="lotus-risk",
+        description="Authoritative source service.",
+        json_schema_extra={"example": "lotus-risk"},
+    )
+    lineage_version: str = Field(
+        default="risk-event-affected-cohort.v1",
+        description="Lineage policy version used for this cohort evaluation.",
+        json_schema_extra={"example": "risk-event-affected-cohort.v1"},
+    )
+    request_fingerprint: str = Field(
+        description="Deterministic request fingerprint for replay and audit.",
+        json_schema_extra={"example": "sha256:abc123"},
+    )
+    calculation_supportability: RiskEventCohortSupportabilityState = Field(
+        description="Source-owned supportability posture for the cohort.",
+        json_schema_extra={"example": "ready"},
+    )
+
+
+class RiskEventAffectedCohortResponse(BaseModel):
+    cohort_id: str = Field(
+        description="Deterministic affected-cohort identifier.",
+        json_schema_extra={"example": "risk_event_cohort_7f4d2a1c"},
+    )
+    risk_event_id: str = Field(
+        description="Governed risk-event identifier.",
+        json_schema_extra={"example": "RISK_EVENT_2026_Q2_RATES_UP"},
+    )
+    display_name: str = Field(
+        description="Business display name for the governed risk event.",
+        json_schema_extra={"example": "Rates-up inflation persistence"},
+    )
+    as_of_date: dt.date = Field(
+        description="Business date for the cohort evaluation.",
+        json_schema_extra={"example": "2026-05-10"},
+    )
+    affected_portfolios: list[RiskEventAffectedPortfolio] = Field(
+        description="Portfolios whose source-owned risk-event impact meets the inclusion threshold.",
+        json_schema_extra={
+            "example": [
+                {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+                    "portfolio_manager_id": "pm-singapore-01",
+                    "impact_score": 0.0745,
+                    "dominant_bucket": "FIXED_INCOME",
+                    "bucket_impacts": {"EQUITY": -0.022, "FIXED_INCOME": -0.0525, "CASH": 0.0},
+                    "source_ref": (
+                        "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:"
+                        "2026-05-10:PB_SG_GLOBAL_BAL_001"
+                    ),
+                    "reason_codes": ["RISK_EVENT_THRESHOLD_BREACHED"],
+                }
+            ]
+        },
+    )
+    excluded_portfolios: list[RiskEventExcludedPortfolio] = Field(
+        description="Candidate portfolios excluded with explicit source-owner reason codes.",
+        json_schema_extra={
+            "example": [
+                {
+                    "portfolio_id": "PB_SG_LOW_RISK_002",
+                    "impact_score": 0.015,
+                    "reason_codes": ["RISK_EVENT_BELOW_THRESHOLD"],
+                }
+            ]
+        },
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded reason codes explaining overall cohort posture.",
+        json_schema_extra={"example": ["RISK_EVENT_AFFECTED_COHORT_READY"]},
+    )
+    metadata: RiskEventCohortMetadata = Field(
+        description="Source-owned product, lineage, and supportability metadata.",
+        json_schema_extra={
+            "example": {
+                "product_name": "RiskEventAffectedCohort",
+                "product_version": "v1",
+                "source_service": "lotus-risk",
+                "lineage_version": "risk-event-affected-cohort.v1",
+                "request_fingerprint": "sha256:abc123",
+                "calculation_supportability": "ready",
+            }
+        },
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -34,6 +34,10 @@ from app.contracts.rolling import (
     RollingResponse,
 )
 from app.contracts.risk import RiskAnalyticsRequest, RiskInputMode, RiskResponse
+from app.contracts.risk_event_cohort import (
+    RiskEventAffectedCohortRequest,
+    RiskEventAffectedCohortResponse,
+)
 from app.contracts.scenario import RegimeScenarioPackRequest, RegimeScenarioPackResponse
 from app.enterprise_readiness import (
     build_enterprise_audit_middleware,
@@ -53,6 +57,7 @@ from app.services.drawdown_mode_adapter import calculate_drawdown_stateful
 from app.services.rolling_engine import calculate_rolling_metrics
 from app.services.rolling_mode_adapter import calculate_rolling_metrics_stateful
 from app.services.risk_engine import calculate_risk
+from app.services.risk_event_cohort_engine import evaluate_risk_event_affected_cohort
 from app.services.risk_mode_adapter import calculate_risk_stateful
 from app.services.scenario_engine import evaluate_regime_scenario_pack
 from app.trust_telemetry import (
@@ -594,6 +599,17 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
                     "does not forecast market states or accept browser-owned scenario methodology",
                 ],
             ),
+            CapabilityWorkflow(
+                workflow_key="risk_event_affected_cohort",
+                endpoint_path="/analytics/risk/risk-event-cohorts/evaluate",
+                supported_input_modes=["stateless"],
+                support_status="partial",
+                notes=[
+                    "evaluates candidate portfolios against governed risk-event definitions",
+                    "returns affected membership, exclusions, impact scores, source refs, and supportability",
+                    "does not create rebalance waves or own campaign approval workflow",
+                ],
+            ),
         ],
     )
 
@@ -635,6 +651,30 @@ async def analytics_risk_regime_scenario_pack(
         endpoint="regime-scenario-pack",
         input_mode="stateless",
         operation=lambda: evaluate_regime_scenario_pack(request_payload),
+    )
+
+
+@app.post(
+    "/analytics/risk/risk-event-cohorts/evaluate",
+    response_model=RiskEventAffectedCohortResponse,
+    responses=STANDARD_ERROR_RESPONSES,
+    summary="Evaluate a governed risk-event affected cohort",
+    tags=["risk-analytics"],
+    description=(
+        "Evaluates candidate portfolios against governed risk-event definitions and returns "
+        "source-owned affected-cohort membership, impact scores, exclusions, lineage source refs, "
+        "bounded reason codes, and supportability posture. Consumers must not reconstruct "
+        "risk-event cohort membership outside lotus-risk, and this endpoint does not create "
+        "rebalance waves, approvals, or campaign workflow."
+    ),
+)
+async def analytics_risk_event_affected_cohort(
+    request_payload: RiskEventAffectedCohortRequest,
+) -> RiskEventAffectedCohortResponse:
+    return await _observed_endpoint(
+        endpoint="risk-event-cohort",
+        input_mode="stateless",
+        operation=lambda: evaluate_risk_event_affected_cohort(request_payload),
     )
 
 

--- a/src/app/services/risk_event_cohort_engine.py
+++ b/src/app/services/risk_event_cohort_engine.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+
+from app.contracts.risk_event_cohort import (
+    RiskEventAffectedCohortRequest,
+    RiskEventAffectedCohortResponse,
+    RiskEventAffectedPortfolio,
+    RiskEventCohortMetadata,
+    RiskEventCohortSupportabilityState,
+    RiskEventExcludedPortfolio,
+)
+
+
+@dataclass(frozen=True)
+class RiskEventDefinition:
+    risk_event_id: str
+    display_name: str
+    shock_by_bucket: dict[str, float]
+
+
+RISK_EVENTS: dict[str, RiskEventDefinition] = {
+    "RISK_EVENT_2026_Q2_RATES_UP": RiskEventDefinition(
+        risk_event_id="RISK_EVENT_2026_Q2_RATES_UP",
+        display_name="Rates-up inflation persistence",
+        shock_by_bucket={
+            "EQUITY": -0.04,
+            "FIXED_INCOME": -0.15,
+            "ALTERNATIVES": -0.03,
+            "CASH": 0.0,
+        },
+    ),
+    "RISK_EVENT_2026_Q2_RISK_OFF": RiskEventDefinition(
+        risk_event_id="RISK_EVENT_2026_Q2_RISK_OFF",
+        display_name="Risk-off liquidity stress",
+        shock_by_bucket={
+            "EQUITY": -0.18,
+            "FIXED_INCOME": -0.02,
+            "ALTERNATIVES": -0.10,
+            "CASH": 0.0,
+        },
+    ),
+}
+
+
+def evaluate_risk_event_affected_cohort(
+    request: RiskEventAffectedCohortRequest,
+) -> RiskEventAffectedCohortResponse:
+    risk_event = RISK_EVENTS.get(request.risk_event_id)
+    if risk_event is None:
+        raise ValueError(f"Unsupported risk_event_id: {request.risk_event_id}")
+
+    affected: list[RiskEventAffectedPortfolio] = []
+    excluded: list[RiskEventExcludedPortfolio] = []
+    unsupported_bucket_seen = False
+    supported_buckets = set(risk_event.shock_by_bucket)
+
+    for portfolio in request.portfolios:
+        normalized_exposures = {
+            bucket.upper(): weight for bucket, weight in portfolio.exposure_weights.items()
+        }
+        unsupported_buckets = sorted(set(normalized_exposures) - supported_buckets)
+        unsupported_bucket_seen = unsupported_bucket_seen or bool(unsupported_buckets)
+        bucket_impacts = {
+            bucket: round(weight * risk_event.shock_by_bucket.get(bucket, 0.0), 6)
+            for bucket, weight in normalized_exposures.items()
+        }
+        impact_score = round(sum(abs(value) for value in bucket_impacts.values()), 6)
+        dominant_bucket = max(
+            bucket_impacts,
+            key=lambda bucket: abs(bucket_impacts[bucket]),
+            default="UNKNOWN",
+        )
+        if impact_score >= request.minimum_impact_score and not unsupported_buckets:
+            affected.append(
+                RiskEventAffectedPortfolio(
+                    portfolio_id=portfolio.portfolio_id,
+                    mandate_id=portfolio.mandate_id,
+                    portfolio_manager_id=portfolio.portfolio_manager_id,
+                    impact_score=impact_score,
+                    dominant_bucket=dominant_bucket,
+                    bucket_impacts=bucket_impacts,
+                    source_ref=(
+                        "risk-event-cohort:"
+                        f"{request.risk_event_id}:{request.as_of_date.isoformat()}:"
+                        f"{portfolio.portfolio_id}"
+                    ),
+                    reason_codes=["RISK_EVENT_THRESHOLD_BREACHED"],
+                )
+            )
+            continue
+
+        reason_codes = ["RISK_EVENT_BELOW_THRESHOLD"]
+        if unsupported_buckets:
+            reason_codes = ["RISK_EVENT_UNSUPPORTED_EXPOSURE_BUCKET"]
+        excluded.append(
+            RiskEventExcludedPortfolio(
+                portfolio_id=portfolio.portfolio_id,
+                impact_score=impact_score,
+                reason_codes=reason_codes,
+            )
+        )
+
+    supportability = RiskEventCohortSupportabilityState.READY
+    reason_codes = ["RISK_EVENT_AFFECTED_COHORT_READY"]
+    if unsupported_bucket_seen:
+        supportability = RiskEventCohortSupportabilityState.DEGRADED
+        reason_codes.append("RISK_EVENT_PARTIAL_UNSUPPORTED_EXPOSURE_BUCKETS")
+    if not affected:
+        supportability = RiskEventCohortSupportabilityState.PENDING_REVIEW
+        reason_codes.append("RISK_EVENT_NO_AFFECTED_PORTFOLIOS")
+
+    request_fingerprint = _request_fingerprint(request)
+    return RiskEventAffectedCohortResponse(
+        cohort_id=_cohort_id(request_fingerprint),
+        risk_event_id=request.risk_event_id,
+        display_name=risk_event.display_name,
+        as_of_date=request.as_of_date,
+        affected_portfolios=affected,
+        excluded_portfolios=excluded,
+        reason_codes=sorted(set(reason_codes)),
+        metadata=RiskEventCohortMetadata(
+            request_fingerprint=request_fingerprint,
+            calculation_supportability=supportability,
+        ),
+    )
+
+
+def _request_fingerprint(request: RiskEventAffectedCohortRequest) -> str:
+    payload = request.model_dump(mode="json")
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _cohort_id(request_fingerprint: str) -> str:
+    return "risk_event_cohort_" + request_fingerprint.removeprefix("sha256:")[:16]

--- a/src/app/trust_telemetry.py
+++ b/src/app/trust_telemetry.py
@@ -200,7 +200,7 @@ class DeclaredConsumerDependencyTelemetry(BaseModel):
 class TrustTelemetryReviewSummary(BaseModel):
     declared_product_count: int = Field(
         description="Number of repo-native declared producer products included in the snapshot.",
-        json_schema_extra={"example": 6},
+        json_schema_extra={"example": 7},
     )
     declared_dependency_count: int = Field(
         description="Number of repo-native declared upstream dependencies included in the snapshot.",
@@ -290,7 +290,7 @@ class DeclaredProductTrustTelemetrySnapshot(BaseModel):
         description="Operator-facing rollup of declaration counts and current runtime dependency posture.",
         json_schema_extra={
             "example": {
-                "declared_product_count": 6,
+                "declared_product_count": 7,
                 "declared_dependency_count": 6,
                 "degraded_dependency_count": 2,
                 "unavailable_dependency_count": 0,

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -215,7 +215,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         body["consumer_declaration_source"]
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
-    assert body["summary"]["declared_product_count"] == 6
+    assert body["summary"]["declared_product_count"] == 7
     assert body["summary"]["declared_dependency_count"] == 6
     assert [product["product_name"] for product in body["products"]] == [
         "RiskMetricsReport",
@@ -224,6 +224,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
         "RegimeScenarioPackEvaluation",
+        "RiskEventAffectedCohort",
     ]
 
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -44,6 +44,7 @@ def test_integration_capabilities_contract() -> None:
         "risk.analytics.rolling_metrics",
         "risk.analytics.historical_attribution",
         "risk.analytics.regime_scenario_pack",
+        "risk.analytics.risk_event_affected_cohort",
         "risk.analytics.metrics",
         "risk.observability.calculation_supportability",
     }
@@ -55,6 +56,7 @@ def test_integration_capabilities_contract() -> None:
         "rolling_risk_analytics",
         "historical_risk_attribution",
         "regime_scenario_pack_evaluation",
+        "risk_event_affected_cohort",
     }
     workflow_by_key = {workflow["workflow_key"]: workflow for workflow in body["workflows"]}
     assert workflow_by_key["risk_snapshot"]["endpoint_path"] == "/analytics/risk/calculate"
@@ -73,6 +75,10 @@ def test_integration_capabilities_contract() -> None:
     assert workflow_by_key["regime_scenario_pack_evaluation"]["supported_input_modes"] == [
         "stateless"
     ]
+    assert workflow_by_key["risk_event_affected_cohort"]["endpoint_path"] == (
+        "/analytics/risk/risk-event-cohorts/evaluate"
+    )
+    assert workflow_by_key["risk_event_affected_cohort"]["support_status"] == "partial"
     assert (
         "stateful active-risk ISSUER remains gated"
         in workflow_by_key["historical_risk_attribution"]["notes"]
@@ -212,7 +218,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         == "lotus-performance"
     )
     assert trust_telemetry_body["declared_dependencies"][0]["runtime_status"] == "ok"
-    assert trust_telemetry_body["summary"]["declared_product_count"] == 6
+    assert trust_telemetry_body["summary"]["declared_product_count"] == 7
     assert trust_telemetry_body["summary"]["declared_dependency_count"] == 6
     assert trust_telemetry_body["summary"]["degraded_dependency_count"] == 0
     assert trust_telemetry_body["summary"]["unavailable_dependency_count"] == 0
@@ -224,6 +230,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
         "RegimeScenarioPackEvaluation",
+        "RiskEventAffectedCohort",
     ]
     assert all(
         product["lifecycle_status"] == "active" for product in trust_telemetry_body["products"]
@@ -493,7 +500,7 @@ def test_openapi_exposes_local_trust_telemetry_snapshot_schema() -> None:
     assert (
         dependency_schema["properties"]["runtime_issue_code"]["example"] == "UPSTREAM_HIGH_LATENCY"
     )
-    assert summary_schema["properties"]["declared_product_count"]["example"] == 6
+    assert summary_schema["properties"]["declared_product_count"]["example"] == 7
     assert summary_schema["properties"]["declared_dependency_count"]["example"] == 6
     assert (
         seed_schema["properties"]["readiness_status"]["description"]

--- a/tests/unit/test_domain_data_products.py
+++ b/tests/unit/test_domain_data_products.py
@@ -25,6 +25,7 @@ def test_list_declared_products_matches_expected_wave() -> None:
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
         "RegimeScenarioPackEvaluation",
+        "RiskEventAffectedCohort",
     ]
 
 

--- a/tests/unit/test_risk_event_cohort_api.py
+++ b/tests/unit/test_risk_event_cohort_api.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+def test_risk_event_affected_cohort_endpoint_returns_source_contract() -> None:
+    client = TestClient(app)
+
+    response = client.post(
+        "/analytics/risk/risk-event-cohorts/evaluate",
+        json={
+            "risk_event_id": "RISK_EVENT_2026_Q2_RATES_UP",
+            "as_of_date": "2026-05-10",
+            "minimum_impact_score": 0.05,
+            "portfolios": [
+                {
+                    "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                    "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+                    "portfolio_manager_id": "pm-singapore-01",
+                    "exposure_weights": {
+                        "EQUITY": 0.55,
+                        "FIXED_INCOME": 0.35,
+                        "CASH": 0.10,
+                    },
+                }
+            ],
+        },
+        headers={"X-Correlation-Id": "corr-risk-event-cohort"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["risk_event_id"] == "RISK_EVENT_2026_Q2_RATES_UP"
+    assert body["metadata"]["product_name"] == "RiskEventAffectedCohort"
+    assert body["metadata"]["calculation_supportability"] == "ready"
+    assert body["affected_portfolios"][0]["portfolio_id"] == "PB_SG_GLOBAL_BAL_001"
+    assert body["affected_portfolios"][0]["source_ref"].startswith("risk-event-cohort:")
+
+
+def test_capabilities_include_risk_event_cohort_workflow() -> None:
+    client = TestClient(app)
+
+    response = client.get("/integration/capabilities")
+
+    assert response.status_code == 200
+    workflows = {workflow["workflow_key"]: workflow for workflow in response.json()["workflows"]}
+    assert workflows["risk_event_affected_cohort"]["endpoint_path"] == (
+        "/analytics/risk/risk-event-cohorts/evaluate"
+    )
+    assert workflows["risk_event_affected_cohort"]["support_status"] == "partial"

--- a/tests/unit/test_risk_event_cohort_engine.py
+++ b/tests/unit/test_risk_event_cohort_engine.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from app.contracts.risk_event_cohort import (
+    RiskEventAffectedCohortRequest,
+    RiskEventCohortSupportabilityState,
+)
+from app.services.risk_event_cohort_engine import evaluate_risk_event_affected_cohort
+
+
+def _request(**overrides: object) -> RiskEventAffectedCohortRequest:
+    payload: dict[str, object] = {
+        "risk_event_id": "RISK_EVENT_2026_Q2_RATES_UP",
+        "as_of_date": "2026-05-10",
+        "minimum_impact_score": 0.05,
+        "portfolios": [
+            {
+                "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+                "mandate_id": "MANDATE-PB-SG-GLOBAL-BAL-001",
+                "portfolio_manager_id": "pm-singapore-01",
+                "exposure_weights": {
+                    "EQUITY": 0.55,
+                    "FIXED_INCOME": 0.35,
+                    "CASH": 0.10,
+                },
+            },
+            {
+                "portfolio_id": "PB_SG_LOW_RISK_002",
+                "mandate_id": "MANDATE-PB-SG-LOW-RISK-002",
+                "portfolio_manager_id": "pm-singapore-01",
+                "exposure_weights": {
+                    "FIXED_INCOME": 0.10,
+                    "CASH": 0.90,
+                },
+            },
+        ],
+    }
+    payload.update(overrides)
+    return RiskEventAffectedCohortRequest.model_validate(payload)
+
+
+def test_risk_event_affected_cohort_returns_source_owned_membership() -> None:
+    response = evaluate_risk_event_affected_cohort(_request())
+
+    assert response.risk_event_id == "RISK_EVENT_2026_Q2_RATES_UP"
+    assert response.display_name == "Rates-up inflation persistence"
+    assert response.metadata.product_name == "RiskEventAffectedCohort"
+    assert response.metadata.product_version == "v1"
+    assert response.metadata.source_service == "lotus-risk"
+    assert response.metadata.calculation_supportability == RiskEventCohortSupportabilityState.READY
+    assert response.cohort_id.startswith("risk_event_cohort_")
+    assert response.reason_codes == ["RISK_EVENT_AFFECTED_COHORT_READY"]
+    assert [member.portfolio_id for member in response.affected_portfolios] == [
+        "PB_SG_GLOBAL_BAL_001"
+    ]
+    member = response.affected_portfolios[0]
+    assert member.impact_score == 0.0745
+    assert member.dominant_bucket == "FIXED_INCOME"
+    assert member.source_ref == (
+        "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:2026-05-10:PB_SG_GLOBAL_BAL_001"
+    )
+    assert member.reason_codes == ["RISK_EVENT_THRESHOLD_BREACHED"]
+    assert [excluded.portfolio_id for excluded in response.excluded_portfolios] == [
+        "PB_SG_LOW_RISK_002"
+    ]
+
+
+def test_risk_event_affected_cohort_degrades_unsupported_exposure_bucket() -> None:
+    response = evaluate_risk_event_affected_cohort(
+        _request(
+            portfolios=[
+                {
+                    "portfolio_id": "PB_SG_PRIVATE_MARKETS_003",
+                    "exposure_weights": {"PRIVATE_CREDIT": 1.0},
+                }
+            ]
+        )
+    )
+
+    assert (
+        response.metadata.calculation_supportability
+        == RiskEventCohortSupportabilityState.PENDING_REVIEW
+    )
+    assert response.affected_portfolios == []
+    assert response.excluded_portfolios[0].reason_codes == [
+        "RISK_EVENT_UNSUPPORTED_EXPOSURE_BUCKET"
+    ]
+    assert "RISK_EVENT_NO_AFFECTED_PORTFOLIOS" in response.reason_codes
+    assert "RISK_EVENT_PARTIAL_UNSUPPORTED_EXPOSURE_BUCKETS" in response.reason_codes
+
+
+def test_risk_event_affected_cohort_rejects_unknown_event() -> None:
+    with pytest.raises(ValueError, match="Unsupported risk_event_id"):
+        evaluate_risk_event_affected_cohort(_request(risk_event_id="RISK_EVENT_UNKNOWN"))

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -205,7 +205,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     assert snapshot.declared_dependencies[2].runtime_status == "degraded"
     assert snapshot.declared_dependencies[2].runtime_category == "data_gap"
     assert snapshot.declared_dependencies[2].runtime_issue_code == "RISK_FREE_SERIES_STALE"
-    assert snapshot.summary.declared_product_count == 6
+    assert snapshot.summary.declared_product_count == 7
     assert snapshot.summary.declared_dependency_count == 6
     assert snapshot.summary.degraded_dependency_count == 4
     assert snapshot.summary.unavailable_dependency_count == 0
@@ -225,6 +225,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
         "RegimeScenarioPackEvaluation",
+        "RiskEventAffectedCohort",
     ]
     assert all(product.lifecycle_status == "active" for product in snapshot.products)
     assert snapshot.products[0].product_family == "analytics_output"

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -13,8 +13,10 @@
   - `lotus-risk:HistoricalRiskAttributionReport:v1`
   - `lotus-risk:ConcentrationRiskReport:v1`
   - `lotus-risk:RegimeScenarioPackEvaluation:v1`
-- Product role: governed risk analytics reports and scenario-pack evaluation outputs for advisory,
-  reporting, gateway, Workbench discovery, and manage construction-supportability flows
+  - `lotus-risk:RiskEventAffectedCohort:v1`
+- Product role: governed risk analytics reports, scenario-pack evaluation outputs, and risk-event
+  affected-cohort membership for advisory, reporting, gateway, Workbench discovery, manage
+  construction-supportability, and future rebalance-wave trigger flows
 - Source declaration: `contracts/domain-data-products/`
 - Trust telemetry: `contracts/trust-telemetry/`
 
@@ -35,11 +37,13 @@ flowchart LR
     GW[lotus-gateway<br/>risk composition]
     WB[lotus-workbench<br/>risk workspace]
     MANAGE[lotus-manage<br/>realized outcome source adapter]
+    COHORT[lotus-risk<br/>RiskEventAffectedCohort:v1]
 
     PERF -->|dated return series| RISK
     RISK -->|rolling active-risk metrics + lineage| GW
     GW --> WB
     RISK -->|source-owned scalar evidence| MANAGE
+    COHORT -->|affected portfolios + source refs| MANAGE
 ```
 
 Audience notes:
@@ -52,6 +56,9 @@ Audience notes:
   valid ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling tracking error locally.
+- Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
+  exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
+  membership locally.
 - Sales and pre-sales can describe the canonical capability as implementation-backed for supported
   seeded portfolios, while broader portfolio-archetype coverage still depends on live validation
   evidence.

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -44,7 +44,9 @@ The current domain workflows are:
 4. historical attribution analytics via `/analytics/risk/historical-attribution`,
 5. concentration analytics via `/analytics/risk/concentration`,
 6. governed regime scenario-pack evaluation via
-   `/analytics/risk/regime-scenario-pack/evaluate`.
+   `/analytics/risk/regime-scenario-pack/evaluate`,
+7. governed risk-event affected-cohort evaluation via
+   `/analytics/risk/risk-event-cohorts/evaluate`.
 
 Operational and integration surfaces also matter:
 


### PR DESCRIPTION
## Summary
- adds RiskEventAffectedCohort:v1 as a lotus-risk source-owned data product for RFC41-WTBD-003
- exposes POST /analytics/risk/risk-event-cohorts/evaluate with typed request/response contracts, bounded reason codes, source refs, supportability, and deterministic cohort identity
- publishes capability discovery, API vocabulary inventory, data-product declaration, README/context/wiki docs, and trust telemetry count updates
- keeps the boundary explicit: this endpoint evaluates affected membership only; it does not create rebalance waves, approvals, OMS execution, or campaign workflow

## Validation
- platform mirror PR #313 merged: sgajbi/lotus-platform#313, merge commit 4218d4319d5dac82e87106429fadb14247c36515
- make ci
- python C:\\Users\\Sandeep\\projects\\lotus-platform\\automation\\validate_engineering_context_system.py
- powershell -ExecutionPolicy Bypass -File C:\\Users\\Sandeep\\projects\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md, Overview.md)
- git diff --check
- git fetch origin --prune && git branch -r --no-merged origin/main returned no unmerged lotus-risk governance branches before commit