### PR TITLE
Pin RiskMetricsReport beta methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -49,15 +49,17 @@ Current repository posture:
     source-supplied exposure weights against governed risk-event definitions and returns affected
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
-11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY` and
-    `SHARPE`: the docs and tests pin percentage-point input conventions, optional log-return
-    transformation, frequency compounding before volatility or Sharpe, `ddof=1` sample standard
-    deviation, decimal volatility details, periodic risk-free rate resolution, annualized
+11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
+    `SHARPE`, and `BETA`: the docs and tests pin percentage-point input conventions, optional
+    log-return transformation, frequency compounding before metric calculation, `ddof=1` sample
+    standard deviation/covariance/variance behavior, decimal volatility and risk-free details,
+    percentage-point-squared beta covariance/benchmark-variance details, annualized
     percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-    `metrics.SHARPE.value`, default and override annualization-factor resolution, no benchmark
-    dependency posture for Sharpe, no risk-free dependency posture for volatility,
-    no-denominator posture for volatility, zero-volatility fail-closed posture for Sharpe, and
-    insufficient-data failure behavior.
+    `metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`, default and override
+    annualization-factor resolution where used, benchmark dependency posture for beta, no
+    benchmark dependency posture for Sharpe, no risk-free dependency posture for volatility and
+    beta, no-denominator posture for volatility, zero-volatility fail-closed posture for Sharpe,
+    zero-benchmark-variance fail-closed posture for beta, and insufficient-data failure behavior.
 12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin

--- a/docs/methodologies/metrics/risk-beta.md
+++ b/docs/methodologies/metrics/risk-beta.md
@@ -8,55 +8,96 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio and benchmark return series in pp.
+- Portfolio return observations for the resolved period, with at least two aligned observations
+  after period filtering and frequency resampling.
+- Benchmark return observations for the same resolved period, with at least two aligned
+  observations after filtering and resampling.
+- Calculation frequency: `DAILY`, `WEEKLY`, or `MONTHLY`.
+- Optional log-return transform flag.
 
 ## Upstream Data Sources
-- Stateless caller provides both.
-- Stateful lotus-performance provides both.
+- Stateless mode: caller-provided `returns` and `benchmark_returns`.
+- Stateful mode: `lotus-performance` portfolio and benchmark return series fetched through the
+  governed risk-calculate integration path.
+- `lotus-risk` owns the beta calculation after dated portfolio and benchmark return series are
+  resolved. It does not source portfolio returns, benchmark returns, or beta assumptions from
+  Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Frequency resampling compounds percentage-point returns and emits percentage-point period
+  returns.
+- If `options.use_log_returns=true`, both portfolio and benchmark returns are transformed with
+  `r_log_pp = ln(1 + r_pp / 100) * 100` before alignment.
+- Mean-return details are stored as decimal ratios:
+  `details.portfolio_mean_return = mean(Rp_used_pp) / 100` and
+  `details.benchmark_mean_return = mean(Rb_used_pp) / 100`.
+- Covariance and benchmark variance details are computed in percentage-point squared units:
+  `details.covariance = cov(Rp_used_pp, Rb_used_pp, ddof=1)` and
+  `details.benchmark_variance = var(Rb_used_pp, ddof=1)`.
+- `metrics.BETA.value` is a dimensionless slope coefficient.
 
 ## Variable Dictionary
-- `t`: aligned observation index over common portfolio/benchmark dates.
-- `Rp_t_pp`: portfolio return at `t` in percentage points (post-transform if log mode is used).
-- `Rb_t_pp`: benchmark return at `t` in percentage points (post-transform if log mode is used).
-- `Cov_pb`: sample covariance between portfolio and benchmark (`ddof=1`).
-- `Var_b`: sample benchmark variance (`ddof=1`).
-- `BETA`: beta slope coefficient (`Cov_pb / Var_b`).
+- `t`: aligned observation date after strict inner date alignment.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rb_t_pp`: benchmark return on date `t`, in percentage points.
+- `Rp_t_used_pp`: portfolio return used for beta after optional log transformation, in
+  percentage points.
+- `Rb_t_used_pp`: benchmark return used for beta after optional log transformation, in
+  percentage points.
+- `n_aligned`: number of aligned portfolio/benchmark observations.
+- `mu_p_decimal`: mean portfolio return as a decimal ratio.
+- `mu_b_decimal`: mean benchmark return as a decimal ratio.
+- `Cov_pb_pp2`: sample covariance between portfolio and benchmark used returns, with `ddof=1`.
+- `Var_b_pp2`: sample benchmark variance of used returns, with `ddof=1`.
+- `BETA`: dimensionless beta slope coefficient.
 
 ## Methodology and Formulas
