### PR TITLE
docs(risk): pin value at risk methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,22 +50,26 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
-    `SHARPE`, `SORTINO`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
+    `SHARPE`, `SORTINO`, `VAR`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
     percentage-point input conventions, optional
     log-return transformation, frequency compounding before metric calculation, `ddof=1` sample
-    standard deviation/covariance/variance behavior, decimal volatility and risk-free details,
+    standard deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, VaR,
+    tracking-error, and information-ratio details,
     percentage-point-squared beta covariance/benchmark-variance details, annualized
     percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-    `metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, dimensionless slope
-    `metrics.BETA.value`, annualized percentage-point `metrics.TRACKING_ERROR.value`,
+    `metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, signed
+    percentage-point `metrics.VAR.value`, dimensionless slope `metrics.BETA.value`,
+    annualized percentage-point `metrics.TRACKING_ERROR.value`,
     dimensionless annualized `metrics.INFORMATION_RATIO.value`, decimal tracking-error and
     information-ratio detail fields, decimal Sortino mean-return, MAR, excess-return,
-    annualized-excess-return, and downside-deviation detail fields, default and override
+    annualized-excess-return, and downside-deviation detail fields, signed VaR base, horizon, and
+    expected-shortfall detail fields, default and override
     annualization-factor resolution where used, benchmark dependency posture for beta, tracking
-    error, and information ratio, no benchmark dependency posture for Sharpe and Sortino, no
-    risk-free dependency posture for volatility, Sortino, beta, tracking error, and information
-    ratio, no-denominator posture for volatility and tracking error, zero-volatility fail-closed
-    posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+    error, and information ratio, no benchmark dependency posture for Sharpe, Sortino, and VaR, no
+    risk-free dependency posture for volatility, Sortino, VaR, beta, tracking error, and
+    information ratio, no-denominator posture for volatility and tracking error, zero-volatility
+    fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+    signed VaR loss-threshold posture, square-root horizon scaling,
     zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture
     for information ratio, constant-active-return zero tracking-error posture, and
     insufficient-data / insufficient-aligned-observation failure behavior.

--- a/docs/methodologies/metrics/risk-var.md
+++ b/docs/methodologies/metrics/risk-var.md
@@ -4,77 +4,127 @@
 - metric_id: VAR
 
 ## Endpoint and Mode Coverage
-- endpoint: /analytics/risk/calculate
+- endpoint: `/analytics/risk/calculate`
 - supported_modes: stateless, stateful
+- source product: `RiskMetricsReport:v1`
 
 ## Inputs
-- Portfolio return series in pp.
-- VaR method, confidence, horizon, ES flag.
+- Portfolio return observations in percentage points.
+- Request periods resolved by the risk calculation contract.
+- `options.frequency` for optional return compounding before metric calculation.
+- `options.use_log_returns` for optional log-return transformation after frequency compounding.
+- `options.var.method`: `HISTORICAL`, `GAUSSIAN`, or `CORNISH_FISHER`.
+- `options.var.confidence`: confidence level, strictly between `0` and `1`.
+- `options.var.horizon_days`: positive integer horizon for square-root-of-time scaling.
+- `options.var.include_expected_shortfall`: whether to emit expected shortfall details.
 
 ## Upstream Data Sources
-- Stateless caller.
-- Stateful lotus-performance.
+- Stateless callers provide return observations directly in the request.
+- Stateful mode resolves return observations from `lotus-performance`.
+- No benchmark dependency is required for `VAR`.
+- No risk-free dependency is required for `VAR`.
 
 ## Unit Conventions
-- Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- VaR and expected shortfall outputs are signed return thresholds in percentage points.
-- Negative values indicate loss thresholds. Positive values can occur when the empirical or parametric lower tail remains positive for the selected sample.
+- Return inputs are percentage points: `1.0` means `+1%`.
+- Frequency resampling compounds percentage-point returns before metric calculation:
+  `r_resampled_pp = ((product(1 + r_raw_pp / 100)) - 1) * 100`.
+- When log returns are enabled, the transformed return remains in percentage points:
+  `r_log_pp = ln(1 + r_pp / 100) * 100`.
+- `metrics.VAR.value`, `details.base_var`, `details.base_expected_shortfall`, and
+  `details.expected_shortfall` are signed return thresholds in percentage points.
+- Negative values indicate lower-tail loss thresholds. Positive values can occur when the selected
+  period's lower-tail return threshold remains positive.
 
 ## Variable Dictionary
