### PR TITLE
Pin rolling volatility methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,11 +50,11 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
-    `ROLLING_TRACKING_ERROR` and `ROLLING_INFORMATION_RATIO`: the docs and tests pin inner date
-    alignment, percentage-point to decimal conversion, `ddof=1` sample standard deviation,
-    annualized decimal tracking-error output, dimensionless information-ratio output,
-    warm-up/null behavior, no-aligned-benchmark supportability posture, and zero-tracking-error
-    information-ratio flagging.
+    `ROLLING_VOLATILITY`, `ROLLING_TRACKING_ERROR`, and `ROLLING_INFORMATION_RATIO`: the docs and
+    tests pin percentage-point to decimal conversion, `ddof=1` sample standard deviation,
+    annualization, annualized decimal volatility output, annualized decimal tracking-error output,
+    dimensionless information-ratio output, warm-up/null behavior, no-aligned-benchmark
+    supportability posture, and zero-tracking-error information-ratio flagging.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/rolling-volatility.md
+++ b/docs/methodologies/metrics/rolling-volatility.md
@@ -8,40 +8,70 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Annualization basis.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns`.
+- Stateful mode: `lotus-performance` portfolio return series fetched through the governed
+  rolling-metrics integration path.
+- `lotus-risk` owns the rolling volatility calculation after dated return series are resolved. It
+  does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio returns to decimal before rolling math:
+  `r_decimal = r_pp / 100`.
+- `ROLLING_VOLATILITY` output is an annualized decimal ratio: `0.3005` means `30.05%`.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the
+  same annualized decimal ratio unit.
 
 ## Variable Dictionary
-- `r_t`: decimal return sample.
-- `W`: rolling window length.
-- `sigma_t(W)`: rolling sample std at endpoint `t`.
-- `AB`: annualization basis.
-- `RV_t(W) = sigma_t(W)*sqrt(AB)`.
+- `t`: observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `AF`: annualization basis.
+- `sigma_p_t(W)`: sample standard deviation of portfolio returns inside the window ending on date
+  `t`, with `ddof=1`.
+- `RV_t(W)`: rolling volatility for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. `r_t=r_pp/100`.
-2. `sigma_t(W)=std_W(r,ddof=1)`.
-3. `RV_t=sigma_t(W)*sqrt(annualization_basis)`.
+1. Convert each portfolio observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100`.
+2. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+3. For each date with at least `min_obs` observations in the rolling window, compute sample
+   portfolio-return standard deviation:
+   `sigma_p_t(W) = std(Rp_{t-W+1} ... Rp_t, ddof=1)`.
+4. Annualize:
+   `RV_t(W) = sigma_p_t(W) * sqrt(AF)`.
+5. Build summary statistics from computed, non-null `RV_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio returns to the period.
+3. Convert the filtered series from percentage points to decimal.
+4. For each requested window length, compute rolling sample standard deviation using `ddof=1`.
+5. Annualize each computed point with `sqrt(rolling_options.annualization_basis)`.
+6. Leave warm-up points as null until the configured minimum observation count is met.
+7. Populate `metric_summaries.ROLLING_VOLATILITY` from non-null annualized values.
+8. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_VOLATILITY` for
+   every point in the rolling result, with warm-up points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Fewer than two portfolio observations in the period returns period-level
+  `error = "Insufficient data"` and no window results.
+- Window warm-up points are null until `min_obs` is met.
+- Constant portfolio returns are valid and produce `0.0`; there is no denominator and no
+  zero-variance error for rolling volatility.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No benchmark or risk-free dependency is required for `ROLLING_VOLATILITY`.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
@@ -55,8 +85,28 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window `3`, decimal returns `[0.010,-0.020,0.015]`.
-| Window | Std | Annualization | Value |
-|---|---:|---:|---:|
-| 1 | `0.01893` | `sqrt(252)` | `0.3005` |
-Output mapping: `window_results[].metric_summaries.ROLLING_VOLATILITY.latest=0.3005`.
+Assume daily annualization (`AF = 252`), `STRICT` minimum observations, `W = 3`, and portfolio return
+observations:
+
+| Date | `Rp_t_pp` | `Rp_t = Rp_t_pp / 100` |
+| --- | ---: | ---: |
+| Day 1 | `1.00` | `0.010` |
+| Day 2 | `-2.00` | `-0.020` |
+| Day 3 | `1.50` | `0.015` |
+
+Intermediate calculations for the first full window:
+
+| Step | Value |
+| --- | ---: |
+| Portfolio mean | `0.005 / 3 = 0.0016666667` |
+| Squared deviations sum | `0.0007166667` |
+| Sample variance (`ddof=1`) | `0.0003583333` |
+| `sigma_p_t(3)` | `0.0189296945` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `RV_t(3)` | `0.3004995840` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_VOLATILITY.latest = 0.3004995840`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_VOLATILITY = 0.3004995840`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -5,31 +5,62 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ROLLING_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-tracking-error.md"
 )
