### PR TITLE
docs(risk): pin drawdown methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -50,13 +50,16 @@ Current repository posture:
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
 11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
-    `SHARPE`, `SORTINO`, `VAR`, `BETA`, `TRACKING_ERROR`, and `INFORMATION_RATIO`: the docs and tests pin
+    `DRAWDOWN`, `SHARPE`, `SORTINO`, `VAR`, `BETA`, `TRACKING_ERROR`, and
+    `INFORMATION_RATIO`: the docs and tests pin
     percentage-point input conventions, optional
-    log-return transformation, frequency compounding before metric calculation, `ddof=1` sample
+    log-return transformation, frequency compounding before metric calculation, drawdown
+    cumulative-wealth/running-peak behavior, `ddof=1` sample
     standard deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, VaR,
     tracking-error, and information-ratio details,
     percentage-point-squared beta covariance/benchmark-variance details, annualized
-    percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
+    percentage-point `metrics.VOLATILITY.value`, signed percentage-point
+    `metrics.DRAWDOWN.value`, dimensionless annualized
     `metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, signed
     percentage-point `metrics.VAR.value`, dimensionless slope `metrics.BETA.value`,
     annualized percentage-point `metrics.TRACKING_ERROR.value`,
@@ -65,9 +68,10 @@ Current repository posture:
     annualized-excess-return, and downside-deviation detail fields, signed VaR base, horizon, and
     expected-shortfall detail fields, default and override
     annualization-factor resolution where used, benchmark dependency posture for beta, tracking
-    error, and information ratio, no benchmark dependency posture for Sharpe, Sortino, and VaR, no
-    risk-free dependency posture for volatility, Sortino, VaR, beta, tracking error, and
-    information ratio, no-denominator posture for volatility and tracking error, zero-volatility
+    error, and information ratio, no benchmark dependency posture for Drawdown, Sharpe, Sortino,
+    and VaR, no risk-free dependency posture for volatility, Drawdown, Sortino, VaR, beta,
+    tracking error, and information ratio, no-annualization-factor posture for Drawdown, no-denominator posture for
+    volatility and tracking error, zero-volatility
     fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
     signed VaR loss-threshold posture, square-root horizon scaling,
     zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture

--- a/docs/methodologies/metrics/risk-drawdown.md
+++ b/docs/methodologies/metrics/risk-drawdown.md
@@ -6,41 +6,88 @@
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/calculate
 - supported_modes: stateless, stateful
+- source product: `RiskMetricsReport:v1`
 
 ## Inputs
-- Portfolio return series in pp for selected period.
+- Portfolio return observations for the resolved period, with at least two observations after
+  period filtering and frequency resampling.
+- Calculation frequency: `DAILY`, `WEEKLY`, or `MONTHLY`.
+- Optional log-return transform flag is accepted on the shared risk-calculation contract but is
+  not used by `DRAWDOWN`.
 
 ## Upstream Data Sources
-- Stateless caller returns; stateful lotus-performance returns.
+- Stateless mode: caller-provided `returns`.
+- Stateful mode: `lotus-performance` portfolio return series fetched through the governed
+  risk-calculate integration path.
+- `lotus-risk` owns the drawdown calculation after dated portfolio return series are resolved. It
+  does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
 - Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when required: `r_decimal = r_pp / 100`.
-- Output units are metric-specific (ratio, annualized pp, decimal drawdown, or HHI scale).
+- Frequency resampling compounds percentage-point returns and emits percentage-point period
+  returns.
+- The engine converts percentage-point returns to decimal only inside the cumulative wealth path:
+  `r_decimal = r_pp / 100`.
+- `options.use_log_returns` is not applied to `DRAWDOWN`; the drawdown path is calculated from the
+  simple compounded return series.
+- `metrics.DRAWDOWN.value` and `details.max_drawdown` are signed percentage-point outputs:
+  `-20.0` means a `-20.0%` maximum peak-to-trough drawdown.
 
 ## Variable Dictionary
-- `r_t_pp`: period return at index `t` in percentage points.
-- `r_t = r_t_pp/100`: decimal return.
-- `W_t`: cumulative wealth index.
-- `P_t`: running peak wealth.
-- `DD_t = W_t/P_t - 1`: drawdown decimal.
-- `MDD_pp = min(DD_t)*100`: endpoint metric value in pp.
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points after period filtering and optional
+  frequency resampling.
+- `r_t_decimal`: `r_t_pp / 100`.
+- `W_t`: cumulative wealth index through date `t`, `product(1 + r_i_decimal)` for `i <= t`.
+- `P_t`: running peak wealth through date `t`, `max(W_i)` for `i <= t`.
+- `DD_t`: decimal drawdown ratio on date `t`, `W_t / P_t - 1`.
+- `T`: trough date where `DD_t` is minimal.
+- `P`: peak date selected from the maximum wealth value at or before `T`.
+- `MDD_pp`: signed percentage-point maximum drawdown output, `DD_T * 100`.
 
 ## Methodology and Formulas
-1. Convert returns to decimal and build wealth path.
-2. Build running peak path.
-3. Compute drawdown path.
-4. Select minimum drawdown and convert to pp output.
+1. Resolve the requested period from `scope.as_of_date`, `portfolio_open_date`, and the period
+   definition.
+2. Filter portfolio returns to the resolved period.
+3. Resample returns when `options.frequency` is not `DAILY`:
+   `r_period_pp = (product(1 + r_i_pp / 100) - 1) * 100`.
+4. Do not apply `options.use_log_returns`; drawdown uses the simple percentage-point return series.
+5. Require at least two non-null observations.
+6. Build cumulative wealth:
+   `W_t = product(1 + r_i_pp / 100)`.
+7. Build running peak wealth:
+   `P_t = max(W_i)` for `i <= t`.
+8. Compute the drawdown path:
+   `DD_t = W_t / P_t - 1`.
+9. Select the trough date:
+   `T = argmin(DD_t)`.
+10. Select the peak date from the maximum wealth value at or before `T`.
+11. Map response value and details:
+    `metrics.DRAWDOWN.value = details.max_drawdown = DD_T * 100`.
 
 ## Step-by-Step Computation
-1. Resolve period and series.
-2. Compute wealth/peak/drawdown.
-3. Find min drawdown and peak/trough metadata.
-4. Emit value and details.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Apply weekly or monthly compounding when requested.
+5. Validate that at least two observations remain.
+6. Compute cumulative wealth, running peak, and decimal drawdown paths.
+7. Identify the trough date where drawdown is most negative.
+8. Identify the peak date as the maximum cumulative wealth at or before the trough.
+9. Search for the first post-trough recovery date where wealth is greater than or equal to the
+   trough-date running peak.
+10. Preserve signed percentage-point drawdown value and episode timing details for auditability.
 
 ## Validation and Failure Behavior
-- Fewer than 2 observations -> `Insufficient data`.
-- Value is non-positive in pp for this endpoint metric.
+- Fewer than two observations after period filtering and resampling returns
+  `metrics.DRAWDOWN.value = null` with `details.error = "Insufficient data"`.
+- A non-loss path is valid and produces `metrics.DRAWDOWN.value = 0.0`.
+- Non-numeric return values are rejected by request-contract validation before engine math.
+- No benchmark dependency is required for `DRAWDOWN`.
+- No risk-free dependency is required for `DRAWDOWN`.
+- No annualization factor is used for `DRAWDOWN`.
+- No denominator is used beyond the running peak wealth path, so there is no zero-volatility,
+  zero-tracking-error, or zero-benchmark-variance failure mode.
 
 ## Configuration Options
 - `options.frequency`
@@ -48,15 +95,46 @@
 ## Outputs
 - `results[period].metrics.DRAWDOWN.value`
 - `results[period].metrics.DRAWDOWN.details.max_drawdown`
-- `...details.peak_date`
-- `...details.trough_date`
+- `results[period].metrics.DRAWDOWN.details.peak_date`
+- `results[period].metrics.DRAWDOWN.details.trough_date`
+- `results[period].metrics.DRAWDOWN.details.max_drawdown_date`
+- `results[period].metrics.DRAWDOWN.details.recovery_date`
+- `results[period].metrics.DRAWDOWN.details.is_recovered`
+- `results[period].metrics.DRAWDOWN.details.days_to_trough`
+- `results[period].metrics.DRAWDOWN.details.days_to_recovery`
+- `results[period].metrics.DRAWDOWN.details.time_under_water_days`
+- `results[period].metrics.DRAWDOWN.details.error`
 
 ## Worked Example
-Returns pp `[10,-20,5]`.
-| Date | Return pp | Wealth | Peak | Drawdown (decimal) |
-|---|---:|---:|---:|---:|
-| Day1 | 10.0 | 1.1000 | 1.1000 | 0.0000 |
-| Day2 | -20.0 | 0.8800 | 1.1000 | -0.2000 |
-| Day3 | 5.0 | 0.9240 | 1.1000 | -0.1600 |
-`MDD_pp = -0.2000 * 100 = -20.0`.
-Output mapping: `results[period].metrics.DRAWDOWN.value=-20.0`.
+Assume daily frequency and portfolio return observations:
+
+| Date | `r_t_pp` | `W_t` | `P_t` | `DD_t` |
+| --- | ---: | ---: | ---: | ---: |
+| 2026-01-01 | `10.00` | `1.1000000000` | `1.1000000000` | `0.0000000000` |
+| 2026-01-02 | `-20.00` | `0.8800000000` | `1.1000000000` | `-0.2000000000` |
+| 2026-01-03 | `5.00` | `0.9240000000` | `1.1000000000` | `-0.1600000000` |
+
+Intermediate calculations:
+
+| Step | Value |
+| --- | ---: |
+| Trough date | `2026-01-02` |
+| Peak date at or before trough | `2026-01-01` |
+| Minimum decimal drawdown `DD_T` | `-0.2000000000` |
+| `MDD_pp = DD_T * 100` | `-20.0000000000` |
+| Recovered by period end | `false` |
+| Days from peak to trough | `1` |
+| Time under water through period end | `2` |
+
+Output mapping:
+
+- `results[period].metrics.DRAWDOWN.value = -20.0000000000`
+- `results[period].metrics.DRAWDOWN.details.max_drawdown = -20.0000000000`
+- `results[period].metrics.DRAWDOWN.details.peak_date = "2026-01-01"`
+- `results[period].metrics.DRAWDOWN.details.trough_date = "2026-01-02"`
+- `results[period].metrics.DRAWDOWN.details.max_drawdown_date = "2026-01-02"`
+- `results[period].metrics.DRAWDOWN.details.recovery_date = null`
+- `results[period].metrics.DRAWDOWN.details.is_recovered = false`
+- `results[period].metrics.DRAWDOWN.details.days_to_trough = 1`
+- `results[period].metrics.DRAWDOWN.details.days_to_recovery = null`
+- `results[period].metrics.DRAWDOWN.details.time_under_water_days = 2`

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -15,6 +15,7 @@ ROLLING_MAX_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-max-drawdown.md"
 )
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
+RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
 RISK_SORTINO_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sortino.md"
 RISK_VAR_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-var.md"
@@ -220,6 +221,33 @@ def test_risk_volatility_methodology_is_auditable_against_engine_contract() -> N
         "results[period].metrics.VOLATILITY.value",
         "11.9146968069",
         "0.0075055535",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_risk_drawdown_methodology_is_auditable_against_engine_contract() -> None:
+    text = RISK_DRAWDOWN_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: DRAWDOWN",
+        "/analytics/risk/calculate",
+        "lotus-performance",
+        "not used by `DRAWDOWN`",
+        "r_decimal = r_pp / 100",
+        "signed percentage-point outputs",
+        '`metrics.DRAWDOWN.value = null` with `details.error = "Insufficient data"',
+        "No benchmark dependency is required for `DRAWDOWN`",
+        "No risk-free dependency is required for `DRAWDOWN`",
+        "No annualization factor is used for `DRAWDOWN`",
+        "results[period].metrics.DRAWDOWN.value",
+        "results[period].metrics.DRAWDOWN.details.time_under_water_days",
+        "-20.0000000000",
+        'details.peak_date = "2026-01-01"',
+        "time_under_water_days = 2",
     ]
 
     for phrase in required_truth:

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -149,6 +149,39 @@ def test_volatility_matches_documented_percentage_point_output_contract() -> Non
     assert metric.details["annualization_factor"] == 252
 
 