-- `r_t_pp`: return observation in percentage points (post-transform if log mode is used).
-- `n`: number of observations in the period sample.
-- `c`: confidence level (`options.var.confidence`).
-- `alpha`: tail probability (`alpha = 1 - c`).
-- `z_alpha`: normal quantile at `alpha`.
-- `mu_pp`: sample mean return in pp.
-- `sigma_pp`: sample standard deviation in pp (`ddof=1`).
-- `S`: sample skewness (pandas `Series.skew()`).
-- `K`: sample excess kurtosis (pandas `Series.kurt()`).
+- `t`: observation index in chronological order.
+- `r_raw_t_pp`: raw portfolio return at `t`, in percentage points.
+- `r_used_t_pp`: portfolio return used by the metric after frequency compounding and optional
+  log-return transformation, in percentage points.
+- `N`: count of portfolio observations used by the metric.
+- `c`: confidence level from `options.var.confidence`.
+- `alpha`: tail probability, `1 - c`.
+- `z_alpha`: standard-normal quantile at `alpha`.
+- `mu_pp`: arithmetic mean of `r_used_t_pp`.
+- `sigma_pp`: sample standard deviation of `r_used_t_pp` with `ddof=1`.
+- `S`: sample skewness from `pandas.Series.skew()`.
+- `K`: sample excess kurtosis from `pandas.Series.kurt()`.
 - `z_cf`: Cornish-Fisher adjusted quantile.
-- `VaR_1d_pp`: one-day VaR in pp before horizon scaling.
-- `h`: horizon days (`options.var.horizon_days`).
-- `VaR_h_pp`: horizon-scaled VaR in pp.
-- `ES_1d_pp`: one-day expected shortfall in pp.
-- `ES_h_pp`: horizon-scaled expected shortfall in pp.
+- `VaR_base_pp`: one-day VaR before horizon scaling, in percentage points.
+- `h`: horizon days from `options.var.horizon_days`.
+- `scale_h`: square-root-of-time horizon scale factor, `sqrt(h)`.
+- `VaR_h_pp`: horizon-scaled VaR, in percentage points.
+- `T`: expected-shortfall tail set, `{r_used_t_pp | r_used_t_pp <= VaR_base_pp}`.
+- `ES_base_pp`: one-day expected shortfall before horizon scaling, in percentage points.
+- `ES_h_pp`: horizon-scaled expected shortfall, in percentage points.
 
 ## Methodology and Formulas
