### PR TITLE
Pin risk volatility methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -49,7 +49,13 @@ Current repository posture:
     source-supplied exposure weights against governed risk-event definitions and returns affected
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
-11. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
+11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`: the
+    docs and tests pin percentage-point input conventions, optional log-return transformation,
+    frequency compounding before volatility, `ddof=1` sample standard deviation, decimal
+    `details.standard_deviation`, annualized percentage-point `metrics.VOLATILITY.value`, default
+    and override annualization-factor resolution, no benchmark/risk-free dependency posture,
+    no-denominator posture, and insufficient-data failure behavior.
+12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin
     percentage-point to decimal conversion, `ddof=1` sample standard deviation/covariance/variance

--- a/docs/methodologies/metrics/risk-volatility.md
+++ b/docs/methodologies/metrics/risk-volatility.md
@@ -8,56 +8,79 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return observations for the resolved period (minimum 2).
-- Annualization basis from frequency or explicit override.
+- Portfolio return observations for the resolved period, with at least two observations after
+  period filtering and frequency resampling.
+- Calculation frequency: `DAILY`, `WEEKLY`, or `MONTHLY`.
+- Optional annualization-factor override.
 - Optional log-return transform flag.
 
 ## Upstream Data Sources
-- Stateless: caller `returns[]`.
-- Stateful: lotus-performance return series.
+- Stateless mode: caller-provided `returns`.
+- Stateful mode: `lotus-performance` portfolio return series fetched through the governed
+  risk-calculate integration path.
+- `lotus-risk` owns the volatility calculation after dated portfolio return series are resolved.
+  It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Frequency resampling compounds percentage-point returns and emits percentage-point period
+  returns.
+- If `options.use_log_returns=true`, the engine transforms percentage-point returns with
+  `r_log_pp = ln(1 + r_pp / 100) * 100`.
+- The sample standard deviation detail is stored as a decimal ratio:
+  `details.standard_deviation = std(r_used_pp, ddof=1) / 100`.
+- `metrics.VOLATILITY.value` is an annualized percentage-point output:
+  `11.9147` means `11.9147%`.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: portfolio return at `t` in percentage points.
-- `r_t_pp*`: transformed return used for volatility calculation (`raw` or `log`).
-- `n`: number of observations used in the metric.
-- `mu_pp`: arithmetic mean of transformed pp returns.
-- `sigma_pp`: sample standard deviation of transformed pp returns (`ddof=1`).
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_used_pp`: return used for volatility after optional log transformation, in percentage
+  points.
+- `n`: number of observations after period filtering, resampling, and optional log transformation.
 - `AF`: annualization factor.
-- `VOL`: annualized volatility output.
+- `sigma_pp`: sample standard deviation of `r_t_used_pp` with `ddof=1`, in percentage points.
+- `sigma_decimal`: `sigma_pp / 100`.
+- `VOL_pp`: annualized volatility output in percentage points.
 
 ## Methodology and Formulas
-1. Optional log transform:
-- if `use_log_returns=false`: `r_t_pp* = r_t_pp`
-- if `use_log_returns=true`: `r_t_pp* = ln(1 + r_t_pp/100) * 100`
-2. Sample standard deviation:
-`sigma_pp = std(r_t_pp*, ddof=1)`.
-3. Annualization:
-`VOL = sigma_pp * sqrt(AF)`.
-4. Annualization factor resolution:
-- `AF = options.annualization_factor` when provided;
-- otherwise from frequency map (`DAILY=252`, `WEEKLY=52`, `MONTHLY=12`).
+1. Resolve the requested period from `scope.as_of_date`, `portfolio_open_date`, and the period
+   definition.
+2. Filter portfolio returns to the resolved period.
+3. Resample returns when `options.frequency` is not `DAILY`:
+   `r_period_pp = (product(1 + r_i_pp / 100) - 1) * 100`.
+4. Apply the optional log-return transform:
+   - when `options.use_log_returns=false`, `r_t_used_pp = r_t_pp`;
+   - when `options.use_log_returns=true`, `r_t_used_pp = ln(1 + r_t_pp / 100) * 100`.
+5. Resolve annualization factor:
+   - `AF = options.annualization_factor` when supplied;
+   - otherwise `AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`.
+6. Require at least two non-null observations.
+7. Compute sample standard deviation:
+   `sigma_pp = std(r_t_used_pp, ddof=1)`.
+8. Convert the detail value to decimal:
+   `sigma_decimal = sigma_pp / 100`.
+9. Annualize and map the response value:
+   `VOL_pp = sigma_decimal * sqrt(AF) * 100`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter returns to date window.
-2. Apply frequency resampling when requested (weekly/monthly compounding).
-3. Resolve annualization factor (`AF`) from override or frequency default.
-4. Apply optional log-return transform to produce `r_t_pp*`.
-5. Validate at least two observations after filtering/transforms.
-6. Compute `sigma_pp` using sample standard deviation (`ddof=1`).
-7. Compute annualized volatility `VOL = sigma_pp * sqrt(AF)`.
-8. Return value in `metrics.VOLATILITY.value`.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Apply weekly or monthly compounding when requested.
+5. Apply log-return transformation when requested.
+6. Validate that at least two observations remain.
+7. Compute `details.standard_deviation` as decimal sample standard deviation.
+8. Compute `metrics.VOLATILITY.value` as annualized percentage points.
+9. Preserve `details.observation_count` and `details.annualization_factor` for auditability.
 
 ## Validation and Failure Behavior
