### PR TITLE
docs(risk): pin sortino methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,22 +50,25 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
-    `SHARPE`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
+    `SHARPE`, `SORTINO`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
     percentage-point input conventions, optional
     log-return transformation, frequency compounding before metric calculation, `ddof=1` sample
     standard deviation/covariance/variance behavior, decimal volatility and risk-free details,
     percentage-point-squared beta covariance/benchmark-variance details, annualized
     percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-    `metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`, annualized
-    percentage-point `metrics.TRACKING_ERROR.value`, dimensionless annualized
-    `metrics.INFORMATION_RATIO.value`, decimal tracking-error and information-ratio detail fields,
-    default and override annualization-factor resolution where used, benchmark dependency posture
-    for beta, tracking error, and information ratio, no benchmark dependency posture for Sharpe, no
-    risk-free dependency posture for volatility, beta, tracking error, and information ratio,
-    no-denominator posture for volatility and tracking error, zero-volatility fail-closed posture
-    for Sharpe, zero-benchmark-variance fail-closed posture for beta, zero-tracking-error
-    fail-closed posture for information ratio, constant-active-return zero tracking-error posture,
-    and insufficient-data / insufficient-aligned-observation failure behavior.
+    `metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, dimensionless slope
+    `metrics.BETA.value`, annualized percentage-point `metrics.TRACKING_ERROR.value`,
+    dimensionless annualized `metrics.INFORMATION_RATIO.value`, decimal tracking-error and
+    information-ratio detail fields, decimal Sortino mean-return, MAR, excess-return,
+    annualized-excess-return, and downside-deviation detail fields, default and override
+    annualization-factor resolution where used, benchmark dependency posture for beta, tracking
+    error, and information ratio, no benchmark dependency posture for Sharpe and Sortino, no
+    risk-free dependency posture for volatility, Sortino, beta, tracking error, and information
+    ratio, no-denominator posture for volatility and tracking error, zero-volatility fail-closed
+    posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+    zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture
+    for information ratio, constant-active-return zero tracking-error posture, and
+    insufficient-data / insufficient-aligned-observation failure behavior.
 12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin

--- a/docs/methodologies/metrics/risk-sortino.md
+++ b/docs/methodologies/metrics/risk-sortino.md
@@ -4,96 +4,161 @@
 - metric_id: SORTINO
 
 ## Endpoint and Mode Coverage
-- endpoint: /analytics/risk/calculate
+- endpoint: `/analytics/risk/calculate`
 - supported_modes: stateless, stateful
+- source product: `RiskMetricsReport:v1`
 
 ## Inputs
-- Portfolio return series in pp.
-- Minimum acceptable return annual rate.
+- Portfolio return observations in percentage points.
+- Request periods resolved by the risk calculation contract.
+- `options.frequency` for optional return compounding before metric calculation.
+- `options.use_log_returns` for optional log-return transformation after frequency compounding.
+- `options.mar_annual_rate` as the annual minimum acceptable return.
+- Optional `options.annualization_factor` override.
 
 ## Upstream Data Sources
-- Stateless caller returns.
-- Stateful lotus-performance returns.
+- Stateless callers provide return observations directly in the request.
+- Stateful mode resolves return observations from `lotus-performance`.
+- No benchmark dependency is required for `SORTINO`.
+- No risk-free dependency is required for `SORTINO`; MAR is supplied separately through risk
+  options.
 
 ## Unit Conventions
-- Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Return inputs are percentage points: `1.0` means `+1%`.
+- Frequency resampling compounds percentage-point returns before metric calculation:
+  `r_resampled_pp = ((product(1 + r_raw_pp / 100)) - 1) * 100`.
+- When log returns are enabled, the transformed return remains in percentage points:
+  `r_log_pp = ln(1 + r_pp / 100) * 100`.
+- Mean return, periodic MAR, excess return, annualized excess return, and downside deviation in
+  `details` are decimals.
+- `metrics.SORTINO.value` is a dimensionless annualized ratio.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: portfolio return at `t` in percentage points (post-transform if log mode is used).
+- `t`: aligned observation index in chronological order.
+- `r_raw_t_pp`: raw portfolio return at `t`, in percentage points.
+- `r_used_t_pp`: portfolio return used by the metric after frequency compounding and optional
+  log-return transformation, in percentage points.
+- `r_used_t_dec`: `r_used_t_pp / 100`.
 - `AF`: annualization factor.
-- `mar_annual`: annual minimum acceptable return from options.
-- `mar_p`: periodic MAR threshold in decimal.
-- `x_t`: excess return vs MAR in decimal (`x_t = r_t_pp/100 - mar_p`).
-- `D`: downside set, all `x_t < 0`.
-- `sigma_down`: downside deviation (`sqrt(mean(D^2))`).
-- `mu_excess`: mean excess return vs MAR in decimal.
+- `MAR_annual`: annual minimum acceptable return from `options.mar_annual_rate`, in decimal units.
+- `MAR_periodic`: periodic minimum acceptable return, in decimal units.
+- `x_t`: excess return versus periodic MAR, `r_used_t_dec - MAR_periodic`.
+- `D`: downside excess-return set containing all `x_t < 0`.
+- `N`: count of all portfolio observations used by the metric.
+- `N_down`: count of downside observations in `D`.
+- `mu_dec`: arithmetic mean of all `r_used_t_dec`.
+- `mu_excess_dec`: `mu_dec - MAR_periodic`.
+- `sigma_down_dec`: downside deviation, computed as `sqrt(mean(x_t^2 for x_t in D))`.
 - `SORTINO`: annualized Sortino ratio.
 
 ## Methodology and Formulas
-1. Optional return transform:
-- if `use_log_returns=false`: use raw `r_t_pp`
-- if `use_log_returns=true`: `r_t_pp = ln(1 + r_raw_t_pp/100) * 100`
-2. Resolve annualization factor:
-- `AF = options.annualization_factor` when provided;
-- else from frequency map (`DAILY=252`, `WEEKLY=52`, `MONTHLY=12`).
-3. Convert annual MAR to periodic MAR:
-`mar_p = (1 + mar_annual)^(1/AF) - 1`.
-4. Compute excess return series:
-`x_t = r_t_pp/100 - mar_p`.
-5. Construct downside set:
-`D = {x_t | x_t < 0}`.
-6. Compute downside deviation:
-`sigma_down = sqrt(mean(D^2))`.
-7. Compute mean excess return:
-`mu_excess = mean(r_t_pp)/100 - mar_p`.
-8. Compute Sortino:
-`SORTINO = (mu_excess / sigma_down) * sqrt(AF)`.
+1. Resolve the requested period window.
+2. Filter portfolio returns to the period window.
+3. Apply `options.frequency`:
+   - `DAILY`: use daily observations as supplied.
+   - `WEEKLY`: compound observations into Friday-ending weekly returns.
+   - `MONTHLY`: compound observations into month-end returns.
+4. Apply optional log-return transformation:
+   - when `use_log_returns=false`, `r_used_t_pp = r_resampled_t_pp`;
+   - when `use_log_returns=true`, `r_used_t_pp = ln(1 + r_resampled_t_pp / 100) * 100`.
+5. Resolve annualization factor:
+   - use `options.annualization_factor` when supplied;
+   - otherwise `AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`.
+6. Convert annual MAR to periodic MAR:
+   `MAR_periodic = (1 + MAR_annual)^(1 / AF) - 1`.
+7. Convert the used returns to decimals:
+   `r_used_t_dec = r_used_t_pp / 100`.
+8. Compute downside excess returns:
+   `x_t = r_used_t_dec - MAR_periodic`.
+9. Build downside set:
+   `D = {x_t | x_t < 0}`.
+10. Compute downside deviation:
+    `sigma_down_dec = sqrt(mean(x_t^2 for x_t in D))`.
+11. Compute full-sample mean excess return:
+    `mu_excess_dec = mean(r_used_t_dec) - MAR_periodic`.
+12. Compute dimensionless annualized Sortino ratio:
+    `SORTINO = (mu_excess_dec / sigma_down_dec) * sqrt(AF)`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter return observations to the selected window.
-2. Apply frequency resampling and optional log-return transform.
-3. Resolve annualization factor and compute periodic MAR threshold.
-4. Compute excess return series `x_t`.
-5. Build downside set `D` from values where `x_t < 0`.
-6. If `D` is empty, emit deterministic metric error `No downside observations`.
-7. Compute downside deviation from `D`.
-8. Compute `mu_excess` from full return sample (not downside-only sample).
-9. Compute annualized Sortino and map to response.
+1. Resolve the period start/end dates from the request period and portfolio open date.
+2. Select portfolio returns within the resolved period.
+3. Compound returns to the requested frequency when frequency is not `DAILY`.
+4. Apply optional log-return transformation.
+5. Require at least two observations after filtering, frequency compounding, and optional
+   transformation.
+6. Resolve `AF` and `MAR_periodic`.
+7. Convert used percentage-point returns to decimals.
+8. Compute `x_t` for every observation.
+9. Keep only negative `x_t` values in downside set `D`.
+10. Fail closed when `D` is empty.
+11. Compute `sigma_down_dec` as root-mean-square downside excess return.
+12. Compute full-sample `mu_excess_dec`, annualized excess return, and Sortino output.
+13. Populate metric value and details fields.
 
 ## Validation and Failure Behavior
-- Fewer than 2 observations after filtering/resampling: `details.error = "Insufficient data"`.
-- Empty downside set `D`: `details.error = "No downside observations"`.
-- Non-numeric return values: rejected by request-contract validation before engine math.
-- `options.mar_annual_rate` is required/validated at request-contract layer.
+- Fewer than two portfolio observations after period filtering, frequency compounding, and optional
+  transformation return `metrics.SORTINO.value = null` with `details.error = "Insufficient data"`.
+- Empty downside set after MAR comparison returns `metrics.SORTINO.value = null` with
+  `details.error = "No downside observations"`.
+- Non-numeric return values are rejected by request validation before engine math.
+- Invalid log-return inputs that make `ln(1 + r_pp / 100)` undefined are rejected by request
+  validation or produce invalid numeric results before supportable output is claimed.
+- No benchmark dependency is required for `SORTINO`.
+- No risk-free dependency is required for `SORTINO`.
+- The denominator is `sigma_down_dec`; it is computed only from downside excess returns and is not
+  annualized before the ratio calculation.
 
 ## Configuration Options
+- `options.frequency`
+- `options.use_log_returns`
 - `options.mar_annual_rate`
 - `options.annualization_factor`
 
 ## Outputs
 - `results[period].metrics.SORTINO.value`
-- `...details.error`
+- `results[period].metrics.SORTINO.details.observation_count`
+- `results[period].metrics.SORTINO.details.annualization_factor`
+- `results[period].metrics.SORTINO.details.mar_annual_rate`
+- `results[period].metrics.SORTINO.details.periodic_mar`
+- `results[period].metrics.SORTINO.details.mean_return`
+- `results[period].metrics.SORTINO.details.excess_return`
+- `results[period].metrics.SORTINO.details.annualized_excess_return`
+- `results[period].metrics.SORTINO.details.downside_observation_count`
+- `results[period].metrics.SORTINO.details.downside_deviation`
+- `results[period].metrics.SORTINO.details.error`
 
 ## Worked Example
 Assume:
-- returns (pp): `[1.00, -2.00, 0.50]`
-- `mar_annual = 0.00`, `AF = 252`
+- returns (pp): `[1.00, -0.50, 0.20, -0.10]`
+- `MAR_annual = 0.02`
+- `AF = 252`
 - `use_log_returns = false`
 
-| Date | `r_t_pp` | `r_t_pp/100` | `mar_p` | `x_t = r_t_pp/100 - mar_p` | In downside set `D`? | `x_t^2` if in `D` |
-|---|---:|---:|---:|---:|---|---:|
-| Day1 | 1.00 | 0.0100 | 0.0000 | 0.0100 | No | - |
-| Day2 | -2.00 | -0.0200 | 0.0000 | -0.0200 | Yes | 0.000400 |
-| Day3 | 0.50 | 0.0050 | 0.0000 | 0.0050 | No | - |
+| Date | `r_used_t_pp` | `r_used_t_dec` | `MAR_periodic` | `x_t = r_used_t_dec - MAR_periodic` | In `D`? | `x_t^2` if in `D` |
+| --- | ---: | ---: | ---: | ---: | --- | ---: |
+| 2026-01-01 | 1.00 | 0.0100000000 | 0.0000785849 | 0.0099214151 | No | - |
+| 2026-01-02 | -0.50 | -0.0050000000 | 0.0000785849 | -0.0050785849 | Yes | 0.0000257920 |
+| 2026-01-03 | 0.20 | 0.0020000000 | 0.0000785849 | 0.0019214151 | No | - |
+| 2026-01-04 | -0.10 | -0.0010000000 | 0.0000785849 | -0.0010785849 | Yes | 0.0000011633 |
 
 Intermediate calculations:
-- `D = [-0.0200]`
-- `sigma_down = sqrt(mean([0.000400])) = 0.0200`
-- `mu_excess = mean([0.0100, -0.0200, 0.0050]) - 0.0000 = -0.001667`
-- `SORTINO = (-0.001667 / 0.0200) * sqrt(252) = -1.323`
+- `N = 4`
+- `N_down = 2`
+- `MAR_periodic = (1 + 0.02)^(1 / 252) - 1 = 0.0000785849`
+- `mu_dec = mean([0.0100000000, -0.0050000000, 0.0020000000, -0.0010000000]) = 0.0015000000`
+- `mu_excess_dec = 0.0015000000 - 0.0000785849 = 0.0014214151`
+- `annualized_excess_return = 0.0014214151 * 252 = 0.3581965946`
+- `sigma_down_dec = sqrt(mean([0.0000257920, 0.0000011633])) = 0.0036711967`
+- `SORTINO = (0.0014214151 / 0.0036711967) * sqrt(252) = 6.1462967894`
 
 Output mapping:
-- `results[period].metrics.SORTINO.value = -1.323`
+- `results[period].metrics.SORTINO.value = 6.1462967894`
+- `results[period].metrics.SORTINO.details.observation_count = 4`
+- `results[period].metrics.SORTINO.details.annualization_factor = 252`
+- `results[period].metrics.SORTINO.details.mar_annual_rate = 0.0200000000`
+- `results[period].metrics.SORTINO.details.periodic_mar = 0.0000785849`
+- `results[period].metrics.SORTINO.details.mean_return = 0.0015000000`
+- `results[period].metrics.SORTINO.details.excess_return = 0.0014214151`
+- `results[period].metrics.SORTINO.details.annualized_excess_return = 0.3581965946`
+- `results[period].metrics.SORTINO.details.downside_observation_count = 2`
+- `results[period].metrics.SORTINO.details.downside_deviation = 0.0036711967`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -16,6 +16,7 @@ ROLLING_MAX_DRAWDOWN_DOC = (
 )
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
+RISK_SORTINO_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sortino.md"
 RISK_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-beta.md"
 RISK_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-tracking-error.md"
@@ -246,6 +247,35 @@ def test_risk_sharpe_methodology_is_auditable_against_engine_contract() -> None:
         "4.7688716199",
         "0.0000785849",
         "0.0075055535",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_sortino_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_SORTINO_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: SORTINO",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "MAR_periodic = (1 + MAR_annual)^(1 / AF) - 1",
+        "sigma_down_dec = sqrt(mean(x_t^2 for x_t in D))",
+        "`metrics.SORTINO.value` is a dimensionless annualized ratio",
+        "`AF = 252` for `DAILY`, `52` for `WEEKLY`, and `12` for `MONTHLY`",
+        'details.error = "Insufficient data"',
+        'details.error = "No downside observations"',
+        "No benchmark dependency is required for `SORTINO`",
+        "No risk-free dependency is required for `SORTINO`",
+        "The denominator is `sigma_down_dec`",
+        "results[period].metrics.SORTINO.value",
+        "6.1462967894",
+        "0.0000785849",
+        "0.0036711967",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -136,6 +136,41 @@ def test_sharpe_matches_documented_dimensionless_output_contract() -> None:
     assert metric.details["annualization_factor"] == 252
 
 
+def test_sortino_matches_documented_dimensionless_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-04", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["SORTINO"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+            "mar_annual_rate": 0.02,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 1.00},
+            {"date": "2026-01-02", "value": -0.50},
+            {"date": "2026-01-03", "value": 0.20},
+            {"date": "2026-01-04", "value": -0.10},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["SORTINO"]
+    assert metric.value == pytest.approx(6.146296789445203)
+    assert metric.details is not None
+    assert metric.details["observation_count"] == 4
+    assert metric.details["annualization_factor"] == 252
+    assert metric.details["mar_annual_rate"] == pytest.approx(0.02)
+    assert metric.details["periodic_mar"] == pytest.approx(0.0000785849419846496)
+    assert metric.details["mean_return"] == pytest.approx(0.0015)
+    assert metric.details["excess_return"] == pytest.approx(0.0014214150580153504)
+    assert metric.details["annualized_excess_return"] == pytest.approx(0.3581965946198683)
+    assert metric.details["downside_observation_count"] == 2
+    assert metric.details["downside_deviation"] == pytest.approx(0.003671196704756452)
+
+
 def test_beta_matches_documented_dimensionless_output_contract() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,20 +23,22 @@
 ## Implementation-backed methodology coverage
 
 `RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, Sharpe,
