### PR TITLE
docs(risk): pin ulcer index methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -88,12 +88,14 @@ Current repository posture:
     dependency supportability posture, zero-excess-volatility Sharpe flagging,
     zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
 13. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
-    `MAX_DRAWDOWN` and `AVERAGE_DRAWDOWN`: the docs and tests pin percentage-point input
-    conventions, decimal cumulative-wealth/running-peak drawdown behavior, decimal
-    `summary.max_drawdown` and `summary.average_drawdown` outputs, episode peak/trough/recovery
-    semantics, strictly-underwater average-drawdown inclusion, empty-period insufficient-data
-    posture, never-underwater zero-drawdown posture, duration-unit day counter behavior, and
-    episode-list filter isolation from the summary maximum and average drawdown values.
+    `MAX_DRAWDOWN`, `AVERAGE_DRAWDOWN`, and `ULCER_INDEX`: the docs and tests pin
+    percentage-point input conventions, decimal cumulative-wealth/running-peak drawdown behavior,
+    decimal `summary.max_drawdown`, `summary.average_drawdown`, and non-negative
+    `summary.ulcer_index` outputs, episode peak/trough/recovery semantics, strictly-underwater
+    average-drawdown inclusion, full-path squared drawdown inclusion for ulcer index, empty-period
+    insufficient-data posture, never-underwater zero-drawdown posture, duration-unit day counter
+    behavior, and episode-list filter isolation from the summary maximum, average, and ulcer-index
+    drawdown values.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/drawdown-ulcer-index.md
+++ b/docs/methodologies/metrics/drawdown-ulcer-index.md
@@ -6,78 +6,122 @@
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/drawdown
 - supported_modes: stateless, stateful
+- source product: `DrawdownAnalyticsReport:v1`
 
 ## Inputs
-- Drawdown path over period.
+- Portfolio return observations for the resolved period.
+- Return contract unit: percentage points (`value=1.0` means `+1%`).
+- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, `QTD`, `MTD`, `1Y`, `3Y`,
+  `5Y`, or `SI`).
+- Drawdown analysis options controlling underwater-series inclusion, episode-list filtering, and
+  duration convention for episode counters.
 
 ## Upstream Data Sources
