### PR TITLE
Pin RiskMetricsReport Sharpe methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -49,12 +49,15 @@ Current repository posture:
     source-supplied exposure weights against governed risk-event definitions and returns affected
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
-11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`: the
-    docs and tests pin percentage-point input conventions, optional log-return transformation,
-    frequency compounding before volatility, `ddof=1` sample standard deviation, decimal
-    `details.standard_deviation`, annualized percentage-point `metrics.VOLATILITY.value`, default
-    and override annualization-factor resolution, no benchmark/risk-free dependency posture,
-    no-denominator posture, and insufficient-data failure behavior.
+11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY` and
+    `SHARPE`: the docs and tests pin percentage-point input conventions, optional log-return
+    transformation, frequency compounding before volatility or Sharpe, `ddof=1` sample standard
+    deviation, decimal volatility details, periodic risk-free rate resolution, annualized
+    percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
+    `metrics.SHARPE.value`, default and override annualization-factor resolution, no benchmark
+    dependency posture for Sharpe, no risk-free dependency posture for volatility,
+    no-denominator posture for volatility, zero-volatility fail-closed posture for Sharpe, and
+    insufficient-data failure behavior.
 12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin

--- a/docs/methodologies/metrics/risk-sharpe.md
+++ b/docs/methodologies/metrics/risk-sharpe.md
@@ -8,95 +8,152 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio return series in pp.
-- Risk-free settings and annualization basis.
+- Portfolio return observations for the resolved period, with at least two observations after
+  period filtering and frequency resampling.
+- Calculation frequency: `DAILY`, `WEEKLY`, or `MONTHLY`.
+- Optional annualization-factor override.
+- Optional log-return transform flag.
+- Risk-free mode and optional annual risk-free rate.
 
 ## Upstream Data Sources
