### PR TITLE
Pin rolling beta methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,12 +50,13 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
-    `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_TRACKING_ERROR`, and
+    `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`, and
     `ROLLING_INFORMATION_RATIO`: the docs and tests pin percentage-point to decimal conversion,
-    `ddof=1` sample standard deviation, annualization, annualized decimal volatility output,
-    annualized decimal tracking-error output, dimensionless Sharpe and information-ratio output,
-    warm-up/null behavior, source-owned risk-free/benchmark alignment posture, no-aligned
-    dependency supportability posture, zero-excess-volatility Sharpe flagging, and
+    `ddof=1` sample standard deviation/covariance/variance behavior, annualization where used,
+    annualized decimal volatility output, annualized decimal tracking-error output, dimensionless
+    Sharpe, beta, and information-ratio output, warm-up/null behavior, source-owned
+    risk-free/benchmark alignment posture, no-aligned dependency supportability posture,
+    zero-excess-volatility Sharpe flagging, zero-benchmark-variance beta flagging, and
     zero-tracking-error information-ratio flagging.
 
 ## Architecture And Module Map

--- a/docs/methodologies/metrics/rolling-beta.md
+++ b/docs/methodologies/metrics/rolling-beta.md
@@ -8,44 +8,76 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- Benchmark return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns` and `benchmark_returns`.
+- Stateful mode: `lotus-performance` provides portfolio and benchmark return series through the governed rolling-metrics integration path.
+- `lotus-risk` owns the rolling beta calculation after dated return series are resolved. It does not source benchmark returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio and benchmark returns to decimal before rolling math:
+  `r_decimal = r_pp / 100`.
+- `ROLLING_BETA` output is a dimensionless ratio.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the same dimensionless ratio unit.
+- `rolling_options.annualization_basis` is accepted on the shared rolling contract but is not used by `ROLLING_BETA`.
 
 ## Variable Dictionary
-- `r_port_t`, `r_bench_t`: decimal return series.
-- `W`: rolling window length.
-- `cov_t(W)`: rolling covariance.
-- `var_b_t(W)`: rolling benchmark variance.
-- `RBETA_t(W) = cov_t/var_b_t`.
+- `t`: aligned observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rb_t_pp`: benchmark return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `Rb_t`: benchmark return on date `t`, as decimal (`Rb_t_pp / 100`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `cov_t(W)`: sample covariance of portfolio and benchmark returns inside the window ending on date `t`.
+- `var_b_t(W)`: sample variance of benchmark returns inside the window ending on date `t`, with `ddof=1`.
+- `RBETA_t(W)`: rolling beta for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. `cov_t=cov_W(Rp,Rb)`.
-2. `var_t=var_W(Rb)`.
-3. `ROLLING_BETA_t=cov_t/var_t`.
+1. Convert each portfolio and benchmark observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100` and `Rb_t = Rb_t_pp / 100`.
+2. Inner-align portfolio and benchmark series by date for the requested period.
+3. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+4. For each date with at least `min_obs` observations in the rolling window, compute:
+   - `cov_t(W) = cov(Rp_{t-W+1} ... Rp_t, Rb_{t-W+1} ... Rb_t)`;
+   - `var_b_t(W) = var(Rb_{t-W+1} ... Rb_t, ddof=1)`.
+5. Compute beta:
+   `RBETA_t(W) = cov_t(W) / var_b_t(W)`.
+6. Replace infinite results with null before summaries are built.
+7. Build summary statistics from computed, non-null `RBETA_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio and benchmark returns to the period.
+3. Convert both filtered series from percentage points to decimal.
+4. Inner-align the decimal series by date.
+5. If no aligned observations remain, emit no computed metric values and record the benchmark dependency as `NO_ALIGNED_OBSERVATIONS`.
+6. For each requested window length, compute rolling sample covariance and benchmark sample variance.
+7. Divide rolling covariance by rolling benchmark variance.
+8. Convert infinite values to null so zero benchmark-variance windows do not become misleading beta values.
+9. Leave warm-up points as null until the configured minimum observation count is met.
+10. Populate `metric_summaries.ROLLING_BETA` from non-null beta values.
+11. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_BETA` for every point in the rolling result, with warm-up and zero-variance points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Stateless requests that include `ROLLING_BETA` without `benchmark_returns` fail request validation.
+- Stateful requests require benchmark return sourcing from `lotus-performance`; unavailable upstream benchmark data is surfaced through dependency/supportability posture rather than local fallback data.
+- Fewer than two portfolio observations in the period returns period-level `error = "Insufficient data"` and no window results.
+- Benchmark series supplied but with no aligned dates returns `benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"` and emits no computed beta values for the metric.
+- Window warm-up points are null until `min_obs` is met.
+- Zero rolling benchmark variance produces null metric points and quality flag `metric:ROLLING_BETA:benchmark_variance_zero`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
-- `rolling_options.annualization_basis`
 - `rolling_options.min_observations_policy`
 - `rolling_options.include_time_series`
 
@@ -55,8 +87,26 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window benchmark `[0.01,-0.02,0.015]`, portfolio `[0.015,-0.03,0.0225]`.
-| Window | Covariance | Benchmark Variance | Value |
-|---|---:|---:|---:|
-| 1 | `0.000525` | `0.000350` | `1.5` |
-Output mapping: `metric_summaries.ROLLING_BETA.latest=1.5`.
+Assume `STRICT` minimum observations, `W = 3`, and aligned return observations:
+
+| Date | `Rp_t_pp` | `Rb_t_pp` | `Rp_t` | `Rb_t` |
+| --- | ---: | ---: | ---: | ---: |
+| Day 1 | `1.50` | `1.00` | `0.015` | `0.010` |
+| Day 2 | `-3.00` | `-2.00` | `-0.030` | `-0.020` |
+| Day 3 | `2.25` | `1.50` | `0.0225` | `0.015` |
+
+Intermediate calculations for the first full window:
+
+| Step | Value |
+| --- | ---: |
+| Portfolio mean | `0.0025000000` |
+| Benchmark mean | `0.0016666667` |
+| Sample covariance | `0.0005375000` |
+| Benchmark sample variance (`ddof=1`) | `0.0003583333` |
+| `RBETA_t(3)` | `1.5000000000` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_BETA.latest = 1.5000000000`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_BETA = 1.5000000000`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -10,6 +10,7 @@ ROLLING_INFORMATION_RATIO_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-information-ratio.md"
 )
 ROLLING_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-sharpe.md"
