### PR TITLE
docs(risk): pin time under water methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -88,14 +88,15 @@ Current repository posture:
     dependency supportability posture, zero-excess-volatility Sharpe flagging,
     zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
 13. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
-    `MAX_DRAWDOWN`, `AVERAGE_DRAWDOWN`, and `ULCER_INDEX`: the docs and tests pin
-    percentage-point input conventions, decimal cumulative-wealth/running-peak drawdown behavior,
-    decimal `summary.max_drawdown`, `summary.average_drawdown`, and non-negative
-    `summary.ulcer_index` outputs, episode peak/trough/recovery semantics, strictly-underwater
-    average-drawdown inclusion, full-path squared drawdown inclusion for ulcer index, empty-period
-    insufficient-data posture, never-underwater zero-drawdown posture, duration-unit day counter
-    behavior, and episode-list filter isolation from the summary maximum, average, and ulcer-index
-    drawdown values.
+    `MAX_DRAWDOWN`, `AVERAGE_DRAWDOWN`, `ULCER_INDEX`, and `TIME_UNDER_WATER_DAYS`: the docs and
+    tests pin percentage-point input conventions, decimal cumulative-wealth/running-peak drawdown
+    behavior, decimal `summary.max_drawdown`, `summary.average_drawdown`, non-negative
+    `summary.ulcer_index`, and observation-count `summary.time_under_water_days` outputs, episode
+    peak/trough/recovery semantics, strictly-underwater average-drawdown inclusion, full-path
+    squared drawdown inclusion for ulcer index, strictly-underwater observation counting for time
+    under water, empty-period insufficient-data posture, never-underwater zero-drawdown posture,
+    duration-unit day counter behavior, and episode-list filter isolation from the summary
+    maximum, average, ulcer-index, and time-under-water drawdown values.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/drawdown-time-under-water.md
+++ b/docs/methodologies/metrics/drawdown-time-under-water.md
@@ -6,75 +6,124 @@
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/drawdown
 - supported_modes: stateless, stateful
+- source product: `DrawdownAnalyticsReport:v1`
 
 ## Inputs
-- Drawdown path over period.
+- Portfolio return observations for the resolved period.
+- Return contract unit: percentage points (`value=1.0` means `+1%`).
+- Period boundaries after period resolution (`EXPLICIT`, `YEAR`, `YTD`, `QTD`, `MTD`, `1Y`, `3Y`,
+  `5Y`, or `SI`).
+- Drawdown analysis options controlling underwater-series inclusion, episode-list filtering, and
+  duration convention for episode counters.
 
 ## Upstream Data Sources
-- Derived in drawdown engine.
+- Stateless mode: caller-provided `stateless_input.returns[]`.
+- Stateful mode: `lotus-risk` sources `series.portfolio_returns` from
+  `lotus-performance` `/integration/returns/series` through the governed drawdown stateful
+  adapter.
+- `lotus-risk` owns the time-under-water calculation after dated portfolio return series are
+  resolved. It does not source portfolio returns from Workbench, Gateway, or manage.
 
 ## Unit Conventions