-- Derived in drawdown engine.
+- Stateless mode: caller-provided `stateless_input.returns[]`.
+- Stateful mode: `lotus-risk` sources `series.portfolio_returns` from
+  `lotus-performance` `/integration/returns/series` through the governed drawdown stateful
+  adapter.
+- `lotus-risk` owns the ulcer-index calculation after dated portfolio return series are resolved.
+  It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
-- Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Input return values are percentage points: `5.0` means `+5.0%`.
+- The engine converts percentage-point returns to decimal only inside the wealth path:
+  `r_decimal = r_pp / 100`.
+- `summary.ulcer_index` is a non-negative decimal drawdown ratio:
+  `0.06851` means root-mean-square drawdown depth of about `6.851%`.
+- Every decimal drawdown observation in the period enters the root-mean-square calculation,
+  including peak observations where `DD_t = 0`.
+- `analysis_options.duration_unit`, `analysis_options.top_n_episodes`, and
+  `analysis_options.minimum_episode_depth_bps` do not change `summary.ulcer_index`.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: period return at index `t` in percentage points.
-- `r_t`: period return at index `t` in decimal (`r_t = r_t_pp / 100`).
-- `W_t`: cumulative wealth index up to `t`.
-- `P_t`: running peak wealth up to `t`.
-- `DD_t`: drawdown at `t`.
-- `SQ_t`: squared drawdown (`DD_t^2`).
-- `UI`: ulcer index.
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_decimal`: `r_t_pp / 100`.
+- `W_t`: cumulative wealth index through date `t`, `product(1 + r_i_decimal)` for `i <= t`.
+- `P_t`: running peak wealth through date `t`, `max(W_i)` for `i <= t`.
+- `DD_t`: decimal drawdown ratio on date `t`, `W_t / P_t - 1`.
+- `S_t`: squared decimal drawdown value, `DD_t^2`.
+- `N`: number of drawdown observations in the resolved period.
+- `UI`: ulcer-index summary value.
 
 ## Methodology and Formulas
-1. Convert returns from pp to decimal:
-`r_t = r_t_pp / 100`.
-2. Build wealth path:
-`W_t = ∏_{i=1..t}(1 + r_i)`.
-3. Build running peak:
-`P_t = max(W_1, W_2, ..., W_t)`.
-4. Build drawdown path:
-`DD_t = (W_t / P_t) - 1`.
-5. Square drawdowns:
-`SQ_t = DD_t^2`.
-6. Ulcer index:
-`UI = sqrt(mean_t(SQ_t))`.
+1. Resolve the requested period from `scope.as_of_date`, the first return observation date, and the
+   period definition.
+2. Filter portfolio returns to the resolved period.
+3. Require at least one observation in the resolved period; an empty period emits period-level
+   error `"Insufficient data"`.
+4. Convert percentage-point returns to decimal:
+   `r_t_decimal = r_t_pp / 100`.
+5. Build cumulative wealth:
+   `W_t = product(1 + r_i_decimal)` for `i <= t`.
+6. Build running peak wealth:
+   `P_t = max(W_i)` for `i <= t`.
+7. Build decimal drawdown path:
+   `DD_t = W_t / P_t - 1`.
+8. Square every drawdown observation:
+   `S_t = DD_t^2`.
+9. Map summary output:
+   `summary.ulcer_index = sqrt(sum(S_t) / N)`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter return observations to analysis window.
-2. Sort returns by date and convert pp values to decimal.
-3. Compute `W_t`, `P_t`, and `DD_t` for each timestamp.
-4. Square each `DD_t` to produce `SQ_t`.
-5. Compute arithmetic mean of all `SQ_t` values in the period.
-6. Take square root of this mean to obtain `UI`.
-7. Return `UI` as non-negative decimal in summary payload.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Return a period-level `"Insufficient data"` error when the filtered period is empty.
+5. Compute cumulative wealth, running peak, and drawdown paths.
+6. Square every decimal drawdown observation, including zero drawdowns at new peaks.
+7. Compute the arithmetic mean of the squared drawdown values.
+8. Take the square root of that mean.
+9. Build optional `episodes[]` and `underwater_series[]` independently from the ulcer-index
+   summary value.
 
 ## Validation and Failure Behavior
-- No observations in period: period result carries `Insufficient data`.
-- Single observation: `DD_t` is `0`, so `UI = 0`.
-- Non-numeric returns: rejected by request-contract validation before engine computation.
-- Ulcer index is always `>= 0` by construction (square then square-root).
+- Empty service-level return input returns an empty `results` map.
+- Empty return series for a requested period returns that period with `summary = null`,
+  `episodes = []`, and `error = "Insufficient data"`.
+- A one-observation or never-underwater period is valid and emits `summary.ulcer_index = 0.0`.
+- Non-numeric return entries are rejected by request-contract validation before engine math.
+- `summary.ulcer_index` is non-negative by construction.
+- `analysis_options.duration_unit` changes episode day counters only.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` do not alter
+  `summary.ulcer_index`.
 
 ## Configuration Options
-- No dedicated metric knob.
+- `analysis_options.include_underwater_series`
+- `analysis_options.include_episode_list`
+- `analysis_options.top_n_episodes`
+- `analysis_options.minimum_episode_depth_bps`
 
 ## Outputs
 - `results[period].summary.ulcer_index`
+- `results[period].summary.time_under_water_days`
+- `results[period].underwater_series[].drawdown`
+- `results[period].error`
 
 ## Worked Example
-Input return sequence (pp): Day1 `+5.00`, Day2 `-10.00`, Day3 `+2.00`, Day4 `+4.00`.
+Assume `include_underwater_series=true` and portfolio return observations:
 