-- Fewer than 2 observations after period filtering/resampling: `details.error = "Insufficient data"`.
-- Invalid return values (non-numeric): rejected by request-contract validation before engine math.
-- If all transformed returns are identical, `sigma_pp = 0` and output volatility is `0`.
-- Frequency resampling happens before standard deviation, so the observation count can change materially.
+- Fewer than two observations after period filtering, resampling, and optional transformation
+  returns `metrics.VOLATILITY.value = null` with `details.error = "Insufficient data"`.
+- Constant transformed returns are valid and produce `0.0`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No benchmark or risk-free dependency is required for `VOLATILITY`.
+- No denominator is used, so there is no zero-denominator quality flag for this metric.
 
 ## Configuration Options
 - `options.frequency`
@@ -66,23 +89,36 @@
 
 ## Outputs
 - `results[period].metrics.VOLATILITY.value`
+- `results[period].metrics.VOLATILITY.details.standard_deviation`
+- `results[period].metrics.VOLATILITY.details.observation_count`
+- `results[period].metrics.VOLATILITY.details.annualization_factor`
 - `results[period].metrics.VOLATILITY.details.error`
 
 ## Worked Example
-Assume no log transform (`use_log_returns=false`) and daily annualization (`AF=252`).
+Assume no log transform (`options.use_log_returns=false`), daily frequency, default daily
+annualization (`AF = 252`), and portfolio return observations:
 
-| Date | `r_t_pp` | `r_t_pp*` used in std | `r_t_pp* - mu_pp` | `(r_t_pp* - mu_pp)^2` |
-|---|---:|---:|---:|---:|
-| Day1 | 1.00 | 1.00 | 0.7667 | 0.5878 |
-| Day2 | -0.50 | -0.50 | -0.7333 | 0.5378 |
-| Day3 | 0.20 | 0.20 | -0.0333 | 0.0011 |
+| Date | `r_t_pp` | `r_t_used_pp` |
+| --- | ---: | ---: |
+| Day 1 | `1.00` | `1.00` |
+| Day 2 | `-0.50` | `-0.50` |
+| Day 3 | `0.20` | `0.20` |
 
 Intermediate calculations:
-- `mu_pp = (1.00 + (-0.50) + 0.20) / 3 = 0.2333`
-- Sum of squared deviations `= 0.5878 + 0.5378 + 0.0011 = 1.1267`
-- Sample variance `= 1.1267 / (3-1) = 0.5633`
-- `sigma_pp = sqrt(0.5633) = 0.7505`
-- `VOL = 0.7505 * sqrt(252) = 11.914`
+
+| Step | Value |
+| --- | ---: |
+| Mean return, pp | `0.2333333333` |
+| Squared deviations sum | `1.1266666667` |
+| Sample variance, pp (`ddof=1`) | `0.5633333333` |
+| `sigma_pp` | `0.7505553499` |
+| `details.standard_deviation = sigma_pp / 100` | `0.0075055535` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `VOL_pp` | `11.9146968069` |
 
 Output mapping:
-- `results[period].metrics.VOLATILITY.value = 11.914`
+
+- `results[period].metrics.VOLATILITY.value = 11.9146968069`
+- `results[period].metrics.VOLATILITY.details.standard_deviation = 0.0075055535`
+- `results[period].metrics.VOLATILITY.details.observation_count = 3`
+- `results[period].metrics.VOLATILITY.details.annualization_factor = 252`

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -276,6 +276,35 @@ def test_e2e_risk_calculate_happy_path() -> None:
     assert metrics["VAR"]["value"] is not None
 
 