+def test_drawdown_matches_documented_signed_percentage_point_output_contract() -> None:
+    payload = {
+        "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},
+        "portfolio_open_date": "2026-01-01",
+        "periods": [{"type": "YTD", "name": "YTD"}],
+        "metrics": ["DRAWDOWN"],
+        "options": {
+            "frequency": "DAILY",
+            "use_log_returns": True,
+        },
+        "returns": [
+            {"date": "2026-01-01", "value": 10.00},
+            {"date": "2026-01-02", "value": -20.00},
+            {"date": "2026-01-03", "value": 5.00},
+        ],
+    }
+
+    response = calculate_risk(RiskCalculationRequest.model_validate(payload))
+
+    metric = response.results["YTD"].metrics["DRAWDOWN"]
+    assert metric.value == pytest.approx(-20.0)
+    assert metric.details is not None
+    assert metric.details["max_drawdown"] == pytest.approx(-20.0)
+    assert metric.details["peak_date"] == "2026-01-01"
+    assert metric.details["trough_date"] == "2026-01-02"
+    assert metric.details["max_drawdown_date"] == "2026-01-02"
+    assert metric.details["recovery_date"] is None
+    assert metric.details["is_recovered"] is False
+    assert metric.details["days_to_trough"] == 1
+    assert metric.details["days_to_recovery"] is None
+    assert metric.details["time_under_water_days"] == 2
+
+
 def test_sharpe_matches_documented_dimensionless_output_contract() -> None:
     payload = {
         "scope": {"as_of_date": "2026-01-03", "net_or_gross": "NET"},

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -22,20 +22,23 @@
 
 ## Implementation-backed methodology coverage
 
-`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, Sharpe,
-Sortino, VaR, beta, tracking error, and information ratio. The methodologies are tied to the implemented
+`RiskMetricsReport:v1` now has auditable source-owner methodology truth for volatility, drawdown,
+Sharpe, Sortino, VaR, beta, tracking error, and information ratio. The methodologies are tied to the implemented
 `/analytics/risk/calculate` engine and state the exact percentage-point input convention, optional
-log-return transform, frequency compounding before metric calculation, `ddof=1` sample standard
+log-return transform, frequency compounding before metric calculation, drawdown
+cumulative-wealth/running-peak behavior, `ddof=1` sample standard
 deviation/covariance/variance behavior, decimal volatility, risk-free, Sortino, VaR,
 tracking-error, and information-ratio details, percentage-point-squared beta covariance/benchmark-variance
-details, annualized percentage-point `metrics.VOLATILITY.value`, dimensionless annualized
-`metrics.SHARPE.value`, dimensionless annualized `metrics.SORTINO.value`, signed
+details, annualized percentage-point `metrics.VOLATILITY.value`, signed percentage-point
+`metrics.DRAWDOWN.value`, dimensionless annualized `metrics.SHARPE.value`, dimensionless
+annualized `metrics.SORTINO.value`, signed
 percentage-point `metrics.VAR.value`, dimensionless slope `metrics.BETA.value`, annualized
 percentage-point `metrics.TRACKING_ERROR.value`, dimensionless
 annualized `metrics.INFORMATION_RATIO.value`, annualization-factor resolution where used,
 benchmark dependency for beta, tracking error, and information ratio, no benchmark dependency for
-Sharpe, Sortino, and VaR, no risk-free dependency for volatility, Sortino, VaR, beta, tracking
-error, and information ratio, no-denominator posture for volatility and tracking error,
+Drawdown, Sharpe, Sortino, and VaR, no risk-free dependency for volatility, Drawdown, Sortino,
+VaR, beta, tracking error, and information ratio, no-annualization-factor posture for Drawdown,
+no-denominator posture for volatility and tracking error,
 zero-volatility fail-closed posture for Sharpe, no-downside-observation fail-closed posture for Sortino,
 signed VaR loss-threshold posture, square-root horizon scaling,
 zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture for
@@ -86,7 +89,8 @@ Audience notes:
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
-  dispersion in percentage points for the resolved period, Sharpe as annualized excess return per
+  dispersion in percentage points for the resolved period, Drawdown as signed percentage-point
+  maximum peak-to-trough loss, Sharpe as annualized excess return per
   unit of portfolio return volatility, Sortino as annualized excess return over MAR per unit of
   downside deviation, and VaR as a signed lower-tail return threshold in percentage points. Beta is
   the period sensitivity slope of portfolio returns to benchmark return
@@ -100,8 +104,8 @@ Audience notes:
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
-- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, Sharpe,
-  Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
+- Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
+  Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort


### PR DESCRIPTION
## Summary
- promote non-rolling `DRAWDOWN` methodology for `RiskMetricsReport:v1` to the v3 auditable standard
- pin signed percentage-point output, simple-return drawdown behavior, episode timing fields, and no benchmark/risk-free/annualization dependency posture
- update Risk repo context and repo-authored wiki source for implementation-backed DRAWDOWN methodology truth

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_risk_engine.py -q` -> 30 passed
- `python -m ruff check tests\unit\test_methodology_docs.py tests\unit\test_risk_engine.py`
- `python -m ruff format --check tests\unit\test_methodology_docs.py tests\unit\test_risk_engine.py`
- `git diff --check` -> only CRLF warnings for markdown/test files
- `make check` -> 340 unit tests passed plus Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, and domain-data-product gates
- `make test-pyramid-gate` -> unit 340 / integration 94 / e2e 23 within policy
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift: `Mesh-Data-Products.md`

## Notes
- No `lotus-gateway` or `lotus-workbench` files changed; those repos remain reserved for the other active agent.
- This advances RFC42-WTBD-006 and does not close the WTBD.