-1. Optional return transform:
-- if `use_log_returns=false`: use raw pp returns
-- if `use_log_returns=true`: transform each series using `ln(1 + r_pp/100) * 100`
-2. Align portfolio and benchmark returns by date (inner join).
-3. Compute sample covariance matrix with `ddof=1`.
-4. Extract covariance and benchmark variance:
-- `Cov_pb = cov(Rp, Rb)`
-- `Var_b = var(Rb)`
-5. Compute beta:
-`BETA = Cov_pb / Var_b`
-6. If `Var_b` is numerically zero (`np.isclose`), emit error instead of value.
+1. Resolve the requested period from `scope.as_of_date`, `portfolio_open_date`, and the period
+   definition.
+2. Filter portfolio and benchmark returns to the resolved period.
+3. Resample both series when `options.frequency` is not `DAILY`:
+   `r_period_pp = (product(1 + r_i_pp / 100) - 1) * 100`.
+4. Apply the optional log-return transform to both series:
+   - when `options.use_log_returns=false`, `Rp_t_used_pp = Rp_t_pp` and
+     `Rb_t_used_pp = Rb_t_pp`;
+   - when `options.use_log_returns=true`,
+     `r_t_used_pp = ln(1 + r_t_pp / 100) * 100` for each series.
+5. Strictly inner-align portfolio and benchmark returns by date.
+6. Require at least two aligned observations.
+7. Compute the sample covariance matrix with `ddof=1`:
+   - `Cov_pb_pp2 = cov(Rp_used_pp, Rb_used_pp, ddof=1)`;
+   - `Var_b_pp2 = var(Rb_used_pp, ddof=1)`.
+8. Require `Var_b_pp2` to be non-zero under `np.isclose`.
+9. Compute beta:
+   `BETA = Cov_pb_pp2 / Var_b_pp2`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter portfolio and benchmark series to date window.
-2. Apply configured frequency resampling to both series.
-3. Apply optional log-return transform to both series.
-4. Inner-align on dates and build two-column matrix (`portfolio`, `benchmark`).
-5. Validate minimum data (`>=2` aligned observations); else emit `Insufficient data`.
-6. Compute covariance matrix via `np.cov(..., ddof=1)`.
-7. Read denominator as benchmark variance (`matrix[1,1]`).
-8. If denominator is near zero, emit `Benchmark variance is zero`.
-9. Else compute and return beta.
+1. Build dated portfolio and benchmark return series and sort both by date.
+2. Resolve each requested period.
+3. Filter both return series to the period date range.
+4. Apply weekly or monthly compounding to both series when requested.
+5. Apply log-return transformation to both series when requested.
+6. Inner-align both series by date.
+7. Validate that at least two aligned observations remain.
+8. Compute `details.portfolio_mean_return` and `details.benchmark_mean_return` as decimal ratios.
+9. Compute `details.covariance` and `details.benchmark_variance` from percentage-point used
+   returns with `ddof=1`.
+10. Compute `metrics.BETA.value` as the dimensionless slope coefficient.
+11. Preserve `details.aligned_observation_count` for auditability.
 
 ## Validation and Failure Behavior
-- Missing benchmark series for benchmark-dependent metrics: `details.error = "Benchmark returns required for benchmark-dependent metric"`.
-- Fewer than 2 aligned observations: `details.error = "Insufficient data"`.
-- Near-zero benchmark variance: `details.error = "Benchmark variance is zero"`.
-- Non-numeric return entries: rejected by request-contract validation before engine computation.
-- Alignment is strict inner join, so non-overlapping dates are dropped.
+- Missing benchmark returns for `BETA` return `metrics.BETA.value = null` with
+  `details.error = "Benchmark returns required for benchmark-dependent metric"`.
+- Fewer than two aligned observations after period filtering, resampling, and optional
+  transformation return `metrics.BETA.value = null` with
+  `details.error = "Insufficient aligned observations"`.
+- Zero or near-zero benchmark variance returns `metrics.BETA.value = null` with
+  `details.error = "Benchmark variance is zero"`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No risk-free dependency is required for `BETA`.
+- The denominator is `Var_b_pp2`; zero denominator is fail-closed and is not promoted as a valid
+  ratio.
 
 ## Configuration Options
 - `options.frequency`
