### PR TITLE
Pin risk information ratio methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,20 +50,22 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
-    `SHARPE`, `BETA`, and `TRACKING_ERROR`: the docs and tests pin percentage-point input
-    conventions, optional
+    `SHARPE`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
+    percentage-point input conventions, optional
     log-return transformation, frequency compounding before metric calculation, `ddof=1` sample
     standard deviation/covariance/variance behavior, decimal volatility and risk-free details,
     percentage-point-squared beta covariance/benchmark-variance details, annualized
     percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
     `metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`, annualized
-    percentage-point `metrics.TRACKING_ERROR.value`, decimal tracking-error detail fields, default
-    and override annualization-factor resolution where used, benchmark dependency posture for beta
-    and tracking error, no benchmark dependency posture for Sharpe, no risk-free dependency posture
-    for volatility, beta, and tracking error, no-denominator posture for volatility and tracking
-    error, zero-volatility fail-closed posture for Sharpe, zero-benchmark-variance fail-closed
-    posture for beta, constant-active-return zero tracking-error posture, and insufficient-data /
-    insufficient-aligned-observation failure behavior.
+    percentage-point `metrics.TRACKING_ERROR.value`, dimensionless annualized
+    `metrics.INFORMATION_RATIO.value`, decimal tracking-error and information-ratio detail fields,
+    default and override annualization-factor resolution where used, benchmark dependency posture
+    for beta, tracking error, and information ratio, no benchmark dependency posture for Sharpe, no
+    risk-free dependency posture for volatility, beta, tracking error, and information ratio,
+    no-denominator posture for volatility and tracking error, zero-volatility fail-closed posture
+    for Sharpe, zero-benchmark-variance fail-closed posture for beta, zero-tracking-error
+    fail-closed posture for information ratio, constant-active-return zero tracking-error posture,
+    and insufficient-data / insufficient-aligned-observation failure behavior.
 12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin

--- a/docs/methodologies/metrics/risk-information-ratio.md
+++ b/docs/methodologies/metrics/risk-information-ratio.md
@@ -8,62 +8,120 @@
 - supported_modes: stateless, stateful
 
 ## Inputs
-- Portfolio and benchmark returns.
-- Annualization basis.
+- Portfolio return observations for the resolved period, with at least two aligned observations
+  after period filtering and frequency resampling.
+- Benchmark return observations for the same resolved period, with at least two aligned
+  observations after filtering and resampling.
+- Calculation frequency: `DAILY`, `WEEKLY`, or `MONTHLY`.
+- Optional annualization-factor override.
+- Optional log-return transform flag.
 
 ## Upstream Data Sources
-- Stateless caller.
-- Stateful lotus-performance.
+- Stateless mode: caller-provided `returns` and `benchmark_returns`.
+- Stateful mode: `lotus-performance` portfolio and benchmark return series fetched through the
+  governed risk-calculate integration path.
+- `lotus-risk` owns the information-ratio calculation after dated portfolio and benchmark return
+  series are resolved. It does not source portfolio returns, benchmark returns, active-return
+  assumptions, or information-ratio assumptions from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Frequency resampling compounds percentage-point returns and emits percentage-point period
+  returns.
+- If `options.use_log_returns=true`, both portfolio and benchmark returns are transformed with
+  `r_log_pp = ln(1 + r_pp / 100) * 100` before alignment.
+- Mean-return details are stored as decimal ratios:
+  `details.portfolio_mean_return = mean(Rp_used_pp) / 100`,
+  `details.benchmark_mean_return = mean(Rb_used_pp) / 100`, and
+  `details.active_mean_return = mean(A_used_pp) / 100`.
+- Tracking-error detail is stored as a decimal ratio:
+  `details.tracking_error = std(A_used_pp, ddof=1) / 100`.
+- Annualized active-return detail is stored as a decimal ratio:
+  `details.annualized_active_return = details.active_mean_return * AF`.
+- Annualized tracking-error detail is stored as a decimal ratio:
+  `details.annualized_tracking_error = details.tracking_error * sqrt(AF)`.
+- `metrics.INFORMATION_RATIO.value` is a dimensionless annualized ratio.
 
 ## Variable Dictionary
