### PR TITLE
docs(risk): pin max drawdown methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -87,6 +87,12 @@ Current repository posture:
     warm-up/null behavior, source-owned risk-free/benchmark alignment posture, no-aligned
     dependency supportability posture, zero-excess-volatility Sharpe flagging,
     zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
+13. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
+    `MAX_DRAWDOWN`: the docs and tests pin percentage-point input conventions, decimal
+    cumulative-wealth/running-peak drawdown behavior, decimal `summary.max_drawdown` output,
+    episode peak/trough/recovery semantics, empty-period insufficient-data posture, never-underwater
+    zero-drawdown posture, duration-unit day counter behavior, and episode-list filter isolation
+    from the summary maximum drawdown value.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/drawdown-max-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-max-drawdown.md
@@ -6,79 +6,105 @@
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/drawdown
 - supported_modes: stateless, stateful
+- source product: `DrawdownAnalyticsReport:v1`
 
 ## Inputs
-- Portfolio return time series for the resolved period.
+- Portfolio return observations for the resolved period.
 - Return contract unit: percentage points (`value=1.0` means `+1%`).
-- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, etc.).
+- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, `QTD`, `MTD`, `1Y`, `3Y`,
+  `5Y`, or `SI`).
+- Drawdown analysis options controlling duration convention, underwater-series inclusion, and
+  episode-list filtering.
 
 ## Upstream Data Sources
-- Stateless:
-  - caller provides `stateless_input.returns[]`.
-- Stateful:
-  - lotus-risk sources `series.portfolio_returns` from lotus-performance `/integration/returns/series`.
+- Stateless mode: caller-provided `stateless_input.returns[]`.
+- Stateful mode: `lotus-risk` sources `series.portfolio_returns` from
+  `lotus-performance` `/integration/returns/series` through the governed drawdown stateful
+  adapter.
+- `lotus-risk` owns the maximum-drawdown calculation after dated portfolio return series are
+  resolved. It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
-- Input return values are provided in percentage points in the API contract.
-- Engine computation normalizes to decimal for wealth-path math:
-  - `r_decimal = r_percentage_points / 100`
-- `MAX_DRAWDOWN` output is in decimal drawdown units (for example `-0.10` means `-10%`).
+- Input return values are percentage points: `5.0` means `+5.0%`.
+- The engine converts percentage-point returns to decimal only inside the wealth path:
+  `r_decimal = r_pp / 100`.
+- `summary.max_drawdown` and episode `depth` values are decimal drawdown ratios:
+  `-0.2000` means a `-20.00%` peak-to-trough drawdown.
+- `analysis_options.duration_unit` changes day counters only; it does not change the drawdown
+  ratio.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` filter the
+  optional episode list only; they do not change `summary.max_drawdown`.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: period return at index `t` in percentage points.
-- `r_t`: period return at index `t` in decimal (`r_t = r_t_pp / 100`).
-- `W_t`: cumulative wealth index up to `t`.
-- `P_t`: running peak wealth up to `t`.
-- `DD_t`: drawdown at `t`.
-- `MDD`: maximum drawdown over the analysis window.
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_decimal`: `r_t_pp / 100`.
+- `W_t`: cumulative wealth index through date `t`, `product(1 + r_i_decimal)` for `i <= t`.
+- `P_t`: running peak wealth through date `t`, `max(W_i)` for `i <= t`.
+- `DD_t`: decimal drawdown ratio on date `t`, `W_t / P_t - 1`.
+- `E`: set of drawdown episodes, where an episode starts when `DD_t < 0` after a non-underwater
+  observation and ends when `DD_t >= 0` or period end is reached.
+- `depth_e`: minimum `DD_t` inside episode `e`.
+- `MDD`: maximum drawdown summary value, `min(depth_e)` when episodes exist, otherwise `0.0`.
 
 ## Methodology and Formulas