+ROLLING_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-volatility.md"
 ROLLING_INFORMATION_RATIO_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-information-ratio.md"
 )
 
 
+EXPECTED_V3_SECTIONS = [
+    "## Metric",
+    "## Endpoint and Mode Coverage",
+    "## Inputs",
+    "## Upstream Data Sources",
+    "## Unit Conventions",
+    "## Variable Dictionary",
+    "## Methodology and Formulas",
+    "## Step-by-Step Computation",
+    "## Validation and Failure Behavior",
+    "## Configuration Options",
+    "## Outputs",
+    "## Worked Example",
+]
+
+
+def _assert_v3_section_order(text: str) -> None:
+    section_positions = [text.index(section) for section in EXPECTED_V3_SECTIONS]
+    assert section_positions == sorted(section_positions)
+
+
+def test_rolling_volatility_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_VOLATILITY_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ROLLING_VOLATILITY",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "annualized decimal ratio",
+        "ddof=1",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        "Constant portfolio returns are valid and produce `0.0`",
+        "No benchmark or risk-free dependency is required for `ROLLING_VOLATILITY`",
+        "metric_summaries.ROLLING_VOLATILITY.latest",
+        "metric_series[].metric_values.ROLLING_VOLATILITY",
+        "0.3004995840",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
 def test_rolling_tracking_error_methodology_is_auditable_against_engine_contract() -> None:
     text = ROLLING_TRACKING_ERROR_DOC.read_text(encoding="utf-8")
 
-    expected_sections = [
-        "## Metric",
-        "## Endpoint and Mode Coverage",
-        "## Inputs",
-        "## Upstream Data Sources",
-        "## Unit Conventions",
-        "## Variable Dictionary",
-        "## Methodology and Formulas",
-        "## Step-by-Step Computation",
-        "## Validation and Failure Behavior",
-        "## Configuration Options",
-        "## Outputs",
-        "## Worked Example",
-    ]
-
-    section_positions = [text.index(section) for section in expected_sections]
-    assert section_positions == sorted(section_positions)
+    _assert_v3_section_order(text)
 
     required_truth = [
         "metric_id: ROLLING_TRACKING_ERROR",
@@ -54,23 +85,7 @@ def test_rolling_tracking_error_methodology_is_auditable_against_engine_contract
 def test_rolling_information_ratio_methodology_is_auditable_against_engine_contract() -> None:
     text = ROLLING_INFORMATION_RATIO_DOC.read_text(encoding="utf-8")
 
-    expected_sections = [
-        "## Metric",
-        "## Endpoint and Mode Coverage",
-        "## Inputs",
-        "## Upstream Data Sources",
-        "## Unit Conventions",
-        "## Variable Dictionary",
-        "## Methodology and Formulas",
-        "## Step-by-Step Computation",
-        "## Validation and Failure Behavior",
-        "## Configuration Options",
-        "## Outputs",
-        "## Worked Example",
-    ]
-
-    section_positions = [text.index(section) for section in expected_sections]
-    assert section_positions == sorted(section_positions)
+    _assert_v3_section_order(text)
 
     required_truth = [
         "metric_id: ROLLING_INFORMATION_RATIO",

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -72,6 +72,44 @@ def test_rolling_engine_returns_window_results_and_metadata() -> None:
     assert len(window.metric_series) > 0
 
 
+def test_rolling_volatility_matches_documented_decimal_methodology() -> None:
+    payload = RollingStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-01", "value": 1.0},
+                {"date": "2026-01-02", "value": -2.0},
+                {"date": "2026-01-03", "value": 1.5},
+            ],
+            "rolling_options": {
+                "window_lengths": [3],
+                "metrics": ["ROLLING_VOLATILITY"],
+                "annualization_basis": 252,
+                "min_observations_policy": "STRICT",
+                "include_time_series": True,
+            },
+        }
+    )
+
+    response = calculate_rolling_metrics(payload, input_mode=RollingInputMode.STATELESS)
+
+    window = response.results["YTD"].window_results[0]
+    summary = window.metric_summaries["ROLLING_VOLATILITY"]
+
+    assert summary.latest == pytest.approx(0.3004995840263344)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-03"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 1
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-03"
+    assert latest_point.metric_values["ROLLING_VOLATILITY"] == pytest.approx(summary.latest)
+
+
 def test_rolling_tracking_error_matches_documented_decimal_methodology() -> None:
     response = calculate_rolling_metrics(_base_input(), input_mode=RollingInputMode.STATELESS)
 

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -22,13 +22,13 @@
 
 ## Implementation-backed methodology coverage
 
