### PR TITLE
Pin rolling Sharpe methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,11 +50,13 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
-    `ROLLING_VOLATILITY`, `ROLLING_TRACKING_ERROR`, and `ROLLING_INFORMATION_RATIO`: the docs and
-    tests pin percentage-point to decimal conversion, `ddof=1` sample standard deviation,
-    annualization, annualized decimal volatility output, annualized decimal tracking-error output,
-    dimensionless information-ratio output, warm-up/null behavior, no-aligned-benchmark
-    supportability posture, and zero-tracking-error information-ratio flagging.
+    `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_TRACKING_ERROR`, and
+    `ROLLING_INFORMATION_RATIO`: the docs and tests pin percentage-point to decimal conversion,
+    `ddof=1` sample standard deviation, annualization, annualized decimal volatility output,
+    annualized decimal tracking-error output, dimensionless Sharpe and information-ratio output,
+    warm-up/null behavior, source-owned risk-free/benchmark alignment posture, no-aligned
+    dependency supportability posture, zero-excess-volatility Sharpe flagging, and
+    zero-tracking-error information-ratio flagging.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/rolling-sharpe.md
+++ b/docs/methodologies/metrics/rolling-sharpe.md
@@ -8,40 +8,78 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- Risk-free return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Annualization basis.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns` and `risk_free_returns`.
+- Stateful mode: `lotus-performance` provides portfolio returns and `lotus-core` provides risk-free reference returns through the governed rolling-metrics integration path.
+- `lotus-risk` owns the rolling Sharpe calculation after dated return series are resolved. It does not source risk-free returns from Workbench, Gateway, manage, or local zero-rate assumptions.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio and risk-free returns to decimal before rolling math:
+  `r_decimal = r_pp / 100`.
+- Excess returns are decimal differences.
+- `ROLLING_SHARPE` output is a dimensionless annualized ratio.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the same dimensionless ratio unit.
 
 ## Variable Dictionary
-- `r_port_t`, `r_rf_t`: decimal portfolio and risk-free returns.
-- `x_t = r_port_t - r_rf_t`: excess return.
-- `W`: rolling window length.
-- `mu_t(W)`, `sigma_t(W)`: rolling excess mean/std.
-- `RS_t(W) = (mu_t/sigma_t)*sqrt(AB)`.
+- `t`: aligned observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rf_t_pp`: risk-free return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `Rf_t`: risk-free return on date `t`, as decimal (`Rf_t_pp / 100`).
+- `x_t`: excess return on date `t`, as decimal (`Rp_t - Rf_t`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `AF`: annualization basis.
+- `mu_x_t(W)`: arithmetic mean of excess returns inside the window ending on date `t`.
+- `sigma_x_t(W)`: sample standard deviation of excess returns inside the window ending on date `t`, with `ddof=1`.
+- `RS_t(W)`: rolling Sharpe ratio for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. `x_t=r_port_t-r_rf_t`.
-2. `mu_t=mean_W(x_t)`, `sigma_t=std_W(x_t,ddof=1)`.
-3. `RS_t=(mu_t/sigma_t)*sqrt(annualization_basis)`.
+1. Convert each portfolio and risk-free observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100` and `Rf_t = Rf_t_pp / 100`.
+2. Inner-align portfolio and risk-free series by date for the requested period.
+3. Compute the excess return series:
+   `x_t = Rp_t - Rf_t`.
+4. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+5. For each date with at least `min_obs` observations in the rolling window, compute:
+   - `mu_x_t(W) = mean(x_{t-W+1} ... x_t)`;
+   - `sigma_x_t(W) = std(x_{t-W+1} ... x_t, ddof=1)`.
+6. Annualize the mean/std ratio:
+   `RS_t(W) = (mu_x_t(W) / sigma_x_t(W)) * sqrt(AF)`.
+7. Replace infinite results with null before summaries are built.
+8. Build summary statistics from computed, non-null `RS_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio and risk-free returns to the period.
+3. Convert both filtered series from percentage points to decimal.
+4. Inner-align the decimal series by date.
+5. If no aligned observations remain, emit no computed metric values and record the risk-free dependency as `NO_ALIGNED_OBSERVATIONS`.
+6. For each requested window length, compute rolling excess-return mean and sample standard deviation using `ddof=1`.
+7. Annualize each non-zero-denominator point with `sqrt(rolling_options.annualization_basis)`.
+8. Convert infinite values to null so zero excess-return volatility windows do not become misleading ratios.
+9. Leave warm-up points as null until the configured minimum observation count is met.
+10. Populate `metric_summaries.ROLLING_SHARPE` from non-null annualized ratios.
+11. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_SHARPE` for every point in the rolling result, with warm-up and zero-denominator points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Stateless requests that include `ROLLING_SHARPE` without `risk_free_returns` fail request validation.
+- Stateful requests require risk-free sourcing from `lotus-core`; unavailable upstream data fails closed with dependency details rather than falling back to a zero risk-free return.
+- Fewer than two portfolio observations in the period returns period-level `error = "Insufficient data"` and no window results.
+- Risk-free series supplied but with no aligned dates returns `risk_free_context.reason = "NO_ALIGNED_OBSERVATIONS"` and emits no computed Sharpe values for the metric.
+- Window warm-up points are null until `min_obs` is met.
+- Zero rolling excess-return standard deviation produces null metric points and quality flag `metric:ROLLING_SHARPE:zero_volatility_window`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
@@ -55,8 +93,28 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window `3`, excess returns `[0.004,0.001,-0.002]`.
-| Window | Mean | Std | Annualization | Value |
-|---|---:|---:|---:|---:|
-| 1 | `0.0010` | `0.0030` | `sqrt(252)` | `5.291` |
-Output mapping: latest value appears in `metric_summaries.ROLLING_SHARPE.latest`.
+Assume daily annualization (`AF = 252`), `STRICT` minimum observations, `W = 3`, and aligned return observations:
+
+| Date | `Rp_t_pp` | `Rf_t_pp` | `Rp_t` | `Rf_t` | `x_t = Rp_t - Rf_t` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Day 1 | `0.50` | `0.01` | `0.005` | `0.0001` | `0.0049` |
+| Day 2 | `0.20` | `0.01` | `0.002` | `0.0001` | `0.0019` |
+| Day 3 | `-0.10` | `0.01` | `-0.001` | `0.0001` | `-0.0011` |
+
+Intermediate calculations for the first full window:
+
+| Step | Value |
+| --- | ---: |
+| Excess mean | `(0.0057) / 3 = 0.0019` |
+| Squared deviations sum | `0.0000180000` |
+| Sample variance (`ddof=1`) | `0.0000090000` |
+| `sigma_x_t(3)` | `0.0030000000` |
+| Mean/std ratio | `0.6333333333` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `RS_t(3)` | `10.0538549820` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_SHARPE.latest = 10.0538549820`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_SHARPE = 10.0538549820`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -9,6 +9,7 @@ ROLLING_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rol
 ROLLING_INFORMATION_RATIO_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-information-ratio.md"
 )
+ROLLING_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-sharpe.md"
 
 
 EXPECTED_V3_SECTIONS = [
@@ -101,6 +102,32 @@ def test_rolling_information_ratio_methodology_is_auditable_against_engine_contr
         "metric_summaries.ROLLING_INFORMATION_RATIO.latest",
         "metric_series[].metric_values.ROLLING_INFORMATION_RATIO",
         "6.9282032303",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_rolling_sharpe_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_SHARPE_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ROLLING_SHARPE",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "lotus-core",
+        "r_decimal = r_pp / 100",
+        "dimensionless annualized ratio",
+        "ddof=1",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        'risk_free_context.reason = "NO_ALIGNED_OBSERVATIONS"',
+        "metric:ROLLING_SHARPE:zero_volatility_window",
+        "metric_summaries.ROLLING_SHARPE.latest",
+        "metric_series[].metric_values.ROLLING_SHARPE",
+        "10.0538549820",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -150,6 +150,51 @@ def test_rolling_information_ratio_matches_documented_decimal_methodology() -> N
     assert latest_point.metric_values["ROLLING_INFORMATION_RATIO"] == pytest.approx(summary.latest)
 
 
+def test_rolling_sharpe_matches_documented_decimal_methodology() -> None:
+    payload = RollingStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-01", "value": 0.50},
+                {"date": "2026-01-02", "value": 0.20},
+                {"date": "2026-01-03", "value": -0.10},
+            ],
+            "risk_free_returns": [
+                {"date": "2026-01-01", "value": 0.01},
+                {"date": "2026-01-02", "value": 0.01},
+                {"date": "2026-01-03", "value": 0.01},
+            ],
+            "rolling_options": {
+                "window_lengths": [3],
+                "metrics": ["ROLLING_SHARPE"],
+                "annualization_basis": 252,
+                "min_observations_policy": "STRICT",
+                "include_time_series": True,
+            },
+        }
+    )
+
+    response = calculate_rolling_metrics(payload, input_mode=RollingInputMode.STATELESS)
+
+    period = response.results["YTD"]
+    window = period.window_results[0]
+    summary = window.metric_summaries["ROLLING_SHARPE"]
+
+    assert period.quality_flags == []
+    assert summary.latest == pytest.approx(10.053854982045443)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-03"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 1
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-03"
+    assert latest_point.metric_values["ROLLING_SHARPE"] == pytest.approx(summary.latest)
+
+
 def test_rolling_engine_returns_period_error_when_insufficient_period_data() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-08", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,12 +23,14 @@
 ## Implementation-backed methodology coverage
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
-volatility, rolling tracking error, and rolling information ratio. The methodologies are tied to
-the implemented `/analytics/risk/rolling-metrics` engine and state the exact percentage-point to
-decimal conversion, `ddof=1` sample standard deviation, annualization basis, strict versus partial
-minimum-observation behavior, warm-up null handling, benchmark date-alignment rule where required,
-no-aligned-benchmark behavior, zero-tracking-error information-ratio flagging, annualized decimal
-volatility output, decimal-ratio tracking-error output, and dimensionless information-ratio output.
+volatility, rolling Sharpe, rolling tracking error, and rolling information ratio. The
+methodologies are tied to the implemented `/analytics/risk/rolling-metrics` engine and state the
+exact percentage-point to decimal conversion, `ddof=1` sample standard deviation, annualization
+basis, strict versus partial minimum-observation behavior, warm-up null handling, risk-free and
+benchmark date-alignment rules where required, no-aligned-dependency behavior, zero-excess-volatility
+Sharpe flagging, zero-tracking-error information-ratio flagging, annualized decimal
+volatility output, decimal-ratio tracking-error output, and dimensionless Sharpe and
+information-ratio output.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -56,13 +58,15 @@ flowchart LR
 Audience notes:
 
 - Business users can read rolling volatility as annualized portfolio-return dispersion, rolling
+  Sharpe as annualized excess return per unit of portfolio excess-return volatility, rolling
   tracking error as annualized active-return volatility versus the selected benchmark, and rolling
   information ratio as annualized active return per unit of that active risk.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
-  issues from calculation failure; zero-tracking-error windows are flagged rather than promoted as
-  valid ratios.
+  issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
+  are explicit for Sharpe, and zero-tracking-error windows are flagged rather than promoted as valid
+  ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
-  supportability metadata rather than recomputing rolling volatility, tracking error, or
+  supportability metadata rather than recomputing rolling volatility, Sharpe, tracking error, or
   information ratio locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort


### PR DESCRIPTION
## Summary
- upgrade `ROLLING_SHARPE` methodology to the v3 auditable format for `RollingRiskMetricsReport:v1`
- pin exact implemented behavior: pp-to-decimal conversion, risk-free inner alignment, `ddof=1`, annualized dimensionless ratio output, warm-up nulls, no-aligned-risk-free posture, and zero-excess-volatility flagging
- add documentation and engine regression coverage; refresh Risk repo context and wiki source to include rolling Sharpe in implementation-backed rolling methodology coverage

## Validation
- `python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py -q` (12 passed)
- `python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `make check` (Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, domain-data-product gate, unit tests: 320 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reported expected pre-publication drift in `Mesh-Data-Products.md`; publish after merge and rerun drift check to zero.

## Stranded-truth reconciliation
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` returned no unmerged remote branches for `lotus-risk`
- no open `lotus-risk` PRs before this branch

## Scope
- Risk source-owner methodology/docs/tests only
- No Gateway or Workbench files touched