-1. Optional return transform:
-- if `use_log_returns=false`: use raw pp returns
-- if `use_log_returns=true`: transform each return as `ln(1 + r_pp/100) * 100`
-2. Tail probability:
-`alpha = 1 - confidence`.
-3. One-day VaR by method:
-- `HISTORICAL`: `VaR_1d_pp = percentile(sample, alpha*100)` (NumPy linear interpolation).
-- `GAUSSIAN`: `VaR_1d_pp = mu_pp + sigma_pp * z_alpha`.
-- `CORNISH_FISHER`:
-  - `z_cf = z_alpha + ((z_alpha^2-1)S)/6 + ((z_alpha^3-3z_alpha)K)/24 - ((2z_alpha^3-5z_alpha)S^2)/36`
-  - `VaR_1d_pp = mu_pp + sigma_pp * z_cf`
-4. Horizon scaling:
-`VaR_h_pp = VaR_1d_pp * sqrt(h)`.
-5. Optional expected shortfall:
-- tail set `T = {r_t_pp | r_t_pp <= VaR_1d_pp}`
-- `ES_1d_pp = mean(T)` if `T` non-empty, else `VaR_1d_pp`
-- `ES_h_pp = ES_1d_pp * sqrt(h)`
+1. Resolve the requested period window.
+2. Filter portfolio returns to the period window.
+3. Apply `options.frequency`:
+   - `DAILY`: use daily observations as supplied.
+   - `WEEKLY`: compound observations into Friday-ending weekly returns.
+   - `MONTHLY`: compound observations into month-end returns.
+4. Apply optional log-return transformation:
+   - when `use_log_returns=false`, `r_used_t_pp = r_resampled_t_pp`;
+   - when `use_log_returns=true`, `r_used_t_pp = ln(1 + r_resampled_t_pp / 100) * 100`.
+5. Compute tail probability:
+   `alpha = 1 - c`.
+6. Compute one-day base VaR using the selected method:
+   - `HISTORICAL`: `VaR_base_pp = percentile(r_used_pp, alpha * 100)` using NumPy percentile
+     interpolation.
+   - `GAUSSIAN`: `VaR_base_pp = mu_pp + sigma_pp * z_alpha`.
+   - `CORNISH_FISHER`:
+     `z_cf = z_alpha + ((z_alpha^2 - 1) * S) / 6 + ((z_alpha^3 - 3 * z_alpha) * K) / 24 - ((2 * z_alpha^3 - 5 * z_alpha) * S^2) / 36`;
+     `VaR_base_pp = mu_pp + sigma_pp * z_cf`.
+7. Compute horizon scale:
+   `scale_h = sqrt(h)`.
+8. Compute reported VaR:
+   `VaR_h_pp = VaR_base_pp * scale_h`.
+9. When expected shortfall is enabled, compute:
+   - `T = {r_used_t_pp | r_used_t_pp <= VaR_base_pp}`;
+   - `ES_base_pp = mean(T)` when `T` is non-empty;
+   - `ES_base_pp = VaR_base_pp` when `T` is empty;
+   - `ES_h_pp = ES_base_pp * scale_h`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter return observations to the selected window.
-2. Apply frequency resampling and optional log-return transform.
-3. Validate minimum sample size (`>=2`) for stable distribution estimates.
-4. Read VaR configuration (`method`, `confidence`, `horizon_days`, ES flag).
-5. Compute one-day VaR using the selected method.
-6. Apply horizon scaling `sqrt(horizon_days)` to obtain reported VaR.
-7. If ES is enabled, compute one-day ES from tail at one-day cutoff, then horizon-scale ES.
-8. Emit `metrics.VAR.value` and optional `details.expected_shortfall`.
+1. Resolve the period start/end dates from the request period and portfolio open date.
+2. Select portfolio returns within the resolved period.
+3. Compound returns to the requested frequency when frequency is not `DAILY`.
+4. Apply optional log-return transformation.
+5. Require at least two observations after filtering, frequency compounding, and optional
+   transformation.
+6. Read VaR method, confidence, horizon days, and expected-shortfall flag.
+7. Compute one-day `base_var` through the selected method.
+8. Compute `horizon_scale_factor = sqrt(horizon_days)`.
+9. Compute `metrics.VAR.value = base_var * horizon_scale_factor`.
+10. Count tail observations where `r_used_t_pp <= base_var`.
+11. Populate core details: method, confidence, tail probability, base horizon, horizon days,
+    horizon scale method, horizon scale factor, expected-shortfall flag, base VaR, observation
+    count, and tail observation count.
+12. When expected shortfall is enabled, compute and populate base expected shortfall,
+    expected-shortfall observation count, and horizon-scaled expected shortfall.
 
 ## Validation and Failure Behavior
-- Fewer than 2 observations: `details.error = "Insufficient data"`.
-- Unsupported method: `details.error = "Unsupported VaR method: <method>"`.
-- Non-numeric return values: rejected by request-contract validation before engine math.
-- ES tail set empty is handled deterministically by falling back to one-day VaR before scaling.
-- `horizon_days` must be positive by request-contract validation.
+- Fewer than two portfolio observations after period filtering, frequency compounding, and optional
+  transformation return `metrics.VAR.value = null` with `details.error = "Insufficient data"`.
+- Unsupported methods are rejected by request validation; the engine also fails closed with
+  `details.error = "Unsupported VaR method: <method>"` if an invalid method reaches calculation.
+- `options.var.confidence` must be greater than `0` and less than `1` by request-contract
+  validation.
+- `options.var.horizon_days` must be positive by request-contract validation.
+- Non-numeric return values are rejected by request validation before engine math.
+- Invalid log-return inputs that make `ln(1 + r_pp / 100)` undefined are rejected by request
+  validation or produce invalid numeric results before supportable output is claimed.
+- Expected-shortfall tail-set empty posture is deterministic: `base_expected_shortfall` falls back
+  to `base_var` before horizon scaling.
+- No benchmark dependency is required for `VAR`.
+- No risk-free dependency is required for `VAR`.
+- No annualization factor is used for `VAR`; horizon scaling is controlled only by
+  `options.var.horizon_days`.
 
 ## Configuration Options