-- `t`: aligned observation index over common portfolio/benchmark dates.
-- `Rp_t_pp`: portfolio return at `t` in percentage points (post-transform if log mode is used).
-- `Rb_t_pp`: benchmark return at `t` in percentage points (post-transform if log mode is used).
-- `a_t_pp`: active return in percentage points (`a_t_pp = Rp_t_pp - Rb_t_pp`).
-- `mu_a_pp`: arithmetic mean of active pp returns.
-- `sigma_a_pp`: sample standard deviation of active pp returns (`ddof=1`).
+- `t`: aligned observation date after strict inner date alignment.
+- `Rp_t_pp`: portfolio return on date `t`, in percentage points.
+- `Rb_t_pp`: benchmark return on date `t`, in percentage points.
+- `Rp_t_used_pp`: portfolio return used for information ratio after optional log transformation,
+  in percentage points.
+- `Rb_t_used_pp`: benchmark return used for information ratio after optional log transformation,
+  in percentage points.
+- `A_t_pp`: active return in percentage points, `A_t_pp = Rp_t_used_pp - Rb_t_used_pp`.
+- `n_aligned`: number of aligned portfolio/benchmark observations.
+- `mu_p_decimal`: mean portfolio return as a decimal ratio.
+- `mu_b_decimal`: mean benchmark return as a decimal ratio.
+- `mu_a_pp`: mean active return in percentage points.
+- `mu_a_decimal`: mean active return as a decimal ratio.
+- `sigma_a_pp`: sample active-return standard deviation with `ddof=1`, in percentage points.
+- `sigma_a_decimal`: `sigma_a_pp / 100`.
 - `AF`: annualization factor.
-- `IR`: annualized information ratio.
+- `annualized_active_decimal`: `mu_a_decimal * AF`.
+- `annualized_tracking_error_decimal`: `sigma_a_decimal * sqrt(AF)`.
+- `IR`: dimensionless annualized information ratio.
 
 ## Methodology and Formulas
-1. Optional return transform:
-- if `use_log_returns=false`: use raw pp returns
-- if `use_log_returns=true`: transform each series as `ln(1 + r_pp/100) * 100`
-2. Align portfolio and benchmark returns by date (inner join).
-3. Compute active return series in pp:
-`a_t_pp = Rp_t_pp - Rb_t_pp`.
-4. Compute sample active moments:
-- `mu_a_pp = mean(a_t_pp)`
-- `sigma_a_pp = std(a_t_pp, ddof=1)`
-5. Resolve annualization factor:
-- `AF = options.annualization_factor` when provided;
-- else from frequency map (`DAILY=252`, `WEEKLY=52`, `MONTHLY=12`).
-6. Information ratio:
-`IR = (mu_a_pp / sigma_a_pp) * sqrt(AF)`.
-7. If `sigma_a_pp` is numerically zero (`np.isclose`), emit error instead of value.
+1. Resolve the requested period from `scope.as_of_date`, `portfolio_open_date`, and the period
+   definition.
+2. Filter portfolio and benchmark returns to the resolved period.
+3. Resample both series when `options.frequency` is not `DAILY`:
+   `r_period_pp = (product(1 + r_i_pp / 100) - 1) * 100`.
+4. Apply the optional log-return transform to both series:
+   - when `options.use_log_returns=false`, `Rp_t_used_pp = Rp_t_pp` and
+     `Rb_t_used_pp = Rb_t_pp`;
+   - when `options.use_log_returns=true`,
+     `r_t_used_pp = ln(1 + r_t_pp / 100) * 100` for each series.
+5. Strictly inner-align portfolio and benchmark returns by date.
+6. Require at least two aligned observations.
+7. Compute active returns:
+   `A_t_pp = Rp_t_used_pp - Rb_t_used_pp`.
+8. Compute active-return mean and sample standard deviation:
+   - `mu_a_pp = mean(A_used_pp)`;
+   - `sigma_a_pp = std(A_used_pp, ddof=1)`.
+9. Require `sigma_a_pp` to be non-zero under `np.isclose`.
+10. Resolve annualization factor:
+    - `AF = options.annualization_factor` when supplied;
+    - otherwise `AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`.
+11. Convert details to decimal ratios:
+    - `mu_a_decimal = mu_a_pp / 100`;
+    - `sigma_a_decimal = sigma_a_pp / 100`;
+    - `annualized_active_decimal = mu_a_decimal * AF`;
+    - `annualized_tracking_error_decimal = sigma_a_decimal * sqrt(AF)`.
+12. Compute annualized information ratio:
+    `IR = (mu_a_pp / sigma_a_pp) * sqrt(AF)`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter portfolio and benchmark series to the selected date window.
-2. Apply configured frequency resampling to both series.
-3. Apply optional log-return transform to both series.
-4. Inner-align on dates and build active return vector `a_t_pp`.
-5. Validate at least two aligned observations (`Insufficient data` if not).
-6. Compute `mu_a_pp` and `sigma_a_pp` on active returns (`ddof=1`).
-7. If `sigma_a_pp` is near zero, emit `Tracking error is zero`.
-8. Resolve annualization factor `AF` and compute `IR`.
-9. Return value in `results[period].metrics.INFORMATION_RATIO.value`.
+1. Build dated portfolio and benchmark return series and sort both by date.
+2. Resolve each requested period.
+3. Filter both return series to the period date range.
+4. Apply weekly or monthly compounding to both series when requested.
+5. Apply log-return transformation to both series when requested.
+6. Inner-align both series by date.
+7. Validate that at least two aligned observations remain.
+8. Compute `details.portfolio_mean_return`, `details.benchmark_mean_return`, and
+   `details.active_mean_return` as decimal ratios.
+9. Compute `details.tracking_error` as decimal sample active-return standard deviation.
+10. Compute `details.annualized_active_return` and `details.annualized_tracking_error` as decimal
+    ratios.
+11. Compute `metrics.INFORMATION_RATIO.value` as a dimensionless annualized ratio.
+12. Preserve `details.aligned_observation_count` and `details.annualization_factor` for
+    auditability.
 
 ## Validation and Failure Behavior