+ROLLING_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-beta.md"
 
 
 EXPECTED_V3_SECTIONS = [
@@ -128,6 +129,32 @@ def test_rolling_sharpe_methodology_is_auditable_against_engine_contract() -> No
         "metric_summaries.ROLLING_SHARPE.latest",
         "metric_series[].metric_values.ROLLING_SHARPE",
         "10.0538549820",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_rolling_beta_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_BETA_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ROLLING_BETA",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "dimensionless ratio",
+        "not used by `ROLLING_BETA`",
+        "ddof=1",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        'benchmark_context.reason = "NO_ALIGNED_OBSERVATIONS"',
+        "metric:ROLLING_BETA:benchmark_variance_zero",
+        "metric_summaries.ROLLING_BETA.latest",
+        "metric_series[].metric_values.ROLLING_BETA",
+        "1.5000000000",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -195,6 +195,51 @@ def test_rolling_sharpe_matches_documented_decimal_methodology() -> None:
     assert latest_point.metric_values["ROLLING_SHARPE"] == pytest.approx(summary.latest)
 
 
+def test_rolling_beta_matches_documented_decimal_methodology() -> None:
+    payload = RollingStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-01", "value": 1.50},
+                {"date": "2026-01-02", "value": -3.00},
+                {"date": "2026-01-03", "value": 2.25},
+            ],
+            "benchmark_returns": [
+                {"date": "2026-01-01", "value": 1.00},
+                {"date": "2026-01-02", "value": -2.00},
+                {"date": "2026-01-03", "value": 1.50},
+            ],
+            "rolling_options": {
+                "window_lengths": [3],
+                "metrics": ["ROLLING_BETA"],
+                "annualization_basis": 252,
+                "min_observations_policy": "STRICT",
+                "include_time_series": True,
+            },
+        }
+    )
+
+    response = calculate_rolling_metrics(payload, input_mode=RollingInputMode.STATELESS)
+
+    period = response.results["YTD"]
+    window = period.window_results[0]
+    summary = window.metric_summaries["ROLLING_BETA"]
+
+    assert period.quality_flags == []
+    assert summary.latest == pytest.approx(1.5)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-03"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 1
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-03"
+    assert latest_point.metric_values["ROLLING_BETA"] == pytest.approx(summary.latest)
+
+
 def test_rolling_engine_returns_period_error_when_insufficient_period_data() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-08", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,14 +23,14 @@
 ## Implementation-backed methodology coverage
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
-volatility, rolling Sharpe, rolling tracking error, and rolling information ratio. The
+volatility, rolling Sharpe, rolling beta, rolling tracking error, and rolling information ratio. The
 methodologies are tied to the implemented `/analytics/risk/rolling-metrics` engine and state the
 exact percentage-point to decimal conversion, `ddof=1` sample standard deviation, annualization
 basis, strict versus partial minimum-observation behavior, warm-up null handling, risk-free and
 benchmark date-alignment rules where required, no-aligned-dependency behavior, zero-excess-volatility
