### PR TITLE
docs(risk): pin average drawdown methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -88,11 +88,12 @@ Current repository posture:
     dependency supportability posture, zero-excess-volatility Sharpe flagging,
     zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
 13. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
-    `MAX_DRAWDOWN`: the docs and tests pin percentage-point input conventions, decimal
-    cumulative-wealth/running-peak drawdown behavior, decimal `summary.max_drawdown` output,
-    episode peak/trough/recovery semantics, empty-period insufficient-data posture, never-underwater
-    zero-drawdown posture, duration-unit day counter behavior, and episode-list filter isolation
-    from the summary maximum drawdown value.
+    `MAX_DRAWDOWN` and `AVERAGE_DRAWDOWN`: the docs and tests pin percentage-point input
+    conventions, decimal cumulative-wealth/running-peak drawdown behavior, decimal
+    `summary.max_drawdown` and `summary.average_drawdown` outputs, episode peak/trough/recovery
+    semantics, strictly-underwater average-drawdown inclusion, empty-period insufficient-data
+    posture, never-underwater zero-drawdown posture, duration-unit day counter behavior, and
+    episode-list filter isolation from the summary maximum and average drawdown values.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/drawdown-average-drawdown.md
+++ b/docs/methodologies/metrics/drawdown-average-drawdown.md
@@ -6,78 +6,122 @@
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/drawdown
 - supported_modes: stateless, stateful
+- source product: `DrawdownAnalyticsReport:v1`
 
 ## Inputs
-- Drawdown path derived from return series.
+- Portfolio return observations for the resolved period.
+- Return contract unit: percentage points (`value=1.0` means `+1%`).
+- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, `QTD`, `MTD`, `1Y`, `3Y`,
+  `5Y`, or `SI`).
+- Drawdown analysis options controlling underwater-series inclusion, episode-list filtering, and
+  duration convention for episode counters.
 
 ## Upstream Data Sources