-1. Convert returns from pp to decimal:
-`r_t = r_t_pp / 100`.
-2. Construct cumulative wealth path:
-`W_t = ∏_{i=1..t}(1 + r_i)`.
-3. Construct running peak path:
-`P_t = max(W_1, W_2, ..., W_t)`.
-4. Construct drawdown path:
-`DD_t = (W_t / P_t) - 1`.
-5. Maximum drawdown:
-`MDD = min_t(DD_t)`.
-6. Episode attribution:
-- Peak date is the date of `argmax(W_i)` over `i <= trough_index`.
-- Trough date is the date of `argmin(DD_t)`.
-- Recovery date is first date after trough where `DD_t >= 0`; else `null`.
+1. Resolve the requested period from `scope.as_of_date`, the first return observation date, and the
+   period definition.
+2. Filter portfolio returns to the resolved period.
+3. Require at least one observation in the resolved period; an empty period emits period-level
+   error `"Insufficient data"`.
+4. Convert percentage-point returns to decimal:
+   `r_t_decimal = r_t_pp / 100`.
+5. Build cumulative wealth:
+   `W_t = product(1 + r_i_decimal)` for `i <= t`.
+6. Build running peak wealth:
+   `P_t = max(W_i)` for `i <= t`.
+7. Build decimal drawdown path:
+   `DD_t = W_t / P_t - 1`.
+8. Extract episodes from the drawdown path:
+   - a new episode starts at the first underwater observation where `DD_t < 0`;
+   - `peak_date` is the previous observation date when one exists, otherwise the underwater date;
+   - `trough_date` is the date of the minimum `DD_t` in the episode;
+   - `recovery_date` is the first date in that episode where `DD_t >= 0`; unrecovered episodes use
+     `null`.
+9. Select the maximum-drawdown episode:
+   `max_episode = argmin(depth_e)`.
+10. Map summary output:
+    `summary.max_drawdown = depth_max_episode`.
 
 ## Step-by-Step Computation
-1. Resolve the analysis period and extract portfolio returns for that period.
-2. Sort observations ascending by date; discard points outside the resolved period.
-3. Validate minimum data:
-- if no points are present, period result is returned with error (`Insufficient data`);
-- if only one point exists, drawdown path is degenerate and summary fields follow engine fallback.
-4. Convert pp returns to decimal.
-5. Compute `W_t`, `P_t`, and `DD_t` for each date.
-6. Compute `MDD = min_t(DD_t)`.
-7. Find trough index from `argmin(DD_t)`.
-8. Find peak index from `argmax(W_i)` where `i <= trough_index`.
-9. Determine recovery date as first post-trough date with `DD_t >= 0`, else `null`.
-10. Map values into response summary fields.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Return a period-level `"Insufficient data"` error when the filtered period is empty.
+5. Compute cumulative wealth, running peak, and drawdown paths.
+6. Build all drawdown episodes from contiguous underwater spans.
+7. Compute `summary.max_drawdown` from the deepest episode.
+8. Preserve peak date, trough date, recovery date, recovery flag, days-to-trough,
+   days-to-recovery, and time-under-water fields from the selected deepest episode.
+9. Build optional `episodes[]` from filtered/sorted episodes when `include_episode_list=true`.
+10. Build optional `underwater_series[]` when `include_underwater_series=true`.
 
 ## Validation and Failure Behavior
-- Missing return series for the period: return period error `Insufficient data`.
-- Non-numeric return entries: rejected at request-contract validation layer before engine math.
-- Episode recovery not reached before period end: `max_drawdown_recovery_date = null`, `is_recovered = false`.
-- Configuration options (`top_n_episodes`, `minimum_episode_depth_bps`) do not alter numeric `max_drawdown`, only episode list payload.
+- Empty service-level return input returns an empty `results` map.
+- Empty return series for a requested period returns that period with `summary = null`,
+  `episodes = []`, and `error = "Insufficient data"`.
+- A one-observation or never-underwater period is valid and emits `summary.max_drawdown = 0.0`,
+  no peak/trough/recovery dates, `is_recovered = true`, and zero day counters.
+- Non-numeric return entries are rejected by request-contract validation before engine math.
+- Episode recovery not reached before period end emits `max_drawdown_recovery_date = null`,
+  `is_recovered = false`, and `days_to_recovery = null`.
+- `analysis_options.duration_unit` changes `days_to_trough`, `days_to_recovery`, and episode
+  `total_days` only.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` do not alter
+  `summary.max_drawdown`.
 
 ## Configuration Options
-- `analysis_options.duration_unit`:
-  - controls episode day counters (`BUSINESS_DAYS` vs `CALENDAR_DAYS`)
-  - does not change numeric `MAX_DRAWDOWN`.
-- `analysis_options.include_episode_list`:
-  - controls whether episodes are emitted in response
-  - does not change summary max drawdown value.
-- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps`:
-  - affect episode list selection
-  - do not change summary max drawdown value.
+- `analysis_options.duration_unit`
+- `analysis_options.include_underwater_series`
+- `analysis_options.include_episode_list`
+- `analysis_options.top_n_episodes`
+- `analysis_options.minimum_episode_depth_bps`
 
 ## Outputs
 - `results[period].summary.max_drawdown`
@@ -88,20 +114,43 @@
 - `results[period].summary.is_recovered`
 - `results[period].summary.days_to_trough`
 - `results[period].summary.days_to_recovery`
+- `results[period].summary.time_under_water_days`
+- `results[period].episodes[].depth`
+- `results[period].underwater_series[].drawdown`
+- `results[period].error`
 
 ## Worked Example
