### PR TITLE
Pin rolling max drawdown methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,14 +50,15 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
-    `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`, and
-    `ROLLING_INFORMATION_RATIO`: the docs and tests pin percentage-point to decimal conversion,
-    `ddof=1` sample standard deviation/covariance/variance behavior, annualization where used,
-    annualized decimal volatility output, annualized decimal tracking-error output, dimensionless
-    Sharpe, beta, and information-ratio output, warm-up/null behavior, source-owned
-    risk-free/benchmark alignment posture, no-aligned dependency supportability posture,
-    zero-excess-volatility Sharpe flagging, zero-benchmark-variance beta flagging, and
-    zero-tracking-error information-ratio flagging.
+    `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
+    `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin
+    percentage-point to decimal conversion, `ddof=1` sample standard deviation/covariance/variance
+    behavior, annualization where used, rolling maximum drawdown cumulative-wealth/running-peak
+    behavior, annualized decimal volatility output, annualized decimal tracking-error output,
+    dimensionless Sharpe, beta, and information-ratio output, decimal drawdown-ratio output,
+    warm-up/null behavior, source-owned risk-free/benchmark alignment posture, no-aligned
+    dependency supportability posture, zero-excess-volatility Sharpe flagging,
+    zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/rolling-max-drawdown.md
+++ b/docs/methodologies/metrics/rolling-max-drawdown.md
@@ -8,44 +8,78 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series.
-- Additional required series by metric (benchmark/risk-free where applicable).
-- Window lengths and annualization basis.
+- Portfolio return series as dated percentage-point observations.
+- One or more rolling window lengths.
+- Minimum-observation policy.
+- Optional time-series emission flag.
 
 ## Upstream Data Sources
-- Stateless caller input or stateful integrated return series.
+- Stateless mode: caller-provided `returns`.
+- Stateful mode: `lotus-performance` portfolio return series fetched through the governed
+  rolling-metrics integration path.
+- `lotus-risk` owns the rolling maximum drawdown calculation after dated portfolio return series
+  are resolved. It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- The engine converts portfolio returns to decimal before rolling drawdown math:
+  `r_decimal = r_pp / 100`.
+- `rolling_options.annualization_basis` is accepted on the shared rolling contract but is not used by `ROLLING_MAX_DRAWDOWN`.
+- `ROLLING_MAX_DRAWDOWN` output is a decimal drawdown ratio: `-0.1000` means `-10.00%`.
+- Response summary fields (`latest`, `average`, `minimum`, `maximum`, `p05`, `p50`, `p95`) use the
+  same decimal drawdown ratio unit.
 
 ## Variable Dictionary