+def test_e2e_risk_calculate_volatility_public_contract() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/analytics/risk/calculate",
+        json={
+            "input_mode": "stateless",
+            "stateless_input": {
+                "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+                "portfolio_open_date": "2026-01-01",
+                "periods": [{"type": "YTD", "name": "YTD"}],
+                "metrics": ["VOLATILITY"],
+                "options": {"frequency": "DAILY", "use_log_returns": False},
+                "returns": [
+                    {"date": "2026-01-01", "value": 1.00},
+                    {"date": "2026-01-02", "value": -0.50},
+                    {"date": "2026-01-03", "value": 0.20},
+                ],
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    metric = response.json()["results"]["YTD"]["metrics"]["VOLATILITY"]
+    assert metric["value"] == pytest.approx(11.914696806885186)
+    assert metric["details"]["standard_deviation"] == pytest.approx(0.007505553499465135)
+    assert metric["details"]["observation_count"] == 3
+    assert metric["details"]["annualization_factor"] == 252
+
+
 def test_e2e_risk_calculate_accepts_canonical_rolling_periods() -> None:
     client = TestClient(app)
     payload = _risk_payload()

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -14,6 +14,7 @@ ROLLING_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-b
 ROLLING_MAX_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-max-drawdown.md"
 )
+RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 
 
 EXPECTED_V3_SECTIONS = [
@@ -183,6 +184,32 @@ def test_rolling_max_drawdown_methodology_is_auditable_against_engine_contract()
         "metric_summaries.ROLLING_MAX_DRAWDOWN.latest",
         "metric_series[].metric_values.ROLLING_MAX_DRAWDOWN",
         "-0.1000000000",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_volatility_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_VOLATILITY_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: VOLATILITY",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "details.standard_deviation = std(r_used_pp, ddof=1) / 100",
+        "annualized percentage-point output",
+        "Frequency resampling compounds percentage-point returns",
+        "`AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`",
+        'details.error = "Insufficient data"',
+        "No benchmark or risk-free dependency is required for `VOLATILITY`",
+        "No denominator is used",
+        "results[period].metrics.VOLATILITY.value",
+        "11.9146968069",
+        "0.0075055535",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -1,8 +1,9 @@
+from typing import Any
+
+import pytest
+
 from app.contracts.risk import RiskCalculationRequest, RiskRequestPeriod
 from app.services.risk_engine import calculate_risk
-
-
-from typing import Any
 
 
 def _base_payload() -> dict[str, Any]:
@@ -73,6 +74,33 @@ def test_calculate_risk_var_methods() -> None:
         results.append(var_value)
 
     assert len(set(results)) >= 2
+
+
+def test_volatility_matches_documented_percentage_point_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["VOLATILITY"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 1.00},
+            {"date": "2026-01-02", "value": -0.50},
+            {"date": "2026-01-03", "value": 0.20},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["VOLATILITY"]
+    assert metric.value == pytest.approx(11.914696806885186)
+    assert metric.details is not None
+    assert metric.details["standard_deviation"] == pytest.approx(0.007505553499465135)
+    assert metric.details["observation_count"] == 3
+    assert metric.details["annualization_factor"] == 252
 
 
 def test_drawdown_metadata_fields_present() -> None:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -22,6 +22,13 @@
 
 ## Implementation-backed methodology coverage
 
+`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility. The
+methodology is tied to the implemented `/analytics/risk/calculate` engine and states the exact
+percentage-point input convention, optional log-return transform, frequency compounding before
+volatility, `ddof=1` sample standard deviation, decimal `details.standard_deviation`, annualized
+percentage-point `metrics.VOLATILITY.value`, annualization-factor resolution, no benchmark or
+risk-free dependency, no-denominator posture, and insufficient-data failure behavior.
+
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
 volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
 rolling maximum drawdown. The methodologies are tied to the implemented
@@ -65,6 +72,8 @@ Audience notes:
   active-return volatility versus the selected benchmark, rolling information ratio as annualized
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
+- Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
+  dispersion in percentage points for the resolved period.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
   are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
@@ -72,6 +81,8 @@ Audience notes:
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
+- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility values and
+  supportability metadata rather than recomputing period volatility locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `VOLATILITY` methodology for `RiskMetricsReport:v1` to auditable v3 standard
- pin exact engine behavior: pp inputs, optional log-return transform, frequency compounding, `ddof=1`, decimal `details.standard_deviation`, annualized percentage-point `metrics.VOLATILITY.value`, and insufficient-data behavior
- add methodology and engine regressions plus repo-context and wiki source updates

## Validation
- `python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q` (16 passed)
- `python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py`
- `python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py`
- `make check` (326 unit tests plus Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, and domain-data-product gates)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reports expected authored wiki drift: `Mesh-Data-Products.md`, to clear after merge and wiki publication

## Scope
- No `lotus-gateway` or `lotus-workbench` changes; those repos remain reserved for the other active agent.