-- Derived by drawdown engine.
+- Stateless mode: caller-provided `stateless_input.returns[]`.
+- Stateful mode: `lotus-risk` sources `series.portfolio_returns` from
+  `lotus-performance` `/integration/returns/series` through the governed drawdown stateful
+  adapter.
+- `lotus-risk` owns the average-drawdown calculation after dated portfolio return series are
+  resolved. It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
-- Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Input return values are percentage points: `5.0` means `+5.0%`.
+- The engine converts percentage-point returns to decimal only inside the wealth path:
+  `r_decimal = r_pp / 100`.
+- `summary.average_drawdown` is a decimal drawdown ratio:
+  `-0.07576` means the average underwater observation was `-7.576%` below its running peak.
+- Only strictly underwater observations (`DD_t < 0`) enter the average.
+- `analysis_options.duration_unit`, `analysis_options.top_n_episodes`, and
+  `analysis_options.minimum_episode_depth_bps` do not change `summary.average_drawdown`.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: period return at index `t` in percentage points.
-- `r_t`: period return at index `t` in decimal (`r_t = r_t_pp / 100`).
-- `W_t`: cumulative wealth index up to `t`.
-- `P_t`: running peak wealth up to `t`.
-- `DD_t`: drawdown at `t`.
-- `U`: underwater subset of drawdown values (`DD_t < 0`).
-- `AVG_DD`: average drawdown metric value.
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_decimal`: `r_t_pp / 100`.
+- `W_t`: cumulative wealth index through date `t`, `product(1 + r_i_decimal)` for `i <= t`.
+- `P_t`: running peak wealth through date `t`, `max(W_i)` for `i <= t`.
+- `DD_t`: decimal drawdown ratio on date `t`, `W_t / P_t - 1`.
+- `U`: ordered set of strictly underwater drawdown observations, `{DD_t | DD_t < 0}`.
+- `N_U`: number of observations in `U`.
+- `AVG_DD`: average drawdown summary value.
 
 ## Methodology and Formulas
-1. Convert returns from pp to decimal:
-`r_t = r_t_pp / 100`.
-2. Build wealth path:
-`W_t = ∏_{i=1..t}(1 + r_i)`.
-3. Build running peak:
-`P_t = max(W_1, W_2, ..., W_t)`.
-4. Build drawdown path:
-`DD_t = (W_t / P_t) - 1`.
-5. Construct underwater set:
-`U = {DD_t | DD_t < 0}`.
-6. Average drawdown:
-`AVG_DD = mean(U)` if `U` is non-empty; otherwise `AVG_DD = 0.0`.
+1. Resolve the requested period from `scope.as_of_date`, the first return observation date, and the
+   period definition.
+2. Filter portfolio returns to the resolved period.
+3. Require at least one observation in the resolved period; an empty period emits period-level
+   error `"Insufficient data"`.
+4. Convert percentage-point returns to decimal:
+   `r_t_decimal = r_t_pp / 100`.
+5. Build cumulative wealth:
+   `W_t = product(1 + r_i_decimal)` for `i <= t`.
+6. Build running peak wealth:
+   `P_t = max(W_i)` for `i <= t`.
+7. Build decimal drawdown path:
+   `DD_t = W_t / P_t - 1`.
+8. Select the strictly underwater observations:
+   `U = {DD_t | DD_t < 0}`.
+9. Map summary output:
+   - when `N_U > 0`, `summary.average_drawdown = sum(U) / N_U`;
+   - when `N_U = 0`, `summary.average_drawdown = 0.0`.
 
 ## Step-by-Step Computation
-1. Resolve period and select portfolio return observations in that date range.
-2. Sort observations by date and convert pp returns to decimal.
-3. Compute `W_t`, `P_t`, and `DD_t` for each observation date.
-4. Filter drawdown observations where `DD_t < 0`.
-5. Compute arithmetic mean over filtered values.
-6. If filtered set is empty, set `average_drawdown = 0.0`.
-7. Write final value to response summary field.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Return a period-level `"Insufficient data"` error when the filtered period is empty.
+5. Compute cumulative wealth, running peak, and drawdown paths.
+6. Filter drawdown observations to strictly negative values.
+7. Compute the arithmetic mean of the filtered decimal drawdown values.
+8. Emit `0.0` when the period never goes underwater.
+9. Build optional `episodes[]` and `underwater_series[]` independently from the average-drawdown
+   summary value.
 
 ## Validation and Failure Behavior
-- No observations in period: period result is returned with `Insufficient data`.
-- One observation only: drawdown path is degenerate; underwater set may be empty, resulting in `average_drawdown = 0.0`.
-- Non-numeric returns: rejected by request-contract validation before engine math.
-- This metric is independent of episode-list filters (`top_n_episodes`, `minimum_episode_depth_bps`).
+- Empty service-level return input returns an empty `results` map.
+- Empty return series for a requested period returns that period with `summary = null`,
+  `episodes = []`, and `error = "Insufficient data"`.
+- A one-observation or never-underwater period is valid and emits
+  `summary.average_drawdown = 0.0`.
+- Non-numeric return entries are rejected by request-contract validation before engine math.
+- `analysis_options.duration_unit` changes episode day counters only.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` do not alter
+  `summary.average_drawdown`.
 
 ## Configuration Options
-- No dedicated metric knob.
+- `analysis_options.include_underwater_series`
+- `analysis_options.include_episode_list`
+- `analysis_options.top_n_episodes`
+- `analysis_options.minimum_episode_depth_bps`
 
 ## Outputs
 - `results[period].summary.average_drawdown`
+- `results[period].summary.time_under_water_days`
+- `results[period].underwater_series[].drawdown`
+- `results[period].error`
 
 ## Worked Example
-Input return sequence (pp): Day1 `+5.00`, Day2 `-10.00`, Day3 `+2.00`, Day4 `+4.00`.
+Assume `include_underwater_series=true` and portfolio return observations:
 
-| Date | `r_t_pp` | `r_t` (decimal) | `W_t` | `P_t` | `DD_t = W_t/P_t - 1` | Underwater? |
-|---|---:|---:|---:|---:|---:|---|
-| Day1 | 5.00 | 0.0500 | 1.050000 | 1.050000 | 0.000000 | No |
-| Day2 | -10.00 | -0.1000 | 0.945000 | 1.050000 | -0.100000 | Yes |
-| Day3 | 2.00 | 0.0200 | 0.963900 | 1.050000 | -0.082000 | Yes |
-| Day4 | 4.00 | 0.0400 | 1.002456 | 1.050000 | -0.045280 | Yes |
+| Date | `r_t_pp` | `W_t` | `P_t` | `DD_t` | Included in `U`? |
+| --- | ---: | ---: | ---: | ---: | --- |
+| 2026-01-02 | `5.00` | `1.0500000000` | `1.0500000000` | `0.0000000000` | No |
+| 2026-01-05 | `-10.00` | `0.9450000000` | `1.0500000000` | `-0.1000000000` | Yes |
+| 2026-01-06 | `2.00` | `0.9639000000` | `1.0500000000` | `-0.0820000000` | Yes |
+| 2026-01-07 | `4.00` | `1.0024560000` | `1.0500000000` | `-0.0452800000` | Yes |
 