-Sharpe flagging, zero-tracking-error information-ratio flagging, annualized decimal
-volatility output, decimal-ratio tracking-error output, and dimensionless Sharpe and
-information-ratio output.
+Sharpe flagging, zero-benchmark-variance beta flagging, zero-tracking-error information-ratio
+flagging, annualized decimal volatility output, decimal-ratio tracking-error output, and
+dimensionless Sharpe, beta, and information-ratio output.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -59,15 +59,16 @@ Audience notes:
 
 - Business users can read rolling volatility as annualized portfolio-return dispersion, rolling
   Sharpe as annualized excess return per unit of portfolio excess-return volatility, rolling
-  tracking error as annualized active-return volatility versus the selected benchmark, and rolling
-  information ratio as annualized active return per unit of that active risk.
+  beta as sensitivity to benchmark return variance, rolling tracking error as annualized
+  active-return volatility versus the selected benchmark, and rolling information ratio as
+  annualized active return per unit of that active risk.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
-  are explicit for Sharpe, and zero-tracking-error windows are flagged rather than promoted as valid
-  ratios.
+  are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
+  zero-tracking-error windows are flagged rather than promoted as valid ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
-  supportability metadata rather than recomputing rolling volatility, Sharpe, tracking error, or
-  information ratio locally.
+  supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
+  or information ratio locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `ROLLING_BETA` methodology to v3 auditable format for `RollingRiskMetricsReport:v1`
- pin exact implemented behavior: pp-to-decimal conversion, benchmark inner alignment, rolling covariance over benchmark variance, `ddof=1`, dimensionless beta output, warm-up nulls, no-aligned-benchmark posture, and zero-benchmark-variance flagging
- add documentation and engine regression coverage; refresh Risk repo context and wiki source to include rolling beta in implementation-backed rolling methodology coverage

## Validation
- `python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py -q` (14 passed)
- `python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `make check` (Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, domain-data-product gate, unit tests: 322 passed)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reported expected pre-publication drift in `Mesh-Data-Products.md`; publish after merge and rerun drift check to zero.

## Stranded-truth reconciliation
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` returned no unmerged remote branches for `lotus-risk`
- no open `lotus-risk` PRs before this branch

## Scope
- Risk source-owner methodology/docs/tests only
- No Gateway or Workbench files touched