-`RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling tracking
-error and rolling information ratio. The methodologies are tied to the implemented
-`/analytics/risk/rolling-metrics` engine and state the exact date-alignment rule, percentage-point
-to decimal conversion, `ddof=1` sample standard deviation, annualization basis, strict versus
-partial minimum-observation behavior, warm-up null handling, no-aligned-benchmark behavior,
-zero-tracking-error information-ratio flagging, decimal-ratio tracking-error output, and
-dimensionless information-ratio output.
+`RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
+volatility, rolling tracking error, and rolling information ratio. The methodologies are tied to
+the implemented `/analytics/risk/rolling-metrics` engine and state the exact percentage-point to
+decimal conversion, `ddof=1` sample standard deviation, annualization basis, strict versus partial
+minimum-observation behavior, warm-up null handling, benchmark date-alignment rule where required,
+no-aligned-benchmark behavior, zero-tracking-error information-ratio flagging, annualized decimal
+volatility output, decimal-ratio tracking-error output, and dimensionless information-ratio output.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -55,14 +55,15 @@ flowchart LR
 
 Audience notes:
 
-- Business users can read rolling tracking error as annualized active-return volatility versus the
-  selected benchmark, and rolling information ratio as annualized active return per unit of that
-  active risk.
+- Business users can read rolling volatility as annualized portfolio-return dispersion, rolling
+  tracking error as annualized active-return volatility versus the selected benchmark, and rolling
+  information ratio as annualized active return per unit of that active risk.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; zero-tracking-error windows are flagged rather than promoted as
   valid ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
-  supportability metadata rather than recomputing rolling tracking error locally.
+  supportability metadata rather than recomputing rolling volatility, tracking error, or
+  information ratio locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `ROLLING_VOLATILITY` to auditable v3 methodology depth for `RollingRiskMetricsReport:v1`
- pin pp-to-decimal conversion, `ddof=1`, annualized decimal output, warm-up/null behavior, no benchmark/risk-free dependency, and worked-example output mapping
- add methodology-doc and engine regressions, and update repo context/wiki source

## Validation
- git fetch origin --prune; git branch -r --no-merged origin/main; git status --short --branch
- gh pr list --state open --limit 20 --json number,title,headRefName,url,statusCheckRollup
- python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py -q
- python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py
- python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py
- make check
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)

## WTBD posture
Advances RFC42-WTBD-006 source-owner methodology depth without touching Gateway or Workbench and without moving risk calculation into downstream consumers.