-| Date | `r_t_pp` | `r_t` (decimal) | `W_t` | `P_t` | `DD_t` | `SQ_t = DD_t^2` |
-|---|---:|---:|---:|---:|---:|---:|
-| Day1 | 5.00 | 0.0500 | 1.050000 | 1.050000 | 0.000000 | 0.000000 |
-| Day2 | -10.00 | -0.1000 | 0.945000 | 1.050000 | -0.100000 | 0.010000 |
-| Day3 | 2.00 | 0.0200 | 0.963900 | 1.050000 | -0.082000 | 0.006724 |
-| Day4 | 4.00 | 0.0400 | 1.002456 | 1.050000 | -0.045280 | 0.002050 |
+| Date | `r_t_pp` | `W_t` | `P_t` | `DD_t` | `S_t = DD_t^2` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-02 | `5.00` | `1.0500000000` | `1.0500000000` | `0.0000000000` | `0.0000000000` |
+| 2026-01-05 | `-10.00` | `0.9450000000` | `1.0500000000` | `-0.1000000000` | `0.0100000000` |
+| 2026-01-06 | `2.00` | `0.9639000000` | `1.0500000000` | `-0.0820000000` | `0.0067240000` |
+| 2026-01-07 | `4.00` | `1.0024560000` | `1.0500000000` | `-0.0452800000` | `0.0020502784` |
 
-Intermediate aggregation:
-- `mean(SQ_t) = (0.000000 + 0.010000 + 0.006724 + 0.002050) / 4 = 0.004694`
+Intermediate calculations:
 
-Final metric:
-- `UI = sqrt(0.004694) = 0.068513`
+| Step | Value |
+| --- | ---: |
+| Observation count `N` | `4` |
+| `sum(S_t)` | `0.0187742784` |
+| `mean(S_t)` | `0.0046935696` |
+| `summary.ulcer_index` | `0.0685096314` |
 
 Output mapping:
-- `results[period].summary.ulcer_index = 0.068513`
+
+- `results[period].summary.ulcer_index = 0.0685096314`
+- `results[period].summary.time_under_water_days = 3`
+- `results[period].underwater_series[1].drawdown = -0.1000000000`
+- `results[period].underwater_series[3].drawdown = -0.0452800000`

--- a/tests/unit/test_drawdown_engine.py
+++ b/tests/unit/test_drawdown_engine.py
@@ -162,6 +162,45 @@ def test_drawdown_average_drawdown_matches_documented_decimal_output_contract() 
     assert period.underwater_series[3].drawdown == pytest.approx(-0.04528)
 
 