-- `r_t`: decimal return sample in a rolling window.
-- `W`: rolling window length.
-- `W_k`: wealth path within one window.
-- `DD_k`: drawdown path within one window.
-- `RMDD_t(W) = min(DD_k)`.
+- `t`: observation date.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rp_t`: portfolio return on date `t`, as decimal (`Rp_t_pp / 100`).
+- `W`: requested rolling window length.
+- `min_obs`: minimum observations required for a window result.
+- `k`: observation index inside the rolling window.
+- `C_k`: cumulative wealth path inside the window through index `k`.
+- `P_k`: running peak cumulative wealth through index `k`.
+- `DD_k`: drawdown at index `k`.
+- `RMDD_t(W)`: rolling maximum drawdown for the window ending on date `t`.
 
 ## Methodology and Formulas
-1. Within each window, build wealth `W_k=Π(1+r_k)`.
-2. Drawdown `DD_k=W_k/cummax(W_k)-1`.
-3. `RMDD_t=min(DD_k)`.
+1. Convert each portfolio observation from pp to decimal:
+   `Rp_t = Rp_t_pp / 100`.
+2. Resolve minimum observations:
+   - `min_obs = W` when `min_observations_policy = STRICT`;
+   - `min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`.
+3. For each date with at least `min_obs` observations in the rolling window, build the cumulative
+   wealth path from the window's decimal returns:
+   `C_k = product(1 + Rp_i)` for all observations from the start of the window through `k`.
+4. Compute the running peak:
+   `P_k = max(C_1 ... C_k)`.
+5. Compute the drawdown path:
+   `DD_k = C_k / P_k - 1`.
+6. Select the minimum drawdown in the window:
+   `RMDD_t(W) = min(DD_k)`.
+7. Build summary statistics from computed, non-null `RMDD_t(W)` values only.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns.
-2. Align required series by date for the metric.
-3. Compute rolling metric pointwise for each requested window.
-4. Build summaries and optional metric series.
+1. Resolve each requested period from `scope.as_of_date` and the period definition.
+2. Filter portfolio returns to the period.
+3. Convert the filtered series from percentage points to decimal.
+4. For each requested window length, apply the rolling maximum drawdown function to each eligible
+   rolling window.
+5. Leave warm-up points as null until the configured minimum observation count is met.
+6. Populate `metric_summaries.ROLLING_MAX_DRAWDOWN` from non-null decimal drawdown values.
+7. When `include_time_series=true`, emit `metric_series[].metric_values.ROLLING_MAX_DRAWDOWN` for
+   every point in the rolling result, with warm-up points represented as null.
 
 ## Validation and Failure Behavior
-- Insufficient window observations produce null points until min periods are met.
-- Alignment-empty joins produce empty or null series with quality flags.
-- Zero denominators produce null points and metric-specific flags.
+- Fewer than two portfolio observations in the period returns period-level
+  `error = "Insufficient data"` and no window results.
+- Window warm-up points are null until `min_obs` is met.
+- All-positive or non-declining wealth windows are valid and produce `0.0`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No benchmark or risk-free dependency is required for `ROLLING_MAX_DRAWDOWN`.
+- No denominator is used, so there is no zero-denominator quality flag for this metric.
 
 ## Configuration Options
 - `rolling_options.window_lengths`
-- `rolling_options.annualization_basis`
 - `rolling_options.min_observations_policy`
 - `rolling_options.include_time_series`
 
@@ -55,8 +89,24 @@
 - `results[period].quality_flags`
 
 ## Worked Example
-Window returns `[0.05,-0.10,0.02]`.
-| Window | Wealth Path | Drawdown Path | Value |
-|---|---|---|---:|
-| 1 | `[1.0500,0.9450,0.9639]` | `[0.0000,-0.1000,-0.0820]` | `-0.1000` |
-Output mapping: `metric_summaries.ROLLING_MAX_DRAWDOWN.latest=-0.1000`.
+Assume `STRICT` minimum observations, `W = 3`, and portfolio return observations:
+
+| Date | `Rp_t_pp` | `Rp_t = Rp_t_pp / 100` |
+| --- | ---: | ---: |
+| Day 1 | `5.00` | `0.050` |
+| Day 2 | `-10.00` | `-0.100` |
+| Day 3 | `2.00` | `0.020` |
+
+Intermediate calculations for the first full window:
+
+| Step | Day 1 | Day 2 | Day 3 |
+| --- | ---: | ---: | ---: |
+| Cumulative wealth `C_k` | `1.0500000000` | `0.9450000000` | `0.9639000000` |
+| Running peak `P_k` | `1.0500000000` | `1.0500000000` | `1.0500000000` |
+| Drawdown `DD_k` | `0.0000000000` | `-0.1000000000` | `-0.0820000000` |
+
+Output mapping:
+
+- `results[period].window_results[0].metric_summaries.ROLLING_MAX_DRAWDOWN.latest = -0.1000000000`
+- when `include_time_series=true`, the Day 3 point is emitted as
+  `metric_series[].metric_values.ROLLING_MAX_DRAWDOWN = -0.1000000000`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -11,6 +11,9 @@ ROLLING_INFORMATION_RATIO_DOC = (
 )
 ROLLING_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-sharpe.md"
 ROLLING_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-beta.md"
+ROLLING_MAX_DRAWDOWN_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-max-drawdown.md"
+)
 
 
 EXPECTED_V3_SECTIONS = [
@@ -155,6 +158,31 @@ def test_rolling_beta_methodology_is_auditable_against_engine_contract() -> None
         "metric_summaries.ROLLING_BETA.latest",
         "metric_series[].metric_values.ROLLING_BETA",
         "1.5000000000",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_rolling_max_drawdown_methodology_is_auditable_against_engine_contract() -> None:
+    text = ROLLING_MAX_DRAWDOWN_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ROLLING_MAX_DRAWDOWN",
+        "/analytics/risk/rolling-metrics",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "not used by `ROLLING_MAX_DRAWDOWN`",
+        "decimal drawdown ratio",
+        "`min_obs = W` when `min_observations_policy = STRICT`",
+        "`min_obs = 2` when `min_observations_policy = ALLOW_PARTIAL`",
+        "No benchmark or risk-free dependency is required for `ROLLING_MAX_DRAWDOWN`",
+        "No denominator is used",
+        "metric_summaries.ROLLING_MAX_DRAWDOWN.latest",
+        "metric_series[].metric_values.ROLLING_MAX_DRAWDOWN",
+        "-0.1000000000",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_rolling_engine.py
+++ b/tests/unit/test_rolling_engine.py
@@ -240,6 +240,46 @@ def test_rolling_beta_matches_documented_decimal_methodology() -> None:
     assert latest_point.metric_values["ROLLING_BETA"] == pytest.approx(summary.latest)
 
 
+def test_rolling_max_drawdown_matches_documented_decimal_methodology() -> None:
+    payload = RollingStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-01", "value": 5.00},
+                {"date": "2026-01-02", "value": -10.00},
+                {"date": "2026-01-03", "value": 2.00},
+            ],
+            "rolling_options": {
+                "window_lengths": [3],
+                "metrics": ["ROLLING_MAX_DRAWDOWN"],
+                "annualization_basis": 252,
+                "min_observations_policy": "STRICT",
+                "include_time_series": True,
+            },
+        }
+    )
+
+    response = calculate_rolling_metrics(payload, input_mode=RollingInputMode.STATELESS)
+
+    period = response.results["YTD"]
+    window = period.window_results[0]
+    summary = window.metric_summaries["ROLLING_MAX_DRAWDOWN"]
+
+    assert period.quality_flags == []
+    assert summary.latest == pytest.approx(-0.1)
+    assert summary.latest_observation_date is not None
+    assert summary.latest_observation_date.isoformat() == "2026-01-03"
+    assert summary.min_observations_required == 3
+    assert summary.warmup_point_count == 2
+    assert summary.computed_point_count == 1
+
+    assert window.metric_series is not None
+    latest_point = window.metric_series[-1]
+    assert latest_point.date.isoformat() == "2026-01-03"
+    assert latest_point.metric_values["ROLLING_MAX_DRAWDOWN"] == pytest.approx(summary.latest)
+
+
 def test_rolling_engine_returns_period_error_when_insufficient_period_data() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-08", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,14 +23,16 @@
 ## Implementation-backed methodology coverage
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
-volatility, rolling Sharpe, rolling beta, rolling tracking error, and rolling information ratio. The
-methodologies are tied to the implemented `/analytics/risk/rolling-metrics` engine and state the
-exact percentage-point to decimal conversion, `ddof=1` sample standard deviation, annualization
-basis, strict versus partial minimum-observation behavior, warm-up null handling, risk-free and
-benchmark date-alignment rules where required, no-aligned-dependency behavior, zero-excess-volatility
-Sharpe flagging, zero-benchmark-variance beta flagging, zero-tracking-error information-ratio
-flagging, annualized decimal volatility output, decimal-ratio tracking-error output, and
-dimensionless Sharpe, beta, and information-ratio output.
+volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
+rolling maximum drawdown. The methodologies are tied to the implemented
+`/analytics/risk/rolling-metrics` engine and state the exact percentage-point to decimal conversion,
+`ddof=1` sample standard deviation/covariance/variance behavior where used, rolling maximum
+drawdown cumulative-wealth/running-peak behavior, annualization basis where used, strict versus
+partial minimum-observation behavior, warm-up null handling, risk-free and benchmark date-alignment
+rules where required, no-aligned-dependency behavior, zero-excess-volatility Sharpe flagging,
+zero-benchmark-variance beta flagging, zero-tracking-error information-ratio flagging, annualized
+decimal volatility output, decimal-ratio tracking-error output, dimensionless Sharpe, beta, and
+information-ratio output, and decimal drawdown-ratio output.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -60,15 +62,16 @@ Audience notes:
 - Business users can read rolling volatility as annualized portfolio-return dispersion, rolling
   Sharpe as annualized excess return per unit of portfolio excess-return volatility, rolling
   beta as sensitivity to benchmark return variance, rolling tracking error as annualized
-  active-return volatility versus the selected benchmark, and rolling information ratio as
-  annualized active return per unit of that active risk.
+  active-return volatility versus the selected benchmark, rolling information ratio as annualized
+  active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
+  peak-to-trough loss inside each rolling return window.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
   are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
   zero-tracking-error windows are flagged rather than promoted as valid ratios.
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
-  or information ratio locally.
+  information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `ROLLING_MAX_DRAWDOWN` methodology to the same auditable v3 standard as the other rolling metrics
- pin exact engine behavior: pp-to-decimal conversion, cumulative wealth/running peak drawdown path, strict/partial warm-up, no benchmark/risk-free dependency, no denominator flag, and decimal drawdown output
- add methodology and engine regressions, plus repo-context and wiki source updates for `RollingRiskMetricsReport:v1`

## Validation
- `python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py -q` (16 passed)
- `python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_rolling_engine.py`
- `make check` (324 unit tests plus Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, and domain-data-product gates)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reports expected authored wiki drift: `Mesh-Data-Products.md`, to clear after merge and wiki publication

## Scope
- No `lotus-gateway` or `lotus-workbench` changes; those repos remain reserved for the other active agent.