@@ -64,25 +105,42 @@
 
 ## Outputs
 - `results[period].metrics.BETA.value`
-- `...details.error`
+- `results[period].metrics.BETA.details.aligned_observation_count`
+- `results[period].metrics.BETA.details.portfolio_mean_return`
+- `results[period].metrics.BETA.details.benchmark_mean_return`
+- `results[period].metrics.BETA.details.covariance`
+- `results[period].metrics.BETA.details.benchmark_variance`
+- `results[period].metrics.BETA.details.error`
 
 ## Worked Example
-Assume aligned returns (pp), no log transform:
-- Portfolio: `[1.0, -1.0, 2.0]`
-- Benchmark: `[0.5, -0.5, 1.0]`
+Assume no log transform (`options.use_log_returns=false`), daily frequency, and aligned return
+observations:
 
-| Date | `Rp_t_pp` | `Rb_t_pp` | `Rp_t_pp - mean(Rp)` | `Rb_t_pp - mean(Rb)` | Product |
-|---|---:|---:|---:|---:|---:|
-| Day1 | 1.0 | 0.5 | 0.3333 | 0.1667 | 0.0556 |
-| Day2 | -1.0 | -0.5 | -1.6667 | -0.8333 | 1.3889 |
-| Day3 | 2.0 | 1.0 | 1.3333 | 0.6667 | 0.8889 |
+| Date | `Rp_t_used_pp` | `Rb_t_used_pp` |
+| --- | ---: | ---: |
+| Day 1 | `1.00` | `0.50` |
+| Day 2 | `-1.00` | `-0.50` |
+| Day 3 | `2.00` | `1.00` |
 
 Intermediate calculations:
-- `mean(Rp) = (1.0 - 1.0 + 2.0)/3 = 0.6667`
-- `mean(Rb) = (0.5 - 0.5 + 1.0)/3 = 0.3333`
-- `Cov_pb = sum(product) / (n-1) = (0.0556 + 1.3889 + 0.8889)/2 = 1.1667`
-- `Var_b = sum((Rb_t_pp - mean(Rb))^2)/(n-1) = (0.0278 + 0.6944 + 0.4444)/2 = 0.5833`
-- `BETA = 1.1667 / 0.5833 = 2.0000`
+
+| Step | Value |
+| --- | ---: |
+| Mean portfolio return, pp | `0.6666666667` |
+| Mean benchmark return, pp | `0.3333333333` |
+| `details.portfolio_mean_return` | `0.0066666667` |
+| `details.benchmark_mean_return` | `0.0033333333` |
+| Product of deviations sum | `2.3333333333` |
+| `details.covariance = Cov_pb_pp2` | `1.1666666667` |
+| Benchmark squared deviations sum | `1.1666666667` |
+| `details.benchmark_variance = Var_b_pp2` | `0.5833333333` |
+| `BETA = Cov_pb_pp2 / Var_b_pp2` | `2.0000000000` |
 
 Output mapping:
-- `results[period].metrics.BETA.value = 2.0`
+
+- `results[period].metrics.BETA.value = 2.0000000000`
+- `results[period].metrics.BETA.details.aligned_observation_count = 3`
+- `results[period].metrics.BETA.details.portfolio_mean_return = 0.0066666667`
+- `results[period].metrics.BETA.details.benchmark_mean_return = 0.0033333333`
+- `results[period].metrics.BETA.details.covariance = 1.1666666667`
+- `results[period].metrics.BETA.details.benchmark_variance = 0.5833333333`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -16,6 +16,7 @@ ROLLING_MAX_DRAWDOWN_DOC = (
 )
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
+RISK_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-beta.md"
 
 
 EXPECTED_V3_SECTIONS = [
@@ -239,6 +240,34 @@ def test_risk_sharpe_methodology_is_auditable_against_engine_contract() -> None:
         "4.7688716199",
         "0.0000785849",
         "0.0075055535",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_beta_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_BETA_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: BETA",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "details.covariance = cov(Rp_used_pp, Rb_used_pp, ddof=1)",
+        "details.benchmark_variance = var(Rb_used_pp, ddof=1)",
+        "`metrics.BETA.value` is a dimensionless slope coefficient",
+        'details.error = "Benchmark returns required for benchmark-dependent metric"',
+        'details.error = "Insufficient aligned observations"',
+        'details.error = "Benchmark variance is zero"',
+        "No risk-free dependency is required for `BETA`",
+        "The denominator is `Var_b_pp2`",
+        "results[period].metrics.BETA.value",
+        "2.0000000000",
+        "1.1666666667",
+        "0.5833333333",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -136,6 +136,40 @@ def test_sharpe_matches_documented_dimensionless_output_contract() -> None:
     assert metric.details["annualization_factor"] == 252
 
 
+def test_beta_matches_documented_dimensionless_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["BETA"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 1.00},
+            {"date": "2026-01-02", "value": -1.00},
+            {"date": "2026-01-03", "value": 2.00},
+        ],
+        "benchmark_returns": [
+            {"date": "2026-01-01", "value": 0.50},
+            {"date": "2026-01-02", "value": -0.50},
+            {"date": "2026-01-03", "value": 1.00},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["BETA"]
+    assert metric.value == pytest.approx(2.0)
+    assert metric.details is not None
+    assert metric.details["aligned_observation_count"] == 3
+    assert metric.details["portfolio_mean_return"] == pytest.approx(0.006666666666666666)
+    assert metric.details["benchmark_mean_return"] == pytest.approx(0.003333333333333333)
+    assert metric.details["covariance"] == pytest.approx(1.1666666666666667)
+    assert metric.details["benchmark_variance"] == pytest.approx(0.5833333333333334)
+
+
 def test_drawdown_metadata_fields_present() -> None:
     payload = _base_payload()
     payload["metrics"] = ["DRAWDOWN"]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -22,14 +22,17 @@
 
 ## Implementation-backed methodology coverage
 
-`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility and Sharpe.
-The methodologies are tied to the implemented `/analytics/risk/calculate` engine and state the
-exact percentage-point input convention, optional log-return transform, frequency compounding
-before volatility or Sharpe, `ddof=1` sample standard deviation, decimal volatility details,
-periodic risk-free rate resolution, annualized percentage-point `metrics.VOLATILITY.value`,
-dimensionless annualized `metrics.SHARPE.value`, annualization-factor resolution, no benchmark
-dependency for Sharpe, no risk-free dependency for volatility, no-denominator posture for
-volatility, zero-volatility fail-closed posture for Sharpe, and insufficient-data failure behavior.
+`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, Sharpe,
+and beta. The methodologies are tied to the implemented `/analytics/risk/calculate` engine and
+state the exact percentage-point input convention, optional log-return transform, frequency
+compounding before metric calculation, `ddof=1` sample standard deviation/covariance/variance
+behavior, decimal volatility and risk-free details, percentage-point-squared beta
+covariance/benchmark-variance details, annualized percentage-point `metrics.VOLATILITY.value`,
+dimensionless annualized `metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`,
+annualization-factor resolution where used, benchmark dependency for beta, no benchmark dependency
+for Sharpe, no risk-free dependency for volatility and beta, no-denominator posture for volatility,
+zero-volatility fail-closed posture for Sharpe, zero-benchmark-variance fail-closed posture for
+beta, and insufficient-data failure behavior.
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
 volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
@@ -76,7 +79,8 @@ Audience notes:
   peak-to-trough loss inside each rolling return window.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period and Sharpe as annualized excess return
-  per unit of portfolio return volatility for the resolved period.
+  per unit of portfolio return volatility for the resolved period. Beta is the period sensitivity
+  slope of portfolio returns to benchmark return variance after strict date alignment.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
   are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
@@ -84,8 +88,8 @@ Audience notes:
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
-- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility and Sharpe
-  values and supportability metadata rather than recomputing period risk metrics locally.
+- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, Sharpe, and
+  beta values and supportability metadata rather than recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrades risk-beta methodology to v3 auditable calculation standard
- adds documentation and engine regressions for BETA output, aligned-observation details, covariance/variance units, and zero-denominator posture
- updates repo context and Mesh Data Products wiki source for RiskMetricsReport:v1 beta source-owner truth

## Validation
- python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q
- python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- make test-pyramid-gate
- make check
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)

## Boundaries
- no Gateway or Workbench changes
- methodology only; no runtime behavior change