-- Stateless caller returns.
-- Stateful lotus-performance returns.
+- Stateless mode: caller-provided `returns`.
+- Stateful mode: `lotus-performance` portfolio return series fetched through the governed
+  risk-calculate integration path.
+- Stateful Sharpe can derive risk-free evidence through the governed risk-free source path when
+  the stateful adapter receives risk-free points; the engine itself consumes only the resolved
+  `options.risk_free_mode` and `options.risk_free_annual_rate`.
+- `lotus-risk` owns the Sharpe calculation after dated portfolio returns and risk-free settings
+  are resolved. It does not source portfolio returns or risk-free assumptions from Workbench,
+  Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Frequency resampling compounds percentage-point returns and emits percentage-point period
+  returns.
+- If `options.use_log_returns=true`, the engine transforms percentage-point returns with
+  `r_log_pp = ln(1 + r_pp / 100) * 100`.
+- Mean return and volatility details are stored as decimal ratios:
+  `details.mean_return = mean(r_used_pp) / 100` and
+  `details.volatility = std(r_used_pp, ddof=1) / 100`.
+- When `options.risk_free_mode=ANNUAL_RATE`, the periodic risk-free rate is a decimal ratio:
+  `details.periodic_risk_free_rate = (1 + rf_annual)^(1 / AF) - 1`.
+- `metrics.SHARPE.value` is a dimensionless annualized ratio.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: return at `t` in percentage points (possibly log-transformed if configured).
-- `mu_pp`: arithmetic mean of `r_t_pp`.
-- `sigma_pp`: sample standard deviation of `r_t_pp` (`ddof=1`).
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_used_pp`: return used for Sharpe after optional log transformation, in percentage points.
+- `n`: number of observations after period filtering, resampling, and optional log transformation.
 - `AF`: annualization factor.
-- `rf_annual`: annual risk-free rate when `risk_free_mode=ANNUAL_RATE`.
-- `rf_p`: periodic risk-free rate corresponding to `AF`.
-- `mu_excess`: excess mean return in decimal.
-- `sigma`: volatility in decimal.
+- `rf_annual`: annual risk-free rate as a decimal ratio when
+  `options.risk_free_mode=ANNUAL_RATE`.
+- `rf_p`: periodic risk-free rate as a decimal ratio.
+- `mu_decimal`: arithmetic mean of `r_t_used_pp`, divided by `100`.
+- `sigma_decimal`: sample standard deviation of `r_t_used_pp` with `ddof=1`, divided by `100`.
+- `excess_decimal`: `mu_decimal - rf_p`.
 - `SHARPE`: annualized Sharpe ratio.
 
 ## Methodology and Formulas
-1. Optional return transform:
-- if `use_log_returns=false`: use raw pp returns.
-- if `use_log_returns=true`: `r_t_pp = ln(1 + r_raw_t_pp/100) * 100`.
-2. Resolve annualization factor:
-- `AF = options.annualization_factor` when provided;
-- else from frequency map (`DAILY=252`, `WEEKLY=52`, `MONTHLY=12`).
-3. Resolve periodic risk-free rate:
-- if `risk_free_mode=ZERO`: `rf_p = 0`
-- if `risk_free_mode=ANNUAL_RATE`: `rf_p = (1 + rf_annual)^(1/AF) - 1`
-4. Compute excess mean and volatility (decimal):
-- `mu_excess = (mu_pp / 100) - rf_p`
-- `sigma = sigma_pp / 100`
-5. Compute Sharpe:
-- `SHARPE = (mu_excess / sigma) * sqrt(AF)`.
+1. Resolve the requested period from `scope.as_of_date`, `portfolio_open_date`, and the period
+   definition.
+2. Filter portfolio returns to the resolved period.
+3. Resample returns when `options.frequency` is not `DAILY`:
+   `r_period_pp = (product(1 + r_i_pp / 100) - 1) * 100`.
+4. Apply the optional log-return transform:
+   - when `options.use_log_returns=false`, `r_t_used_pp = r_t_pp`;
+   - when `options.use_log_returns=true`, `r_t_used_pp = ln(1 + r_t_pp / 100) * 100`.
+5. Resolve annualization factor:
+   - `AF = options.annualization_factor` when supplied;
+   - otherwise `AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`.
+6. Resolve periodic risk-free rate:
+   - when `options.risk_free_mode=ZERO`, `rf_p = 0`;
+   - when `options.risk_free_mode=ANNUAL_RATE`,
+     `rf_p = (1 + rf_annual)^(1 / AF) - 1`.
+7. Require at least two non-null observations.
+8. Compute mean and sample standard deviation:
+   - `mu_decimal = mean(r_t_used_pp) / 100`;
+   - `sigma_decimal = std(r_t_used_pp, ddof=1) / 100`.
+9. Require `sigma_decimal` to be non-zero.
+10. Compute annualized Sharpe:
+    `SHARPE = ((mu_decimal - rf_p) / sigma_decimal) * sqrt(AF)`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter return observations to the selected window.
-2. Apply frequency resampling (if weekly/monthly) and optional log-return transform.
-3. Resolve annualization factor (`AF`) and periodic risk-free rate (`rf_p`).
-4. Validate at least two observations remain.
-5. Compute `mu_pp` and `sigma_pp` on transformed series.
-6. Convert mean/std to decimal (`mu_pp/100`, `sigma_pp/100`).
-7. Compute `mu_excess` and Sharpe ratio.
-8. If `sigma` is zero, emit deterministic metric error `Zero volatility`.
-9. Return value in `results[period].metrics.SHARPE.value`.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Apply weekly or monthly compounding when requested.
+5. Apply log-return transformation when requested.
+6. Resolve `AF` and `rf_p`.
+7. Validate that at least two observations remain.
+8. Compute `details.mean_return`, `details.volatility`, `details.periodic_risk_free_rate`, and
+   `details.excess_return` as decimal ratios.
+9. Compute `metrics.SHARPE.value` as a dimensionless annualized ratio.
+10. Preserve `details.observation_count`, `details.annualization_factor`, and
+    `details.annualized_excess_return` for auditability.
 
 ## Validation and Failure Behavior
-- Fewer than 2 observations after filtering/resampling: `details.error = "Insufficient data"`.
-- `risk_free_mode=ANNUAL_RATE` without valid annual rate: blocked at request validation.
-- `sigma == 0`: `details.error = "Zero volatility"`.
-- Non-numeric returns: rejected by request-contract validation before engine math.
+- Fewer than two observations after period filtering, resampling, and optional transformation
+  returns `metrics.SHARPE.value = null` with `details.error = "Insufficient data"`.
+- `options.risk_free_mode=ANNUAL_RATE` requires `options.risk_free_annual_rate` at request
+  validation.
+- Zero sample volatility returns `metrics.SHARPE.value = null` with
+  `details.error = "Zero volatility"`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No benchmark dependency is required for `SHARPE`.
+- The denominator is `sigma_decimal`; zero denominator is fail-closed and is not promoted as a
+  valid ratio.
 
 ## Configuration Options
-- `options.risk_free_mode`
-- `options.risk_free_annual_rate`
+- `options.frequency`
 - `options.annualization_factor`
 - `options.use_log_returns`
+- `options.risk_free_mode`
+- `options.risk_free_annual_rate`
 
 ## Outputs
 - `results[period].metrics.SHARPE.value`
-- `...details.error`
+- `results[period].metrics.SHARPE.details.mean_return`
+- `results[period].metrics.SHARPE.details.periodic_risk_free_rate`
+- `results[period].metrics.SHARPE.details.excess_return`
+- `results[period].metrics.SHARPE.details.annualized_excess_return`
+- `results[period].metrics.SHARPE.details.volatility`
+- `results[period].metrics.SHARPE.details.observation_count`
+- `results[period].metrics.SHARPE.details.annualization_factor`
+- `results[period].metrics.SHARPE.details.error`
 
 ## Worked Example
-Assume:
-- returns (pp): `[1.00, -0.50, 0.20]`
-- `risk_free_mode=ANNUAL_RATE`, `rf_annual=0.02`
-- `AF=252`
-- `use_log_returns=false`
+Assume no log transform (`options.use_log_returns=false`), daily frequency, default daily
+annualization (`AF = 252`), `options.risk_free_mode=ANNUAL_RATE`,
+`options.risk_free_annual_rate=0.02`, and portfolio return observations:
 
-| Date | `r_t_pp` | `r_t_pp - mu_pp` | `(r_t_pp - mu_pp)^2` |
-|---|---:|---:|---:|
-| Day1 | 1.00 | 0.7667 | 0.5878 |
-| Day2 | -0.50 | -0.7333 | 0.5378 |
-| Day3 | 0.20 | -0.0333 | 0.0011 |
+| Date | `r_t_pp` | `r_t_used_pp` |
+| --- | ---: | ---: |
+| Day 1 | `1.00` | `1.00` |
+| Day 2 | `-0.50` | `-0.50` |
+| Day 3 | `0.20` | `0.20` |
 
 Intermediate calculations:
-- `mu_pp = (1.00 - 0.50 + 0.20)/3 = 0.2333`
-- sample variance `= (0.5878 + 0.5378 + 0.0011)/(3-1) = 0.5633`
-- `sigma_pp = sqrt(0.5633) = 0.7505`
-- mean decimal `= 0.2333/100 = 0.002333`
-- volatility decimal `sigma = 0.7505/100 = 0.007505`
-- `rf_p = (1.02)^(1/252) - 1 = 0.0000786`
-- `mu_excess = 0.002333 - 0.0000786 = 0.0022544`
-- `SHARPE = (0.0022544 / 0.007505) * sqrt(252) = 4.769`
+
+| Step | Value |
+| --- | ---: |
+| Mean return, pp | `0.2333333333` |
+| `details.mean_return = mean / 100` | `0.0023333333` |
+| Squared deviations sum | `1.1266666667` |
+| Sample variance, pp (`ddof=1`) | `0.5633333333` |
+| `sigma_pp` | `0.7505553499` |
+| `details.volatility = sigma_pp / 100` | `0.0075055535` |
+| `details.periodic_risk_free_rate` | `0.0000785849` |
+| `details.excess_return` | `0.0022547484` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `SHARPE` | `4.7688716199` |
 
 Output mapping:
-- `results[period].metrics.SHARPE.value = 4.769`
+
+- `results[period].metrics.SHARPE.value = 4.7688716199`
+- `results[period].metrics.SHARPE.details.mean_return = 0.0023333333`
+- `results[period].metrics.SHARPE.details.periodic_risk_free_rate = 0.0000785849`
+- `results[period].metrics.SHARPE.details.excess_return = 0.0022547484`
+- `results[period].metrics.SHARPE.details.annualized_excess_return = 0.5681965946`
+- `results[period].metrics.SHARPE.details.volatility = 0.0075055535`
+- `results[period].metrics.SHARPE.details.observation_count = 3`
+- `results[period].metrics.SHARPE.details.annualization_factor = 252`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -15,6 +15,7 @@ ROLLING_MAX_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-max-drawdown.md"
 )
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
+RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
 
 
 EXPECTED_V3_SECTIONS = [
@@ -209,6 +210,34 @@ def test_risk_volatility_methodology_is_auditable_against_engine_contract() -> N
         "No denominator is used",
         "results[period].metrics.VOLATILITY.value",
         "11.9146968069",
+        "0.0075055535",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_sharpe_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_SHARPE_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: SHARPE",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "details.volatility = std(r_used_pp, ddof=1) / 100",
+        "details.periodic_risk_free_rate = (1 + rf_annual)^(1 / AF) - 1",
+        "`metrics.SHARPE.value` is a dimensionless annualized ratio",
+        "`AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`",
+        'details.error = "Insufficient data"',
+        'details.error = "Zero volatility"',
+        "No benchmark dependency is required for `SHARPE`",
+        "The denominator is `sigma_decimal`",
+        "results[period].metrics.SHARPE.value",
+        "4.7688716199",
+        "0.0000785849",
         "0.0075055535",
     ]
 

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -103,6 +103,39 @@ def test_volatility_matches_documented_percentage_point_output_contract() -> Non
     assert metric.details["annualization_factor"] == 252
 
 
+def test_sharpe_matches_documented_dimensionless_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["SHARPE"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+            "risk_free_mode": "ANNUAL_RATE",
+            "risk_free_annual_rate": 0.02,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 1.00},
+            {"date": "2026-01-02", "value": -0.50},
+            {"date": "2026-01-03", "value": 0.20},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["SHARPE"]
+    assert metric.value == pytest.approx(4.768871619893194)
+    assert metric.details is not None
+    assert metric.details["mean_return"] == pytest.approx(0.002333333333333333)
+    assert metric.details["periodic_risk_free_rate"] == pytest.approx(0.0000785849419846496)
+    assert metric.details["excess_return"] == pytest.approx(0.0022547483913486835)
+    assert metric.details["annualized_excess_return"] == pytest.approx(0.5681965946198683)
+    assert metric.details["volatility"] == pytest.approx(0.007505553499465135)
+    assert metric.details["observation_count"] == 3
+    assert metric.details["annualization_factor"] == 252
+
+
 def test_drawdown_metadata_fields_present() -> None:
     payload = _base_payload()
     payload["metrics"] = ["DRAWDOWN"]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -22,12 +22,14 @@
 
 ## Implementation-backed methodology coverage
 
-`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility. The
-methodology is tied to the implemented `/analytics/risk/calculate` engine and states the exact
-percentage-point input convention, optional log-return transform, frequency compounding before
-volatility, `ddof=1` sample standard deviation, decimal `details.standard_deviation`, annualized
-percentage-point `metrics.VOLATILITY.value`, annualization-factor resolution, no benchmark or
-risk-free dependency, no-denominator posture, and insufficient-data failure behavior.
+`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility and Sharpe.
+The methodologies are tied to the implemented `/analytics/risk/calculate` engine and state the
+exact percentage-point input convention, optional log-return transform, frequency compounding
+before volatility or Sharpe, `ddof=1` sample standard deviation, decimal volatility details,
+periodic risk-free rate resolution, annualized percentage-point `metrics.VOLATILITY.value`,
+dimensionless annualized `metrics.SHARPE.value`, annualization-factor resolution, no benchmark
+dependency for Sharpe, no risk-free dependency for volatility, no-denominator posture for
+volatility, zero-volatility fail-closed posture for Sharpe, and insufficient-data failure behavior.
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
 volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
@@ -73,7 +75,8 @@ Audience notes:
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
-  dispersion in percentage points for the resolved period.
+  dispersion in percentage points for the resolved period and Sharpe as annualized excess return
+  per unit of portfolio return volatility for the resolved period.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
   are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
@@ -81,8 +84,8 @@ Audience notes:
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
-- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility values and
-  supportability metadata rather than recomputing period volatility locally.
+- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility and Sharpe
+  values and supportability metadata rather than recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrades risk-sharpe methodology to v3 auditable calculation standard
- adds documentation and engine regressions for SHARPE output, risk-free rate conversion, and zero-denominator posture
- updates repo context and Mesh Data Products wiki source for RiskMetricsReport:v1 Sharpe source-owner truth

## Validation
- python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q
- python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- make test-pyramid-gate
- make check
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)

## Boundaries
- no Gateway or Workbench changes
- methodology only; no runtime behavior change