-beta, tracking error, and information ratio. The methodologies are tied to the implemented
+Sortino, beta, tracking error, and information ratio. The methodologies are tied to the implemented
 `/analytics/risk/calculate` engine and state the exact percentage-point input convention, optional
 log-return transform, frequency compounding before metric calculation, `ddof=1` sample standard
-deviation/covariance/variance behavior, decimal volatility, risk-free, tracking-error, and
-information-ratio details, percentage-point-squared beta covariance/benchmark-variance details,
-annualized percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-`metrics.SHARPE.value`, dimensionless slope `metrics.BETA.value`, annualized percentage-point
-`metrics.TRACKING_ERROR.value`, dimensionless annualized `metrics.INFORMATION_RATIO.value`,
-annualization-factor resolution where used, benchmark dependency for beta, tracking error, and
-information ratio, no benchmark dependency for Sharpe, no risk-free dependency for volatility,
-beta, tracking error, and information ratio, no-denominator posture for volatility and tracking
-error, zero-volatility fail-closed posture for Sharpe, zero-benchmark-variance fail-closed posture
-for beta, zero-tracking-error fail-closed posture for information ratio, constant-active-return
-zero tracking-error posture, and insufficient-data failure behavior.
+deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, tracking-error,
+and information-ratio details, percentage-point-squared beta covariance/benchmark-variance
+details, annualized percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
+`metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, dimensionless slope
+`metrics.BETA.value`, annualized percentage-point `metrics.TRACKING_ERROR.value`, dimensionless
+annualized `metrics.INFORMATION_RATIO.value`, annualization-factor resolution where used,
+benchmark dependency for beta, tracking error, and information ratio, no benchmark dependency for
+Sharpe and Sortino, no risk-free dependency for volatility, Sortino, beta, tracking error, and
+information ratio, no-denominator posture for volatility and tracking error, zero-volatility
+fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture for
+information ratio, constant-active-return zero tracking-error posture, and insufficient-data
+failure behavior.
 
 `RollingRiskMetricsReport:v1` now has auditable source-owner methodology truth for rolling
 volatility, rolling Sharpe, rolling beta, rolling tracking error, rolling information ratio, and
@@ -82,12 +84,12 @@ Audience notes:
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
-  dispersion in percentage points for the resolved period and Sharpe as annualized excess return
-  per unit of portfolio return volatility for the resolved period. Beta is the period sensitivity
-  slope of portfolio returns to benchmark return variance after strict date alignment, and tracking
-  error is annualized active-return volatility versus the selected benchmark for the resolved
-  period. Information ratio is annualized active return per unit of tracking error for the same
-  period.
+  dispersion in percentage points for the resolved period, Sharpe as annualized excess return per
+  unit of portfolio return volatility, and Sortino as annualized excess return over MAR per unit of
+  downside deviation. Beta is the period sensitivity slope of portfolio returns to benchmark return
+  variance after strict date alignment, and tracking error is annualized active-return volatility
+  versus the selected benchmark for the resolved period. Information ratio is annualized active
+  return per unit of tracking error for the same period.
 - Operations teams can distinguish warm-up gaps, missing benchmark alignment, and upstream sourcing
   issues from calculation failure; missing risk-free alignment and zero-excess-volatility windows
   are explicit for Sharpe, zero-benchmark-variance windows are explicit for beta, and
@@ -96,7 +98,7 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, Sharpe,
-  beta, tracking-error, and information-ratio values and supportability metadata rather than
+  Sortino, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort


### PR DESCRIPTION
## Summary
- upgrade isk-sortino.md to v3 methodology truth for RiskMetricsReport:v1
- pin Sortino engine behavior with documentation and engine regression tests
- update Risk repository context and Mesh Data Products wiki source for source-owner Sortino support

## Validation
- python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q
- python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- git diff --check
- make test-pyramid-gate
- make check
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)