-- Missing benchmark series for benchmark-dependent metrics: `details.error = "Benchmark returns required for benchmark-dependent metric"`.
-- Fewer than 2 aligned observations: `details.error = "Insufficient data"`.
-- Near-zero active standard deviation: `details.error = "Tracking error is zero"`.
-- Non-numeric return values: rejected by request-contract validation before engine math.
-- Alignment is strict inner join; non-overlapping dates are dropped before metric computation.
+- Missing benchmark returns for `INFORMATION_RATIO` return `metrics.INFORMATION_RATIO.value = null`
+  with `details.error = "Benchmark returns required for benchmark-dependent metric"`.
+- Fewer than two aligned observations after period filtering, resampling, and optional
+  transformation return `metrics.INFORMATION_RATIO.value = null` with
+  `details.error = "Insufficient aligned observations"`.
+- Zero or near-zero active-return standard deviation returns
+  `metrics.INFORMATION_RATIO.value = null` with `details.error = "Tracking error is zero"`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No risk-free dependency is required for `INFORMATION_RATIO`.
+- The denominator is `sigma_a_pp`; zero denominator is fail-closed and is not promoted as a valid
+  ratio.
 
 ## Configuration Options
 - `options.frequency`
@@ -72,26 +130,54 @@
 
 ## Outputs
 - `results[period].metrics.INFORMATION_RATIO.value`
+- `results[period].metrics.INFORMATION_RATIO.details.aligned_observation_count`
+- `results[period].metrics.INFORMATION_RATIO.details.annualization_factor`
+- `results[period].metrics.INFORMATION_RATIO.details.portfolio_mean_return`
+- `results[period].metrics.INFORMATION_RATIO.details.benchmark_mean_return`
+- `results[period].metrics.INFORMATION_RATIO.details.active_mean_return`
+- `results[period].metrics.INFORMATION_RATIO.details.tracking_error`
+- `results[period].metrics.INFORMATION_RATIO.details.annualized_active_return`
+- `results[period].metrics.INFORMATION_RATIO.details.annualized_tracking_error`
 - `results[period].metrics.INFORMATION_RATIO.details.error`
 
 ## Worked Example
-Assume aligned returns (pp), no log transform, daily annualization (`AF=252`):
-- Portfolio: `[1.00, -0.50, 0.20, 0.00]`
-- Benchmark: `[0.80, -0.60, 0.30, 0.00]`
-- Active: `[0.20, 0.10, -0.10, 0.00]`
+Assume no log transform (`options.use_log_returns=false`), daily frequency, default daily
+annualization (`AF = 252`), and aligned return observations:
 
-| Date | `Rp_t_pp` | `Rb_t_pp` | `a_t_pp = Rp_t_pp - Rb_t_pp` | `a_t_pp - mu_a_pp` | `(a_t_pp - mu_a_pp)^2` |
-|---|---:|---:|---:|---:|---:|
-| Day1 | 1.00 | 0.80 | 0.20 | 0.15 | 0.0225 |
-| Day2 | -0.50 | -0.60 | 0.10 | 0.05 | 0.0025 |
-| Day3 | 0.20 | 0.30 | -0.10 | -0.15 | 0.0225 |
-| Day4 | 0.00 | 0.00 | 0.00 | -0.05 | 0.0025 |
+| Date | `Rp_t_used_pp` | `Rb_t_used_pp` | `A_t_pp` |
+| --- | ---: | ---: | ---: |
+| Day 1 | `1.00` | `0.80` | `0.20` |
+| Day 2 | `-0.50` | `-0.60` | `0.10` |
+| Day 3 | `0.20` | `0.30` | `-0.10` |
+| Day 4 | `0.00` | `0.00` | `0.00` |
 
 Intermediate calculations:
-- `mu_a_pp = (0.20 + 0.10 - 0.10 + 0.00) / 4 = 0.05`
-- sample variance `= (0.0225 + 0.0025 + 0.0225 + 0.0025) / (4-1) = 0.016667`
-- `sigma_a_pp = sqrt(0.016667) = 0.1291`
-- `IR = (0.05 / 0.1291) * sqrt(252) = 6.147`
+
+| Step | Value |
+| --- | ---: |
+| Mean portfolio return, pp | `0.1750000000` |
+| Mean benchmark return, pp | `0.1250000000` |
+| Mean active return, pp | `0.0500000000` |
+| `details.portfolio_mean_return` | `0.0017500000` |
+| `details.benchmark_mean_return` | `0.0012500000` |
+| `details.active_mean_return` | `0.0005000000` |
+| Active squared deviations sum | `0.0500000000` |
+| Sample active variance, pp (`ddof=1`) | `0.0166666667` |
+| `sigma_a_pp` | `0.1290994449` |
+| `details.tracking_error = sigma_a_pp / 100` | `0.0012909944` |
+| Annualization multiplier | `sqrt(252) = 15.8745078664` |
+| `details.annualized_active_return` | `0.1260000000` |
+| `details.annualized_tracking_error` | `0.0204939015` |
+| `IR = (mu_a_pp / sigma_a_pp) * sqrt(AF)` | `6.1481704596` |
 
 Output mapping:
-- `results[period].metrics.INFORMATION_RATIO.value = 6.147`
+
+- `results[period].metrics.INFORMATION_RATIO.value = 6.1481704596`
+- `results[period].metrics.INFORMATION_RATIO.details.aligned_observation_count = 4`
+- `results[period].metrics.INFORMATION_RATIO.details.annualization_factor = 252`
+- `results[period].metrics.INFORMATION_RATIO.details.portfolio_mean_return = 0.0017500000`
+- `results[period].metrics.INFORMATION_RATIO.details.benchmark_mean_return = 0.0012500000`
+- `results[period].metrics.INFORMATION_RATIO.details.active_mean_return = 0.0005000000`
+- `results[period].metrics.INFORMATION_RATIO.details.tracking_error = 0.0012909944`
+- `results[period].metrics.INFORMATION_RATIO.details.annualized_active_return = 0.1260000000`
+- `results[period].metrics.INFORMATION_RATIO.details.annualized_tracking_error = 0.0204939015`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -20,6 +20,9 @@ RISK_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-beta.md
 RISK_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-tracking-error.md"
 )