-Input return sequence (pp): Day1 `+5.00`, Day2 `-10.00`, Day3 `+2.00`, Day4 `+4.00`.
+Assume business-day duration, `include_episode_list=true`, `include_underwater_series=true`, and
+portfolio return observations:
 
-| Date | `r_t_pp` | `r_t` (decimal) | `W_t` | `P_t` | `DD_t = W_t/P_t - 1` |
-|---|---:|---:|---:|---:|---:|
-| Day1 | 5.00 | 0.0500 | 1.050000 | 1.050000 | 0.000000 |
-| Day2 | -10.00 | -0.1000 | 0.945000 | 1.050000 | -0.100000 |
-| Day3 | 2.00 | 0.0200 | 0.963900 | 1.050000 | -0.082000 |
-| Day4 | 4.00 | 0.0400 | 1.002456 | 1.050000 | -0.045280 |
+| Date | `r_t_pp` | `W_t` | `P_t` | `DD_t` |
+| --- | ---: | ---: | ---: | ---: |
+| 2026-01-02 | `10.00` | `1.1000000000` | `1.1000000000` | `0.0000000000` |
+| 2026-01-05 | `-20.00` | `0.8800000000` | `1.1000000000` | `-0.2000000000` |
+| 2026-01-06 | `30.00` | `1.1440000000` | `1.1440000000` | `0.0000000000` |
 
-Derived outputs:
-- `max_drawdown = min(DD_t) = -0.100000` (`-10.00%`).
-- `max_drawdown_peak_date = Day1`.
-- `max_drawdown_trough_date = Day2`.
-- `max_drawdown_recovery_date = null` (drawdown never returned to `>= 0` by Day4).
-- `is_recovered = false`.
+Intermediate calculations:
+
+| Step | Value |
+| --- | ---: |
+| Episode start date | `2026-01-05` |
+| Episode peak date | `2026-01-02` |
+| Episode trough date | `2026-01-05` |
+| Episode recovery date | `2026-01-06` |
+| Episode depth | `-0.2000000000` |
+| `summary.max_drawdown` | `-0.2000000000` |
+| Business days from peak to trough | `1` |
+| Business days from trough to recovery | `1` |
+
+Output mapping:
+
+- `results[period].summary.max_drawdown = -0.2000000000`
+- `results[period].summary.max_drawdown_peak_date = "2026-01-02"`
+- `results[period].summary.max_drawdown_trough_date = "2026-01-05"`
+- `results[period].summary.max_drawdown_recovery_date = "2026-01-06"`
+- `results[period].summary.is_recovered = true`
+- `results[period].summary.days_to_trough = 1`
+- `results[period].summary.days_to_recovery = 1`
+- `results[period].summary.time_under_water_days = 1`
+- `results[period].episodes[0].depth = -0.2000000000`
+- `results[period].underwater_series[1].drawdown = -0.2000000000`

--- a/tests/unit/test_drawdown_engine.py
+++ b/tests/unit/test_drawdown_engine.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from app.contracts.drawdown import (
     DrawdownAnalysisOptions,
@@ -77,6 +78,50 @@ def test_drawdown_engine_returns_period_summary_episode_and_underwater() -> None
     assert response.metadata.duration_unit == "BUSINESS_DAYS"
     assert response.metadata.include_benchmark is None
     assert response.metadata.missing_benchmark_policy is None
+
+
+def test_drawdown_max_drawdown_matches_documented_decimal_output_contract() -> None:
+    request = DrawdownStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-06", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-02", "value": 10.0},
+                {"date": "2026-01-05", "value": -20.0},
+                {"date": "2026-01-06", "value": 30.0},
+            ],
+        }
+    )
+
+    response = calculate_drawdown(
+        request,
+        input_mode=DrawdownInputMode.STATELESS,
+        analysis_options=DrawdownAnalysisOptions.model_validate(
+            {
+                "duration_unit": "BUSINESS_DAYS",
+                "include_underwater_series": True,
+                "include_episode_list": True,
+            }
+        ),
+    )
+
+    period = response.results["YTD"]
+    assert period.error is None
+    assert period.summary is not None
+    assert period.summary.max_drawdown == pytest.approx(-0.2)
+    assert str(period.summary.max_drawdown_peak_date) == "2026-01-02"
+    assert str(period.summary.max_drawdown_trough_date) == "2026-01-05"
+    assert str(period.summary.max_drawdown_recovery_date) == "2026-01-06"
+    assert period.summary.is_recovered is True
+    assert period.summary.days_to_trough == 1
+    assert period.summary.days_to_recovery == 1
+    assert period.summary.time_under_water_days == 1
+    assert period.episodes[0].depth == pytest.approx(-0.2)
+    assert str(period.episodes[0].peak_date) == "2026-01-02"
+    assert str(period.episodes[0].trough_date) == "2026-01-05"
+    assert str(period.episodes[0].recovery_date) == "2026-01-06"
+    assert period.underwater_series is not None
+    assert period.underwater_series[1].drawdown == pytest.approx(-0.2)
 
 
 def test_drawdown_engine_handles_empty_returns() -> None:

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -14,6 +14,9 @@ ROLLING_BETA_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-b
 ROLLING_MAX_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "rolling-max-drawdown.md"
 )