+- `options.frequency`
+- `options.use_log_returns`
 - `options.var.method`
 - `options.var.confidence`
 - `options.var.horizon_days`
@@ -82,34 +132,71 @@
 
 ## Outputs
 - `results[period].metrics.VAR.value`
-- `results[period].metrics.VAR.details.expected_shortfall` (when enabled)
+- `results[period].metrics.VAR.details.method`
+- `results[period].metrics.VAR.details.confidence`
+- `results[period].metrics.VAR.details.tail_probability`
+- `results[period].metrics.VAR.details.base_horizon_days`
+- `results[period].metrics.VAR.details.horizon_days`
+- `results[period].metrics.VAR.details.horizon_scale_method`
+- `results[period].metrics.VAR.details.horizon_scale_factor`
+- `results[period].metrics.VAR.details.include_expected_shortfall`
+- `results[period].metrics.VAR.details.base_var`
+- `results[period].metrics.VAR.details.observation_count`
+- `results[period].metrics.VAR.details.tail_observation_count`
+- `results[period].metrics.VAR.details.base_expected_shortfall`
+- `results[period].metrics.VAR.details.expected_shortfall_observation_count`
+- `results[period].metrics.VAR.details.expected_shortfall`
 - `results[period].metrics.VAR.details.error`
 
 Consumer guidance:
-- Display VaR as a signed return-threshold unless a downstream UI explicitly transforms it into a positive loss convention.
-- Do not relabel positive VaR as a loss; explain that the selected period's lower-tail return threshold is positive.
+- Display VaR as a signed return threshold unless a downstream UI explicitly transforms it into a
+  positive loss convention.
+- Do not relabel positive VaR as a loss; explain that the selected period's lower-tail return
+  threshold is positive.
+- Downstream consumers must preserve source-owned signed VaR and expected-shortfall values rather
+  than recalculating or changing sign conventions locally.
 
 ## Worked Example
-Assume method `HISTORICAL`, confidence `0.95`, horizon `h=4`, ES enabled.
-Sample returns (pp): `[-2, -1, 0, 1, 2]`
+Assume:
+- method: `HISTORICAL`
+- confidence: `0.95`
+- horizon days: `h = 4`
+- expected shortfall: enabled
+- returns (pp): `[-2.00, -1.00, 0.00, 1.00, 2.00]`
+- `use_log_returns = false`
 
-| Sorted Index | Return (pp) |
-|---:|---:|
-| 0 | -2.0 |
-| 1 | -1.0 |
-| 2 | 0.0 |
-| 3 | 1.0 |
-| 4 | 2.0 |
+| Sorted index | `r_used_t_pp` |
+| ---: | ---: |
+| 0 | -2.00 |
+| 1 | -1.00 |
+| 2 | 0.00 |
+| 3 | 1.00 |
+| 4 | 2.00 |
 
 Intermediate calculations:
+- `N = 5`
 - `alpha = 1 - 0.95 = 0.05`
-- One-day VaR percentile position (`numpy percentile`, linear): between index 0 and 1 at 20% weight
-- `VaR_1d_pp = -2.0 + 0.2 * (-1.0 - (-2.0)) = -1.8`
-- `VaR_h_pp = -1.8 * sqrt(4) = -3.6`
-- Tail set for ES at one-day cutoff: `T = {r <= -1.8} = [-2.0]`
-- `ES_1d_pp = mean([-2.0]) = -2.0`
-- `ES_h_pp = -2.0 * sqrt(4) = -4.0`
+- NumPy percentile position for `5%` lies between sorted index `0` and `1` at `20%` weight.
+- `VaR_base_pp = -2.00 + 0.20 * (-1.00 - (-2.00)) = -1.8000000000`
+- `scale_h = sqrt(4) = 2.0000000000`
+- `VaR_h_pp = -1.8000000000 * 2.0000000000 = -3.6000000000`
+- `T = {r_used_t_pp <= -1.8000000000} = [-2.00]`
+- `ES_base_pp = mean([-2.00]) = -2.0000000000`
+- `ES_h_pp = -2.0000000000 * 2.0000000000 = -4.0000000000`
 
 Output mapping:
-- `results[period].metrics.VAR.value = -3.6`
-- `results[period].metrics.VAR.details.expected_shortfall = -4.0`
+- `results[period].metrics.VAR.value = -3.6000000000`
+- `results[period].metrics.VAR.details.method = "HISTORICAL"`
+- `results[period].metrics.VAR.details.confidence = 0.9500000000`
+- `results[period].metrics.VAR.details.tail_probability = 0.0500000000`
+- `results[period].metrics.VAR.details.base_horizon_days = 1`
+- `results[period].metrics.VAR.details.horizon_days = 4`
+- `results[period].metrics.VAR.details.horizon_scale_method = "SQRT_TIME"`
+- `results[period].metrics.VAR.details.horizon_scale_factor = 2.0000000000`
+- `results[period].metrics.VAR.details.include_expected_shortfall = true`
+- `results[period].metrics.VAR.details.base_var = -1.8000000000`
+- `results[period].metrics.VAR.details.observation_count = 5`
+- `results[period].metrics.VAR.details.tail_observation_count = 1`
+- `results[period].metrics.VAR.details.base_expected_shortfall = -2.0000000000`
+- `results[period].metrics.VAR.details.expected_shortfall_observation_count = 1`
+- `results[period].metrics.VAR.details.expected_shortfall = -4.0000000000`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -17,6 +17,7 @@ ROLLING_MAX_DRAWDOWN_DOC = (
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
 RISK_SORTINO_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sortino.md"
+RISK_VAR_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-var.md"
 RISK_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-beta.md"
 RISK_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-tracking-error.md"
@@ -276,6 +277,36 @@ def test_risk_sortino_methodology_is_auditable_against_engine_contract() -> None
         "6.1462967894",
         "0.0000785849",
         "0.0036711967",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_var_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_VAR_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: VAR",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "r_log_pp = ln(1 + r_pp / 100) * 100",
+        "`HISTORICAL`, `GAUSSIAN`, or `CORNISH_FISHER`",
+        "signed return thresholds in percentage points",
+        "HISTORICAL`: `VaR_base_pp = percentile(r_used_pp, alpha * 100)`",
+        "GAUSSIAN`: `VaR_base_pp = mu_pp + sigma_pp * z_alpha`",
+        "`z_cf = z_alpha + ((z_alpha^2 - 1) * S) / 6",
+        '`metrics.VAR.value = null` with `details.error = "Insufficient data"',
+        "No benchmark dependency is required for `VAR`",
+        "No risk-free dependency is required for `VAR`",
+        "No annualization factor is used for `VAR`",
+        "results[period].metrics.VAR.details.horizon_scale_method",
+        "results[period].metrics.VAR.details.expected_shortfall",
+        "-3.6000000000",
+        "-1.8000000000",
+        "-4.0000000000",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -76,6 +76,52 @@ def test_calculate_risk_var_methods() -> None:
     assert len(set(results)) >= 2
 
 
+def test_var_matches_documented_signed_percentage_point_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-05", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["VAR"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": False,
+            "var": {
+                "method": "HISTORICAL",
+                "confidence": 0.95,
+                "horizon_days": 4,
+                "include_expected_shortfall": True,
+            },
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": -2.0},
+            {"date": "2026-01-02", "value": -1.0},
+            {"date": "2026-01-03", "value": 0.0},
+            {"date": "2026-01-04", "value": 1.0},
+            {"date": "2026-01-05", "value": 2.0},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["VAR"]
+    assert metric.value == pytest.approx(-3.6)
+    assert metric.details is not None
+    assert metric.details["method"] == "HISTORICAL"
+    assert metric.details["confidence"] == pytest.approx(0.95)
+    assert metric.details["tail_probability"] == pytest.approx(0.05)
+    assert metric.details["base_horizon_days"] == 1
+    assert metric.details["horizon_days"] == 4
+    assert metric.details["horizon_scale_method"] == "SQRT_TIME"
+    assert metric.details["horizon_scale_factor"] == pytest.approx(2.0)
+    assert metric.details["include_expected_shortfall"] is True
+    assert metric.details["base_var"] == pytest.approx(-1.8)
+    assert metric.details["observation_count"] == 5
+    assert metric.details["tail_observation_count"] == 1
+    assert metric.details["base_expected_shortfall"] == pytest.approx(-2.0)
+    assert metric.details["expected_shortfall_observation_count"] == 1
+    assert metric.details["expected_shortfall"] == pytest.approx(-4.0)
+
+
 def test_volatility_matches_documented_percentage_point_output_contract() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -23,19 +23,21 @@
 ## Implementation-backed methodology coverage
 
 `RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, Sharpe,
-Sortino, beta, tracking error, and information ratio. The methodologies are tied to the implemented
+Sortino, VaR, beta, tracking error, and information ratio. The methodologies are tied to the implemented
 `/analytics/risk/calculate` engine and state the exact percentage-point input convention, optional
 log-return transform, frequency compounding before metric calculation, `ddof=1` sample standard
-deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, tracking-error,
-and information-ratio details, percentage-point-squared beta covariance/benchmark-variance
+deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, VaR,
+tracking-error, and information-ratio details, percentage-point-squared beta covariance/benchmark-variance
 details, annualized percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-`metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, dimensionless slope
-`metrics.BETA.value`, annualized percentage-point `metrics.TRACKING_ERROR.value`, dimensionless
+`metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, signed
+percentage-point `metrics.VAR.value`, dimensionless slope `metrics.BETA.value`, annualized
+percentage-point `metrics.TRACKING_ERROR.value`, dimensionless
 annualized `metrics.INFORMATION_RATIO.value`, annualization-factor resolution where used,
 benchmark dependency for beta, tracking error, and information ratio, no benchmark dependency for
-Sharpe and Sortino, no risk-free dependency for volatility, Sortino, beta, tracking error, and
-information ratio, no-denominator posture for volatility and tracking error, zero-volatility
-fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+Sharpe, Sortino, and VaR, no risk-free dependency for volatility, Sortino, VaR, beta, tracking
+error, and information ratio, no-denominator posture for volatility and tracking error,
+zero-volatility fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
+signed VaR loss-threshold posture, square-root horizon scaling,
 zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture for
 information ratio, constant-active-return zero tracking-error posture, and insufficient-data
 failure behavior.
@@ -85,8 +87,9 @@ Audience notes:
   peak-to-trough loss inside each rolling return window.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period, Sharpe as annualized excess return per
-  unit of portfolio return volatility, and Sortino as annualized excess return over MAR per unit of
-  downside deviation. Beta is the period sensitivity slope of portfolio returns to benchmark return
+  unit of portfolio return volatility, Sortino as annualized excess return over MAR per unit of
+  downside deviation, and VaR as a signed lower-tail return threshold in percentage points. Beta is
+  the period sensitivity slope of portfolio returns to benchmark return
   variance after strict date alignment, and tracking error is annualized active-return volatility
   versus the selected benchmark for the resolved period. Information ratio is annualized active
   return per unit of tracking error for the same period.
@@ -98,7 +101,7 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, Sharpe,
-  Sortino, beta, tracking-error, and information-ratio values and supportability metadata rather than
+  Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort


### PR DESCRIPTION
## Summary
- upgrade isk-var.md to v3 methodology truth for RiskMetricsReport:v1
- pin signed VaR and expected-shortfall engine behavior with documentation and engine regressions
- update Risk repository context and Mesh Data Products wiki source for source-owner VaR support

## Validation
- python -m pytest tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py -q
- python -m ruff check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- python -m ruff format --check tests/unit/test_methodology_docs.py tests/unit/test_risk_engine.py
- git diff --check
- make test-pyramid-gate
- make check
- python ..\lotus-platform\automation\validate_engineering_context_system.py
- python ..\lotus-platform\automation\validate_lotus_skill_alignment.py
- ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)