-Underwater subset:
-- `U = [-0.100000, -0.082000, -0.045280]`
+Intermediate calculations:
 
-Average drawdown:
-- `AVG_DD = (-0.100000 - 0.082000 - 0.045280) / 3 = -0.075760`
+| Step | Value |
+| --- | ---: |
+| Underwater set `U` | `[-0.1000000000, -0.0820000000, -0.0452800000]` |
+| `N_U` | `3` |
+| `summary.average_drawdown` | `-0.0757600000` |
+| `summary.time_under_water_days` | `3` |
 
 Output mapping:
-- `results[period].summary.average_drawdown = -0.075760`
+
+- `results[period].summary.average_drawdown = -0.0757600000`
+- `results[period].summary.time_under_water_days = 3`
+- `results[period].underwater_series[1].drawdown = -0.1000000000`
+- `results[period].underwater_series[3].drawdown = -0.0452800000`

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -369,6 +369,34 @@ def test_e2e_drawdown_stateless_happy_path() -> None:
     assert body["results"]["YTD"]["summary"]["max_drawdown"] is not None
 
 
+def test_e2e_drawdown_average_drawdown_public_contract() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/analytics/risk/drawdown",
+        json={
+            "input_mode": "stateless",
+            "stateless_input": {
+                "scope": {"as_of_date": "2026-01-07", "net_or_gross": "NET"},
+                "periods": [{"type": "YTD", "name": "YTD"}],
+                "returns": [
+                    {"date": "2026-01-02", "value": 5.0},
+                    {"date": "2026-01-05", "value": -10.0},
+                    {"date": "2026-01-06", "value": 2.0},
+                    {"date": "2026-01-07", "value": 4.0},
+                ],
+            },
+            "analysis_options": {"include_underwater_series": True},
+        },
+    )
+
+    assert response.status_code == 200
+    period = response.json()["results"]["YTD"]
+    assert period["summary"]["average_drawdown"] == pytest.approx(-0.07576)
+    assert period["summary"]["time_under_water_days"] == 3
+    assert period["underwater_series"][1]["drawdown"] == pytest.approx(-0.1)
+    assert period["underwater_series"][3]["drawdown"] == pytest.approx(-0.04528)
+
+
 def test_e2e_rolling_metrics_stateless_happy_path() -> None:
     client = TestClient(app)
     response = client.post("/analytics/risk/rolling-metrics", json=_rolling_payload())

--- a/tests/unit/test_drawdown_engine.py
+++ b/tests/unit/test_drawdown_engine.py
@@ -124,6 +124,44 @@ def test_drawdown_max_drawdown_matches_documented_decimal_output_contract() -> N
     assert period.underwater_series[1].drawdown == pytest.approx(-0.2)
 
 