+RISK_INFORMATION_RATIO_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-information-ratio.md"
+)
 
 
 EXPECTED_V3_SECTIONS = [
@@ -300,6 +303,37 @@ def test_risk_tracking_error_methodology_is_auditable_against_engine_contract() 
         "2.7495454169",
         "0.0017320508",
         "0.0274954542",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_information_ratio_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_INFORMATION_RATIO_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: INFORMATION_RATIO",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "details.tracking_error = std(A_used_pp, ddof=1) / 100",
+        "details.annualized_active_return = details.active_mean_return * AF",
+        "details.annualized_tracking_error = details.tracking_error * sqrt(AF)",
+        "`metrics.INFORMATION_RATIO.value` is a dimensionless annualized ratio",
+        "`AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`",
+        'details.error = "Benchmark returns required for benchmark-dependent metric"',
+        'details.error = "Insufficient aligned observations"',
+        'details.error = "Tracking error is zero"',
+        "No risk-free dependency is required for `INFORMATION_RATIO`",
+        "The denominator is `sigma_a_pp`",
+        "results[period].metrics.INFORMATION_RATIO.value",
+        "6.1481704596",
+        "0.0012909944",
+        "0.1260000000",
+        "0.0204939015",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -206,6 +206,45 @@ def test_tracking_error_matches_documented_percentage_point_output_contract() ->
     assert metric.details["annualized_tracking_error"] == pytest.approx(0.02749545416973504)
 
 
+def test_information_ratio_matches_documented_dimensionless_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-04", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["INFORMATION_RATIO"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 1.00},
+            {"date": "2026-01-02", "value": -0.50},
+            {"date": "2026-01-03", "value": 0.20},
+            {"date": "2026-01-04", "value": 0.00},
+        ],
+        "benchmark_returns": [
+            {"date": "2026-01-01", "value": 0.80},
+            {"date": "2026-01-02", "value": -0.60},
+            {"date": "2026-01-03", "value": 0.30},
+            {"date": "2026-01-04", "value": 0.00},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["INFORMATION_RATIO"]
+    assert metric.value == pytest.approx(6.148170459575758)
+    assert metric.details is not None
+    assert metric.details["aligned_observation_count"] == 4
+    assert metric.details["annualization_factor"] == 252
+    assert metric.details["portfolio_mean_return"] == pytest.approx(0.00175)
+    assert metric.details["benchmark_mean_return"] == pytest.approx(0.00125)
+    assert metric.details["active_mean_return"] == pytest.approx(0.0005)
+    assert metric.details["tracking_error"] == pytest.approx(0.0012909944487358054)
+    assert metric.details["annualized_active_return"] == pytest.approx(0.126)
+    assert metric.details["annualized_tracking_error"] == pytest.approx(0.020493901531919195)
+
+
 def test_drawdown_metadata_fields_present() -> None:
     payload = _base_payload()
     payload["metrics"] = ["DRAWDOWN"]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,18 +23,20 @@
 ## Implementation-backed methodology coverage
 
 `RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, Sharpe,
-beta, and tracking error. The methodologies are tied to the implemented `/analytics/risk/calculate`
-engine and state the exact percentage-point input convention, optional log-return transform,
-frequency compounding before metric calculation, `ddof=1` sample standard
-deviation/covariance/variance behavior, decimal volatility, risk-free, and tracking-error details,
-percentage-point-squared beta covariance/benchmark-variance details, annualized percentage-point
-`metrics.VOLATILITY.value`, dimensionless annualized `metrics.SHARPE.value`, dimensionless slope
-`metrics.BETA.value`, annualized percentage-point `metrics.TRACKING_ERROR.value`,
-annualization-factor resolution where used, benchmark dependency for beta and tracking error, no
-benchmark dependency for Sharpe, no risk-free dependency for volatility, beta, and tracking error,
-no-denominator posture for volatility and tracking error, zero-volatility fail-closed posture for
-Sharpe, zero-benchmark-variance fail-closed posture for beta, constant-active-return zero
-tracking-error posture, and insufficient-data failure behavior.
+beta, tracking error, and information ratio. The methodologies are tied to the implemented
+`/analytics/risk/calculate` engine and state the exact percentage-point input convention, optional
+log-return transform, frequency compounding before metric calculation, `ddof=1` sample standard
+deviation/covariance/variance behavior, decimal volatility, risk-free, tracking-error, and
+information-ratio details, percentage-point-squared beta covariance/benchmark-variance details,
+annualized percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
+`metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`, annualized percentage-point
+`metrics.TRACKING_ERROR.value`, dimensionless annualized `metrics.INFORMATION_RATIO.value`,
+annualization-factor resolution where used, benchmark dependency for beta, tracking error, and
+information ratio, no benchmark dependency for Sharpe, no risk-free dependency for volatility,
+beta, tracking error, and information ratio, no-denominator posture for volatility and tracking
+error, zero-volatility fail-closed posture for Sharpe, zero-benchmark-variance fail-closed posture
+for beta, zero-tracking-error fail-closed posture for information ratio, constant-active-return
+zero tracking-error posture, and insufficient-data failure behavior.
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
 volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
@@ -84,6 +86,7 @@ Audience notes:
   per unit of portfolio return volatility for the resolved period. Beta is the period sensitivity
   slope of portfolio returns to benchmark return variance after strict date alignment, and tracking
   error is annualized active-return volatility versus the selected benchmark for the resolved
+  period. Information ratio is annualized active return per unit of tracking error for the same
   period.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
@@ -93,8 +96,8 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, Sharpe,
-  beta, and tracking-error values and supportability metadata rather than recomputing period risk
-  metrics locally.
+  beta, tracking-error, and information-ratio values and supportability metadata rather than
+  recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrades `RiskMetricsReport:v1` `INFORMATION_RATIO` methodology to v3 source-owner detail
- pins dimensionless annualized output, decimal detail fields, strict benchmark alignment, denominator failure behavior, and no-risk-free posture
- updates methodology guards, engine regression proof, Risk repository context, and repo-authored wiki source

## Validation
- `python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q` (`24 passed`)
- `python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py`
- `python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py`
- `git diff --check`
- `make test-pyramid-gate` (`334` unit, `94` integration, `23` e2e)
- `make check` (`334 passed` plus Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, and domain-data-product gates)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reports expected pre-merge drift: `Mesh-Data-Products.md`

## Boundaries
- No `lotus-gateway` changes.
- No `lotus-workbench` changes.
- This is source-owner methodology truth only; downstream consumers must preserve the Risk product instead of recomputing information ratio locally.