-- Return inputs are percentage points (pp): `1.0` means `+1%`.
-- Engine converts to decimal when needed: `r_decimal = r_pp / 100`.
-- Output unit follows metric contract (ratio, annualized decimal, drawdown decimal, or HHI scale).
+- Input return values are percentage points: `5.0` means `+5.0%`.
+- The engine converts percentage-point returns to decimal only inside the wealth path:
+  `r_decimal = r_pp / 100`.
+- `summary.time_under_water_days` is an integer count of portfolio return observations where the
+  decimal drawdown is strictly below zero.
+- The field name is retained for contract compatibility, but the implemented value is
+  observation-based. It is not a calendar-day or business-day duration.
+- `analysis_options.duration_unit` changes episode day counters only. It does not change
+  `summary.time_under_water_days`.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` filter
+  returned episodes only. They do not change `summary.time_under_water_days`.
 
 ## Variable Dictionary
-- `t`: observation index in chronological order.
-- `r_t_pp`: period return at index `t` in percentage points.
-- `r_t`: period return at index `t` in decimal (`r_t = r_t_pp / 100`).
-- `W_t`: cumulative wealth index up to `t`.
-- `P_t`: running peak wealth up to `t`.
-- `DD_t`: drawdown at `t`.
-- `I_t`: indicator variable, `1` if `DD_t < 0`, otherwise `0`.
-- `TUW`: time-under-water count over the period.
+- `t`: observation date.
+- `r_t_pp`: portfolio return on date `t`, in percentage points.
+- `r_t_decimal`: `r_t_pp / 100`.
+- `W_t`: cumulative wealth index through date `t`, `product(1 + r_i_decimal)` for `i <= t`.
+- `P_t`: running peak wealth through date `t`, `max(W_i)` for `i <= t`.
+- `DD_t`: decimal drawdown ratio on date `t`, `W_t / P_t - 1`.
+- `I_t`: underwater indicator, `1` when `DD_t < 0`, otherwise `0`.
+- `TUW`: time-under-water observation count.
 
 ## Methodology and Formulas
-1. Convert returns from pp to decimal:
-`r_t = r_t_pp / 100`.
-2. Build wealth path:
-`W_t = ∏_{i=1..t}(1 + r_i)`.
-3. Build running peak:
-`P_t = max(W_1, W_2, ..., W_t)`.
-4. Build drawdown path:
-`DD_t = (W_t / P_t) - 1`.
-5. Build indicator series:
-`I_t = 1` when `DD_t < 0`; else `I_t = 0`.
-6. Time-under-water metric:
-`TUW = Σ_t I_t`.
+1. Resolve the requested period from `scope.as_of_date`, the first return observation date, and the
+   period definition.
+2. Filter portfolio returns to the resolved period.
+3. Require at least one observation in the resolved period; an empty period emits period-level
+   error `"Insufficient data"`.
+4. Convert percentage-point returns to decimal:
+   `r_t_decimal = r_t_pp / 100`.
+5. Build cumulative wealth:
+   `W_t = product(1 + r_i_decimal)` for `i <= t`.
+6. Build running peak wealth:
+   `P_t = max(W_i)` for `i <= t`.
+7. Build decimal drawdown path:
+   `DD_t = W_t / P_t - 1`.
+8. Build the underwater indicator:
+   `I_t = 1 if DD_t < 0 else 0`.
+9. Map summary output:
+   `summary.time_under_water_days = sum(I_t)`.
 
 ## Step-by-Step Computation
-1. Resolve period and filter portfolio returns to that date range.
-2. Sort observations by date and convert pp returns to decimal.
-3. Compute `W_t`, `P_t`, and `DD_t` for each observation date.
-4. Mark each row with indicator `I_t = 1` if `DD_t < 0`, else `0`.
-5. Sum indicators across all rows to get `TUW`.
-6. Return integer `TUW` in summary payload.
-7. Interpret as persistence measure (duration-like count), not a depth measure.
+1. Build a dated portfolio-return series and sort by date.
+2. Resolve each requested period.
+3. Filter the return series to the period date range.
+4. Return a period-level `"Insufficient data"` error when the filtered period is empty.
+5. Compute cumulative wealth, running peak, and drawdown paths.
+6. Mark each drawdown observation as underwater only when it is strictly negative.
+7. Sum the underwater indicators across the resolved period.
+8. Build optional `episodes[]` and `underwater_series[]` independently from the time-under-water
+   summary value.
 
 ## Validation and Failure Behavior
-- No observations in period: period result carries `Insufficient data`.
-- Single observation: `DD_t = 0`, therefore `TUW = 0`.
-- Non-numeric returns: rejected by request-contract validation before engine computation.
-- `duration_unit` option affects episode-day fields, not `time_under_water_days` counting logic.
+- Empty service-level return input returns an empty `results` map.
+- Empty return series for a requested period returns that period with `summary = null`,
+  `episodes = []`, and `error = "Insufficient data"`.
+- A one-observation or never-underwater period is valid and emits
+  `summary.time_under_water_days = 0`.
+- Non-numeric return entries are rejected by request-contract validation before engine math.
+- `analysis_options.duration_unit` changes episode day counters only.
+- `analysis_options.top_n_episodes` and `analysis_options.minimum_episode_depth_bps` do not alter
+  `summary.time_under_water_days`.
 
 ## Configuration Options
-- No dedicated metric knob.
+- `analysis_options.include_underwater_series`
+- `analysis_options.include_episode_list`
+- `analysis_options.top_n_episodes`
+- `analysis_options.minimum_episode_depth_bps`
+- `analysis_options.duration_unit`
 
 ## Outputs
 - `results[period].summary.time_under_water_days`
+- `results[period].underwater_series[].drawdown`
+- `results[period].episodes[].total_days`
+- `results[period].error`
 
 ## Worked Example
-Input return sequence (pp): Day1 `+5.00`, Day2 `-10.00`, Day3 `+2.00`, Day4 `+4.00`.
+Assume `include_underwater_series=true`, `duration_unit=CALENDAR_DAYS`, and portfolio return
+observations:
 
-| Date | `r_t_pp` | `r_t` (decimal) | `W_t` | `P_t` | `DD_t` | `I_t = 1(DD_t<0)` |
-|---|---:|---:|---:|---:|---:|---:|
-| Day1 | 5.00 | 0.0500 | 1.050000 | 1.050000 | 0.000000 | 0 |
-| Day2 | -10.00 | -0.1000 | 0.945000 | 1.050000 | -0.100000 | 1 |
-| Day3 | 2.00 | 0.0200 | 0.963900 | 1.050000 | -0.082000 | 1 |
-| Day4 | 4.00 | 0.0400 | 1.002456 | 1.050000 | -0.045280 | 1 |
+| Date | `r_t_pp` | `W_t` | `P_t` | `DD_t` | `I_t = 1 if DD_t < 0 else 0` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 2026-01-02 | `5.00` | `1.0500000000` | `1.0500000000` | `0.0000000000` | `0` |
+| 2026-01-05 | `-10.00` | `0.9450000000` | `1.0500000000` | `-0.1000000000` | `1` |
+| 2026-01-06 | `2.00` | `0.9639000000` | `1.0500000000` | `-0.0820000000` | `1` |
+| 2026-01-07 | `4.00` | `1.0024560000` | `1.0500000000` | `-0.0452800000` | `1` |
 
-Aggregation:
-- `TUW = 0 + 1 + 1 + 1 = 3`
+Intermediate calculations:
+
+| Step | Value |
+| --- | ---: |
+| Underwater indicators | `[0, 1, 1, 1]` |
+| `sum(I_t)` | `3` |
+| `summary.time_under_water_days` | `3` |
 
 Output mapping:
+
 - `results[period].summary.time_under_water_days = 3`
+- `results[period].underwater_series[1].drawdown = -0.1000000000`
+- `results[period].underwater_series[3].drawdown = -0.0452800000`
+- `analysis_options.duration_unit = "CALENDAR_DAYS"` affects `episodes[].total_days`, not
+  `summary.time_under_water_days`

--- a/src/app/contracts/drawdown.py
+++ b/src/app/contracts/drawdown.py
@@ -397,7 +397,10 @@ class DrawdownSummary(BaseModel):
         json_schema_extra={"example": 11},
     )
     time_under_water_days: int = Field(
-        description="Total duration-unit days in the period where drawdown was below zero.",
+        description=(
+            "Number of portfolio return observations in the period where drawdown was below zero. "
+            "This is observation-based and is not affected by duration_unit."
+        ),
         json_schema_extra={"example": 34},
     )
     average_drawdown: float | None = Field(
@@ -459,7 +462,10 @@ class RelativeDrawdownSummary(BaseModel):
     )
     time_under_water_days: int = Field(
         default=0,
-        description="Number of duration-unit observations where active drawdown remained below zero.",
+        description=(
+            "Number of aligned active-return observations where active drawdown remained below "
+            "zero. This is observation-based and is not affected by duration_unit."
+        ),
         json_schema_extra={"example": 21},
     )
 

--- a/tests/unit/test_drawdown_engine.py
+++ b/tests/unit/test_drawdown_engine.py
@@ -201,6 +201,48 @@ def test_drawdown_ulcer_index_matches_documented_decimal_output_contract() -> No
     assert period.underwater_series[3].drawdown == pytest.approx(-0.04528)
 
 
+def test_drawdown_time_under_water_matches_documented_observation_count_contract() -> None:
+    request = DrawdownStatelessInput.model_validate(
+        {
+            "scope": {"as_of_date": "2026-01-07", "net_or_gross": "NET"},
+            "periods": [{"type": "YTD", "name": "YTD"}],
+            "returns": [
+                {"date": "2026-01-02", "value": 5.0},
+                {"date": "2026-01-05", "value": -10.0},
+                {"date": "2026-01-06", "value": 2.0},
+                {"date": "2026-01-07", "value": 4.0},
+            ],
+        }
+    )
+
+    response = calculate_drawdown(
+        request,
+        input_mode=DrawdownInputMode.STATELESS,
+        analysis_options=DrawdownAnalysisOptions.model_validate(
+            {
+                "duration_unit": "CALENDAR_DAYS",
+                "include_underwater_series": True,
+                "include_episode_list": True,
+                "top_n_episodes": 1,
+                "minimum_episode_depth_bps": 500,
+            }
+        ),
+    )
+
+    period = response.results["YTD"]
+    assert period.error is None
+    assert period.summary is not None
+    assert period.summary.time_under_water_days == 3
+    assert period.episodes[0].total_days == 5
+    assert period.underwater_series is not None
+    assert [point.drawdown < 0 for point in period.underwater_series] == [
+        False,
+        True,
+        True,
+        True,
+    ]
+
+
 def test_drawdown_engine_handles_empty_returns() -> None:
     request = DrawdownStatelessInput.model_validate(
         {

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -23,6 +23,9 @@ DRAWDOWN_AVERAGE_DRAWDOWN_DOC = (
 DRAWDOWN_ULCER_INDEX_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-ulcer-index.md"
 )
+DRAWDOWN_TIME_UNDER_WATER_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-time-under-water.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -289,6 +292,36 @@ def test_drawdown_ulcer_index_methodology_is_auditable_against_engine_contract()
         "results[period].underwater_series[].drawdown",
         "0.0685096314",
         "mean(S_t)",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_drawdown_time_under_water_methodology_is_auditable_against_engine_contract() -> None:
+    text = DRAWDOWN_TIME_UNDER_WATER_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: TIME_UNDER_WATER_DAYS",
+        "/analytics/risk/drawdown",
+        "`DrawdownAnalyticsReport:v1`",
+        "lotus-performance",
+        "r_decimal = r_pp / 100",
+        "integer count of portfolio return observations",
+        "observation-based",
+        "not a calendar-day or business-day duration",
+        "summary.time_under_water_days = sum(I_t)",
+        'error = "Insufficient data"',
+        "A one-observation or never-underwater period is valid",
+        "analysis_options.duration_unit",
+        "analysis_options.minimum_episode_depth_bps",
+        "results[period].summary.time_under_water_days",
+        "results[period].episodes[].total_days",
+        "results[period].underwater_series[].drawdown",
+        "Underwater indicators",
+        "summary.time_under_water_days = 3",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -58,14 +58,17 @@ decimal volatility output, decimal-ratio tracking-error output, dimensionless Sh
 information-ratio output, and decimal drawdown-ratio output.
 
 `DrawdownAnalyticsReport:v1` now has auditable source-owner methodology truth for maximum
-drawdown, average drawdown, and ulcer index. The methodologies are tied to the implemented
-`/analytics/risk/drawdown` engine and state the exact percentage-point input convention, decimal
-cumulative-wealth/running-peak drawdown behavior, decimal `summary.max_drawdown` and
-`summary.average_drawdown` outputs, non-negative decimal `summary.ulcer_index` output, episode
-peak/trough/recovery semantics, strictly-underwater average-drawdown inclusion, full-path squared
-drawdown inclusion for ulcer index, empty-period insufficient-data posture, never-underwater
-zero-drawdown posture, duration-unit day counter behavior, and the boundary that episode-list
-filters do not change the summary maximum, average, or ulcer-index drawdown values.
+drawdown, average drawdown, ulcer index, and time under water. The methodologies are tied to the
+implemented `/analytics/risk/drawdown` engine and state the exact percentage-point input
+convention, decimal cumulative-wealth/running-peak drawdown behavior, decimal
+`summary.max_drawdown` and `summary.average_drawdown` outputs, non-negative decimal
+`summary.ulcer_index` output,
+observation-count `summary.time_under_water_days` output, episode peak/trough/recovery semantics,
+strictly-underwater average-drawdown inclusion, full-path squared drawdown inclusion for ulcer
+index, strictly-underwater observation counting for time under water, empty-period insufficient-data
+posture, never-underwater zero-drawdown posture, duration-unit day counter behavior, and the
+boundary that episode-list filters do not change the summary maximum, average, ulcer-index, or
+time-under-water drawdown values.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
@@ -101,8 +104,9 @@ Audience notes:
 - Business users can read `DrawdownAnalyticsReport:v1` maximum drawdown as the worst decimal
   peak-to-trough portfolio loss for the resolved period, and average drawdown as the mean decimal
   depth across strictly underwater observations. Ulcer index is the non-negative decimal
-  root-mean-square drawdown severity over the full drawdown path, with peak, trough, recovery, and
-  time-under-water evidence for the selected episode.
+  root-mean-square drawdown severity over the full drawdown path. Time under water is the count of
+  portfolio return observations that are strictly below the running peak; duration-unit settings
+  affect episode day counters, not this observation count.
 - Business users can read `RiskMetricsReport:v1` volatility as annualized portfolio-return
   dispersion in percentage points for the resolved period, Drawdown as signed percentage-point
   maximum peak-to-trough loss, Sharpe as annualized excess return per
@@ -120,8 +124,8 @@ Audience notes:
   supportability metadata rather than recomputing rolling volatility, Sharpe, beta, tracking error,
   information ratio, or maximum drawdown locally.
 - Developers and downstream services must preserve `DrawdownAnalyticsReport:v1` maximum drawdown,
-  average drawdown, ulcer index, episode, underwater-series, and relative-drawdown context rather
-  than recomputing drawdown analytics locally.
+  average drawdown, ulcer index, time-under-water, episode, underwater-series, and
+  relative-drawdown context rather than recomputing drawdown analytics locally.
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.


### PR DESCRIPTION
## Summary
- upgrades TIME_UNDER_WATER_DAYS methodology for DrawdownAnalyticsReport:v1 to implementation-backed v3 detail
- clarifies that summary.time_under_water_days is an observation count, not a duration_unit day count
- aligns OpenAPI field descriptions, repo context, wiki source, and methodology/current-state tests
- keeps Gateway and Workbench untouched; no cross-repo API shape change beyond field descriptions

## Validation
- python -m pytest tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py -q
- python -m ruff check src\\app\\contracts\\drawdown.py tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py
- python -m ruff format --check src\\app\\contracts\\drawdown.py tests\\unit\\test_methodology_docs.py tests\\unit\\test_drawdown_engine.py
- git diff --check
- make check
- make test-pyramid-gate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py

## Wiki
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk reports expected pre-merge drift for Mesh-Data-Products.md because this branch updates repo-authored wiki source; publish after merge.