+DRAWDOWN_MAX_DRAWDOWN_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-max-drawdown.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -195,6 +198,35 @@ def test_rolling_max_drawdown_methodology_is_auditable_against_engine_contract()
         "metric_summaries.ROLLING_MAX_DRAWDOWN.latest",
         "metric_series[].metric_values.ROLLING_MAX_DRAWDOWN",
         "-0.1000000000",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_drawdown_max_drawdown_methodology_is_auditable_against_engine_contract() -> None:
+    text = DRAWDOWN_MAX_DRAWDOWN_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: MAX_DRAWDOWN",
+        "/analytics/risk/drawdown",
+        "`DrawdownAnalyticsReport:v1`",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "decimal drawdown ratios",
+        "summary.max_drawdown = depth_max_episode",
+        'error = "Insufficient data"',
+        "A one-observation or never-underwater period is valid",
+        "analysis_options.duration_unit",
+        "analysis_options.minimum_episode_depth_bps",
+        "results[period].summary.max_drawdown",
+        "results[period].episodes[].depth",
+        "results[period].underwater_series[].drawdown",
+        "-0.2000000000",
+        'summary.max_drawdown_peak_date = "2026-01-02"',
+        'summary.max_drawdown_recovery_date = "2026-01-06"',
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -57,6 +57,14 @@ zero-benchmark-variance beta flagging, zero-tracking-error information-ratio fla
 decimal volatility output, decimal-ratio tracking-error output, dimensionless Sharpe, beta, and
 information-ratio output, and decimal drawdown-ratio output.
 
+`DrawdownAnalyticsReport:v1` now has auditable source-owner methodology truth for maximum
+drawdown. The methodology is tied to the implemented `/analytics/risk/drawdown` engine and states
+the exact percentage-point input convention, decimal cumulative-wealth/running-peak drawdown
+behavior, decimal `summary.max_drawdown` output, episode peak/trough/recovery semantics,
+empty-period insufficient-data posture, never-underwater zero-drawdown posture, duration-unit day
+counter behavior, and the boundary that episode-list filters do not change the summary maximum
+drawdown value.
+
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
 scenario contribution rows alongside worst-case loss, threshold-breach posture, lineage, and
@@ -88,6 +96,9 @@ Audience notes:
   active-return volatility versus the selected benchmark, rolling information ratio as annualized
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
+- Business users can read `DrawdownAnalyticsReport:v1` maximum drawdown as the worst decimal
+  peak-to-trough portfolio loss for the resolved period, with peak, trough, recovery, and
+  time-under-water evidence for the selected episode.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period, Drawdown as signed percentage-point
   maximum peak-to-trough loss, Sharpe as annualized excess return per
@@ -104,6 +115,9 @@ Audience notes:
 - Developers and downstream services must preserve `RollingRiskMetricsReport:v1` values and
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
+- Developers and downstream services must preserve `DrawdownAnalyticsReport:v1` maximum drawdown,
+  episode, underwater-series, and relative-drawdown context rather than recomputing drawdown
+  analytics locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.


### PR DESCRIPTION
## Summary
- promote `MAX_DRAWDOWN` methodology for `DrawdownAnalyticsReport:v1` to the v3 auditable standard
- pin decimal drawdown-ratio output, episode peak/trough/recovery semantics, empty-period behavior, and option boundaries
- update Risk repo context and repo-authored wiki source for implementation-backed maximum-drawdown methodology truth

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_drawdown_engine.py -q` -> 24 passed
- `python -m ruff check tests\unit\test_methodology_docs.py tests\unit\test_drawdown_engine.py`
- `python -m ruff format --check tests\unit\test_methodology_docs.py tests\unit\test_drawdown_engine.py`
- `git diff --check` -> only CRLF warnings for markdown/test files
- `make check` -> 342 unit tests passed plus Ruff, format, no-alias, mypy, OpenAPI quality, API vocabulary, and domain-data-product gates
- `make test-pyramid-gate` -> unit 342 / integration 94 / e2e 23 within policy
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift: `Mesh-Data-Products.md`

## Notes
- No `lotus-gateway` or `lotus-workbench` files changed; those repos remain reserved for the other active agent.
- This advances RFC42-WTBD-006 and does not close the WTBD.