+def test_drawdown_average_drawdown_matches_documented_decimal_output_contract() -> None:
+    request = DrawdownStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-07", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-02", "value": 5.0},
+                {"date": "2026-01-05", "value": -10.0},
+                {"date": "2026-01-06", "value": 2.0},
+                {"date": "2026-01-07", "value": 4.0},
+            ],
+        }
+    )
+
+    response = calculate_drawdown(
+        request,
+        input_mode=DrawdownInputMode.STATELESS,
+        analysis_options=DrawdownAnalysisOptions.model_validate(
+            {
+                "include_underwater_series": True,
+                "include_episode_list": True,
+                "top_n_episodes": 1,
+                "minimum_episode_depth_bps": 500,
+            }
+        ),
+    )
+
+    period = response.results["YTD"]
+    assert period.error is None
+    assert period.summary is not None
+    assert period.summary.average_drawdown == pytest.approx(-0.07576)
+    assert period.summary.time_under_water_days == 3
+    assert period.underwater_series is not None
+    assert period.underwater_series[1].drawdown == pytest.approx(-0.1)
+    assert period.underwater_series[2].drawdown == pytest.approx(-0.082)
+    assert period.underwater_series[3].drawdown == pytest.approx(-0.04528)
+
+
 def test_drawdown_engine_handles_empty_returns() -> None:
     request = DrawdownStatelessInput.model_validate(
         {

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -17,6 +17,9 @@ ROLLING_MAX_DRAWDOWN_DOC = (
 DRAWDOWN_MAX_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-max-drawdown.md"
 )
+DRAWDOWN_AVERAGE_DRAWDOWN_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-average-drawdown.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -227,6 +230,34 @@ def test_drawdown_max_drawdown_methodology_is_auditable_against_engine_contract(
         "-0.2000000000",
         'summary.max_drawdown_peak_date = "2026-01-02"',
         'summary.max_drawdown_recovery_date = "2026-01-06"',
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_drawdown_average_drawdown_methodology_is_auditable_against_engine_contract() -> None:
+    text = DRAWDOWN_AVERAGE_DRAWDOWN_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: AVERAGE_DRAWDOWN",
+        "/analytics/risk/drawdown",
+        "`DrawdownAnalyticsReport:v1`",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "decimal drawdown ratio",
+        "Only strictly underwater observations (`DD_t < 0`) enter the average",
+        "summary.average_drawdown = sum(U) / N_U",
+        'error = "Insufficient data"',
+        "A one-observation or never-underwater period is valid",
+        "analysis_options.minimum_episode_depth_bps",
+        "results[period].summary.average_drawdown",
+        "results[period].summary.time_under_water_days",
+        "results[period].underwater_series[].drawdown",
+        "-0.0757600000",
+        "summary.time_under_water_days = 3",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -58,12 +58,13 @@ decimal volatility output, decimal-ratio tracking-error output, dimensionless Sh
 information-ratio output, and decimal drawdown-ratio output.
 
 `DrawdownAnalyticsReport:v1` now has auditable source-owner methodology truth for maximum
-drawdown. The methodology is tied to the implemented `/analytics/risk/drawdown` engine and states
-the exact percentage-point input convention, decimal cumulative-wealth/running-peak drawdown
-behavior, decimal `summary.max_drawdown` output, episode peak/trough/recovery semantics,
-empty-period insufficient-data posture, never-underwater zero-drawdown posture, duration-unit day
-counter behavior, and the boundary that episode-list filters do not change the summary maximum
-drawdown value.
+drawdown and average drawdown. The methodologies are tied to the implemented
+`/analytics/risk/drawdown` engine and state the exact percentage-point input convention, decimal
+cumulative-wealth/running-peak drawdown behavior, decimal `summary.max_drawdown` and
+`summary.average_drawdown` outputs, episode peak/trough/recovery semantics, strictly-underwater
+average-drawdown inclusion, empty-period insufficient-data posture, never-underwater zero-drawdown
+posture, duration-unit day counter behavior, and the boundary that episode-list filters do not
+change the summary maximum or average drawdown values.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -97,7 +98,8 @@ Audience notes:
   active return per unit of that active risk, and rolling maximum drawdown as the worst decimal
   peak-to-trough loss inside each rolling return window.
 - Business users can read `DrawdownAnalyticsReport:v1` maximum drawdown as the worst decimal
-  peak-to-trough portfolio loss for the resolved period, with peak, trough, recovery, and
+  peak-to-trough portfolio loss for the resolved period, and average drawdown as the mean decimal
+  depth across strictly underwater observations, with peak, trough, recovery, and
   time-under-water evidence for the selected episode.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period, Drawdown as signed percentage-point
@@ -116,8 +118,8 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `DrawdownAnalyticsReport:v1` maximum drawdown,
-  episode, underwater-series, and relative-drawdown context rather than recomputing drawdown
-  analytics locally.
+  average drawdown, episode, underwater-series, and relative-drawdown context rather than
+  recomputing drawdown analytics locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.


### PR DESCRIPTION
## Summary
- upgrade DrawdownAnalyticsReport:v1 AVERAGE_DRAWDOWN methodology to implementation-backed v3 truth
- pin average drawdown with methodology, unit, and e2e contract assertions
- update repo context and repo-authored wiki source for source-owner drawdown analytics truth

## Validation
- python -m pytest tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py -q
- python -m pytest tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py tests\\e2e\\test_smoke.py::test_e2e_drawdown_average_drawdown_public_contract -q
- make check
- make test-pyramid-gate
- make test-e2e
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- git diff --check
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md)

## Boundary
- no lotus-gateway or lotus-workbench changes; those repos remain reserved for the other agent