+def test_drawdown_ulcer_index_matches_documented_decimal_output_contract() -> None:
+    request = DrawdownStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-07", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-02", "value": 5.0},
+                {"date": "2026-01-05", "value": -10.0},
+                {"date": "2026-01-06", "value": 2.0},
+                {"date": "2026-01-07", "value": 4.0},
+            ],
+        }
+    )
+
+    response = calculate_drawdown(
+        request,
+        input_mode=DrawdownInputMode.STATELESS,
+        analysis_options=DrawdownAnalysisOptions.model_validate(
+            {
+                "include_underwater_series": True,
+                "include_episode_list": True,
+                "top_n_episodes": 1,
+                "minimum_episode_depth_bps": 500,
+            }
+        ),
+    )
+
+    period = response.results["YTD"]
+    assert period.error is None
+    assert period.summary is not None
+    assert period.summary.ulcer_index == pytest.approx(0.0685096314)
+    assert period.summary.time_under_water_days == 3
+    assert period.underwater_series is not None
+    assert period.underwater_series[0].drawdown == pytest.approx(0.0)
+    assert period.underwater_series[1].drawdown == pytest.approx(-0.1)
+    assert period.underwater_series[2].drawdown == pytest.approx(-0.082)
+    assert period.underwater_series[3].drawdown == pytest.approx(-0.04528)
+
+
 def test_drawdown_engine_handles_empty_returns() -> None:
     request = DrawdownStatelessInput.model_validate(
         {

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -20,6 +20,9 @@ DRAWDOWN_MAX_DRAWDOWN_DOC = (
 DRAWDOWN_AVERAGE_DRAWDOWN_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-average-drawdown.md"
 )
+DRAWDOWN_ULCER_INDEX_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-ulcer-index.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -258,6 +261,34 @@ def test_drawdown_average_drawdown_methodology_is_auditable_against_engine_contr
         "results[period].underwater_series[].drawdown",
         "-0.0757600000",
         "summary.time_under_water_days = 3",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_drawdown_ulcer_index_methodology_is_auditable_against_engine_contract() -> None:
+    text = DRAWDOWN_ULCER_INDEX_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ULCER_INDEX",
+        "/analytics/risk/drawdown",
+        "`DrawdownAnalyticsReport:v1`",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "non-negative decimal drawdown ratio",
+        "including peak observations where `DD_t = 0`",
+        "summary.ulcer_index = sqrt(sum(S_t) / N)",
+        'error = "Insufficient data"',
+        "A one-observation or never-underwater period is valid",
+        "analysis_options.minimum_episode_depth_bps",
+        "results[period].summary.ulcer_index",
+        "results[period].summary.time_under_water_days",
+        "results[period].underwater_series[].drawdown",
+        "0.0685096314",
+        "mean(S_t)",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -58,13 +58,14 @@ decimal volatility output, decimal-ratio tracking-error output, dimensionless Sh
 information-ratio output, and decimal drawdown-ratio output.
 
 `DrawdownAnalyticsReport:v1` now has auditable source-owner methodology truth for maximum
-drawdown and average drawdown. The methodologies are tied to the implemented
+drawdown, average drawdown, and ulcer index. The methodologies are tied to the implemented
 `/analytics/risk/drawdown` engine and state the exact percentage-point input convention, decimal
 cumulative-wealth/running-peak drawdown behavior, decimal `summary.max_drawdown` and
-`summary.average_drawdown` outputs, episode peak/trough/recovery semantics, strictly-underwater
-average-drawdown inclusion, empty-period insufficient-data posture, never-underwater zero-drawdown
-posture, duration-unit day counter behavior, and the boundary that episode-list filters do not
-change the summary maximum or average drawdown values.
+`summary.average_drawdown` outputs, non-negative decimal `summary.ulcer_index` output, episode
+peak/trough/recovery semantics, strictly-underwater average-drawdown inclusion, full-path squared
+drawdown inclusion for ulcer index, empty-period insufficient-data posture, never-underwater
+zero-drawdown posture, duration-unit day counter behavior, and the boundary that episode-list
+filters do not change the summary maximum, average, or ulcer-index drawdown values.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -99,7 +100,8 @@ Audience notes:
   peak-to-trough loss inside each rolling return window.
 - Business users can read `DrawdownAnalyticsReport:v1` maximum drawdown as the worst decimal
   peak-to-trough portfolio loss for the resolved period, and average drawdown as the mean decimal
-  depth across strictly underwater observations, with peak, trough, recovery, and
+  depth across strictly underwater observations. Ulcer index is the non-negative decimal
+  root-mean-square drawdown severity over the full drawdown path, with peak, trough, recovery, and
   time-under-water evidence for the selected episode.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period, Drawdown as signed percentage-point
@@ -118,8 +120,8 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `DrawdownAnalyticsReport:v1` maximum drawdown,
-  average drawdown, episode, underwater-series, and relative-drawdown context rather than
-  recomputing drawdown analytics locally.
+  average drawdown, ulcer index, episode, underwater-series, and relative-drawdown context rather
+  than recomputing drawdown analytics locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.


### PR DESCRIPTION
## Summary
- upgrades the ULcer Index methodology for DrawdownAnalyticsReport:v1 to implementation-backed v3 detail
- pins source-owner truth for percentage-point input, decimal drawdown path, full-path squared drawdown inclusion, and non-negative summary.ulcer_index output
- updates repository context and repo-authored wiki source for DrawdownAnalyticsReport:v1
- keeps Gateway and Workbench untouched; no cross-repo API shape change

## Validation
- python -m pytest tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py -q
- python -m ruff check tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py
- python -m ruff format --check tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py
- git diff --check
- make check
- make test-pyramid-gate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk currently reports expected drift for Mesh-Data-Products.md because this branch updates repo-authored wiki source; publish after merge.