### PR TITLE
docs(risk): pin concentration position hhi methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -97,6 +97,13 @@ Current repository posture:
     under water, empty-period insufficient-data posture, never-underwater zero-drawdown posture,
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
+14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
+    `POSITION_HHI`: the docs and tests pin stateless, stateful, and simulation source resolution,
+    positive numeric position-value extraction, market-value versus quantity fallback precedence,
+    decimal position-weight construction, conventional `0..10000` Herfindahl-Hirschman scaling,
+    six-decimal response rounding, proposed-state fallback to current HHI when projected values are
+    unavailable, input-universe option boundaries, and issuer-enrichment isolation from
+    `risk_proxy.hhi_*` outputs.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/concentration-hhi.md
+++ b/docs/methodologies/metrics/concentration-hhi.md
@@ -2,69 +2,141 @@
 
 ## Metric
 - metric_id: POSITION_HHI
+- source_product: ConcentrationAnalyticsReport:v1
+- methodology_version: concentration.position_hhi.v1
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/concentration
 - supported_modes: stateless, stateful, simulation
+- output_family: `risk_proxy`
 
 ## Inputs
-- Current and proposed position values (market value preferred, quantity fallback).
-- Top-N setting for related concentration fields.
+- Current position rows.
+- Proposed position rows when the caller supplies or source state resolves a projected state.
+- Position identifiers and display names are carried into driver payloads, but `POSITION_HHI`
+  uses only numeric position values.
+- `top_n` is accepted by the endpoint for related top-N concentration fields but does not change
+  the `POSITION_HHI` formula.
 
 ## Upstream Data Sources
-- Stateless: caller-provided current/projected positions.
-- Stateful/simulation: lotus-core baseline and simulated snapshots.
+- Stateless mode uses caller-provided `stateless_input.current_positions` and
+  `stateless_input.projected_positions`.
+- Stateful mode requests a lotus-core baseline snapshot and uses `positions_baseline` for both
+  current and proposed states.
+- Simulation mode creates or reuses a lotus-core simulation session, applies requested changes,
+  requests a simulation snapshot, and uses baseline positions as current state and projected
+  positions as proposed state.
+- There is no lotus-performance dependency for position HHI.
 
 ## Unit Conventions
-- Position inputs are non-negative portfolio amounts:
-  - `market_value_base` when available
-  - `quantity` as fallback when market value is unavailable
-- Position weights are decimals in `[0, 1]`.
-- HHI is reported on the conventional `0..10000` scale.
+- Position inputs are portfolio amount-like values, not return percentages.
+- Stateless current rows use `market_value_base` when present; otherwise they fall back to
+  `quantity`.
+- Stateless projected rows use `projected_market_value_base` when present; otherwise they fall
+  back to `proposed_quantity`.
+- Stateful and simulation snapshot rows use `market_value_base` when present; otherwise they fall
+  back to `quantity`.
+- Values are parsed through Decimal from the source value's string representation. Missing,
+  non-numeric, zero, and negative values are excluded before weight construction.
+- Position weights are decimal ratios in `[0, 1]`.
+- `risk_proxy.hhi_*` values are emitted on the conventional Herfindahl-Hirschman `0..10000`
+  scale and rounded to six decimal places by the service response.
 
 ## Variable Dictionary
-- `v_i`: position value for position `i`.
-- `V = sum_i |v_i|`: absolute total exposure.
-- `w_i = |v_i|/V`: normalized absolute position weight.
-- `HHI = sum_i(w_i^2)*10000`: concentration index.
-- `HHI_current`, `HHI_proposed`, `HHI_delta`: output trio.
+- `C`: current extracted positive numeric position values.
+- `P`: proposed extracted positive numeric position values.
+- `x_i`: one extracted positive current value in `C`.
+- `y_i`: one extracted positive proposed value in `P`.
+- `V_C = sum_i(abs(x_i))`: current absolute exposure denominator.
+- `V_P = sum_i(abs(y_i))`: proposed absolute exposure denominator.
+- `w_i_current = abs(x_i) / V_C` when `V_C > 0`.
+- `w_i_proposed = abs(y_i) / V_P` when `V_P > 0`.
+- `HHI_current_raw = sum_i(w_i_current^2) * 10000`.
+- `HHI_proposed_raw = sum_i(w_i_proposed^2) * 10000`.
+- `HHI_delta_raw = HHI_proposed_raw - HHI_current_raw`.
+- `round6(z)`: Python `round(z, 6)` used by the service response.
 
 ## Methodology and Formulas
-1. Compute absolute denominator `V = sum_i |v_i|` for each state.
-2. Compute position weights `w_i = |v_i| / V`.
-3. Compute `HHI = sum_i (w_i^2) * 10000` for current and proposed states.
-4. Compute `HHI_delta = HHI_proposed - HHI_current`.
+For each state:
+
+1. Extract one positive numeric value per usable position row according to the mode-specific
+   field precedence.
+2. Compute the denominator:
+   `V = sum(abs(v_i))`.
+3. If `V <= 0`, set the state HHI to `0.0`.
+4. Otherwise compute normalized weights:
+   `w_i = abs(v_i) / V`.
+5. Compute the raw concentration index:
+   `HHI_raw = sum(w_i^2) * 10000`.
+6. Emit:
+   - `risk_proxy.hhi_current = round6(HHI_current_raw)`
+   - `risk_proxy.hhi_proposed = round6(HHI_proposed_raw)`
+   - `risk_proxy.hhi_delta = round6(HHI_proposed_raw - HHI_current_raw)`
+
+When no proposed values are available, the implemented service sets
+`HHI_proposed_raw = HHI_current_raw`; the emitted delta is therefore `0.0`.
 
 ## Step-by-Step Computation
-1. Extract numeric values from input rows.
-2. Build current and proposed value vectors.
-3. Normalize to absolute weights.
-4. Compute HHI per state and delta.
-5. Round to service precision and emit response.
+1. Resolve request mode.
+2. Build current position entries:
+   - stateless: caller current positions,
+   - stateful: lotus-core baseline positions,
+   - simulation: lotus-core baseline positions.
+3. Build proposed position entries:
+   - stateless: caller projected positions,
+   - stateful: same baseline positions as current,
+   - simulation: lotus-core projected positions when available.
+4. For each row, parse the preferred value field, fall back to the secondary value field, and keep
+   only positive numeric values.
+5. Compute current HHI from current values.
+6. Compute proposed HHI from proposed values, or reuse current HHI when proposed values are empty.
+7. Compute proposed-minus-current delta.
+8. Round each emitted HHI and delta to six decimal places.
 
 ## Validation and Failure Behavior
-- If no valid values are available, HHI defaults to `0`.
-- Non-numeric, missing, or non-positive values are ignored by the engine after contract parsing.
-- HHI is bounded in `[0, 10000]` for non-negative exposure sets.
+- Empty current values produce `risk_proxy.hhi_current = 0.0`.
+- Empty proposed values do not create an error; proposed HHI falls back to current HHI.
+- Missing, non-numeric, zero, and negative values are excluded from the value vector.
+- A single valid position produces HHI `10000.0`.
+- Equal weights across `N` valid positions produce `10000 / N`.
+- HHI is bounded in `[0, 10000]` for the implemented positive-value extraction path.
+- Issuer enrichment coverage does not change `risk_proxy.hhi_*`; issuer coverage applies to
+  `issuer_concentration`, not position HHI.
+- The endpoint may still emit degraded calculation supportability for issuer coverage gaps, but
+  position HHI remains calculated from the available position values.
 
 ## Configuration Options
-- No direct configuration option changes the HHI formula.
-- Related endpoint options that change the input set:
+- No direct request option changes the HHI formula.
+- Options that can change the source position universe:
   - `include_cash_positions`
   - `include_zero_quantity_positions`
   - `reporting_currency`
+- Options that do not change the position-HHI formula:
+  - `top_n`
+  - `issuer_grouping_level`
+  - `enrichment_policy`
 
 ## Outputs
 - `risk_proxy.hhi_current`
 - `risk_proxy.hhi_proposed`
 - `risk_proxy.hhi_delta`
-- The concentration endpoint also exposes top-position fields in `single_position_concentration`, but those are separate metrics.
+- The concentration endpoint also exposes top-position and issuer-concentration fields, but those
+  are separate metrics and do not alter `POSITION_HHI`.
 
 ## Worked Example
 Current values `[50, 30, 20]`; proposed values `[60, 25, 15]`.
-| State | Values | Weights | Squared Weights | HHI |
-|---|---|---|---:|
-| Current | `[50,30,20]` | `[0.50,0.30,0.20]` | `[0.2500,0.0900,0.0400]` | `3800` |
-| Proposed | `[60,25,15]` | `[0.60,0.25,0.15]` | `[0.3600,0.0625,0.0225]` | `4450` |
-Delta: `4450 - 3800 = 650`.
-Output mapping: `risk_proxy.hhi_current=3800`, `hhi_proposed=4450`, `hhi_delta=650`.
+
+| State | Values | Denominator | Weights | Squared Weights | HHI |
+|---|---|---:|---|---|---:|
+| Current | `[50, 30, 20]` | `100` | `[0.50, 0.30, 0.20]` | `[0.2500, 0.0900, 0.0400]` | `3800.0` |
+| Proposed | `[60, 25, 15]` | `100` | `[0.60, 0.25, 0.15]` | `[0.3600, 0.0625, 0.0225]` | `4450.0` |
+
+Delta:
+
+`risk_proxy.hhi_delta = 4450.0 - 3800.0 = 650.0`.
+
+Output mapping:
+
+- `risk_proxy.hhi_current = 3800.0`
+- `risk_proxy.hhi_proposed = 4450.0`
+- `risk_proxy.hhi_delta = 650.0`

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-10T14:04:39.680501+00:00",
+  "generatedAt": "2026-05-15T07:39:13.884277+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -999,7 +999,7 @@
       "semanticId": "lotus.hhi_current",
       "canonicalTerm": "hhi_current",
       "preferredName": "hhi_current",
-      "description": "Current Herfindahl-Hirschman Index value (0 to 10000).",
+      "description": "Current position-level Herfindahl-Hirschman Index on the conventional 0..10000 scale, computed from positive extracted current position values.",
       "example": 2450.0,
       "type": "number",
       "locations": [
@@ -1013,7 +1013,7 @@
       "semanticId": "lotus.hhi_delta",
       "canonicalTerm": "hhi_delta",
       "preferredName": "hhi_delta",
-      "description": "Difference between proposed and current concentration.",
+      "description": "Proposed-minus-current position-level HHI change on the 0..10000 scale.",
       "example": 260.0,
       "type": "number",
       "locations": [
@@ -1027,7 +1027,7 @@
       "semanticId": "lotus.hhi_proposed",
       "canonicalTerm": "hhi_proposed",
       "preferredName": "hhi_proposed",
-      "description": "Proposed Herfindahl-Hirschman Index after applying projected positions.",
+      "description": "Proposed position-level Herfindahl-Hirschman Index on the conventional 0..10000 scale after projected positions are applied; falls back to current HHI when no proposed position values are available.",
       "example": 2710.0,
       "type": "number",
       "locations": [

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -427,15 +427,22 @@ class ConcentrationRequest(BaseModel):
 
 class ConcentrationRiskProxy(BaseModel):
     hhi_current: float = Field(
-        description="Current Herfindahl-Hirschman Index value (0 to 10000).",
+        description=(
+            "Current position-level Herfindahl-Hirschman Index on the conventional 0..10000 "
+            "scale, computed from positive extracted current position values."
+        ),
         json_schema_extra={"example": 2450.0},
     )
     hhi_proposed: float = Field(
-        description="Proposed Herfindahl-Hirschman Index after applying projected positions.",
+        description=(
+            "Proposed position-level Herfindahl-Hirschman Index on the conventional 0..10000 "
+            "scale after projected positions are applied; falls back to current HHI when no "
+            "proposed position values are available."
+        ),
         json_schema_extra={"example": 2710.0},
     )
     hhi_delta: float = Field(
-        description="Difference between proposed and current concentration.",
+        description="Proposed-minus-current position-level HHI change on the 0..10000 scale.",
         json_schema_extra={"example": 260.0},
     )
 

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -121,6 +121,40 @@ async def test_calculate_concentration_stateless_uses_projected_values_when_prov
 
 
 @pytest.mark.asyncio
+async def test_position_hhi_matches_documented_stateless_methodology_example() -> None:
+    request = ConcentrationRequest.model_validate(
+        {
+            "input_mode": "stateless",
+            "stateless_input": {
+                "current_positions": [
+                    {"security_id": "A", "market_value_base": 50},
+                    {"security_id": "B", "market_value_base": 30},
+                    {"security_id": "C", "market_value_base": 20},
+                    {"security_id": "IGNORED_ZERO", "market_value_base": 0},
+                    {"security_id": "IGNORED_NEGATIVE", "market_value_base": -10},
+                ],
+                "projected_positions": [
+                    {"security_id": "A", "projected_market_value_base": 60},
+                    {"security_id": "B", "projected_market_value_base": 25},
+                    {"security_id": "C", "projected_market_value_base": 15},
+                    {"security_id": "IGNORED_MISSING"},
+                ],
+                "top_n": 2,
+            },
+        }
+    )
+
+    response = (await calculate_concentration(request)).model_dump()
+
+    assert response["risk_proxy"] == {
+        "hhi_current": 3800.0,
+        "hhi_proposed": 4450.0,
+        "hhi_delta": 650.0,
+    }
+    assert response["single_position_concentration"]["top_n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_calculate_concentration_rejects_legacy_payload() -> None:
     with pytest.raises(ValidationError):
         ConcentrationRequest.model_validate(

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -26,6 +26,9 @@ DRAWDOWN_ULCER_INDEX_DOC = (
 DRAWDOWN_TIME_UNDER_WATER_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "drawdown-time-under-water.md"
 )
+CONCENTRATION_POSITION_HHI_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-hhi.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -322,6 +325,42 @@ def test_drawdown_time_under_water_methodology_is_auditable_against_engine_contr
         "results[period].underwater_series[].drawdown",
         "Underwater indicators",
         "summary.time_under_water_days = 3",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_concentration_position_hhi_methodology_is_auditable_against_engine_contract() -> None:
+    text = CONCENTRATION_POSITION_HHI_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: POSITION_HHI",
+        "source_product: ConcentrationAnalyticsReport:v1",
+        "/analytics/risk/concentration",
+        "`risk_proxy`",
+        "lotus-core baseline snapshot",
+        "lotus-core simulation session",
+        "There is no lotus-performance dependency for position HHI",
+        "market_value_base` when present",
+        "projected_market_value_base` when present",
+        "Missing, non-numeric, zero, and negative values are excluded",
+        "Position weights are decimal ratios in `[0, 1]`",
+        "`risk_proxy.hhi_*` values are emitted on the conventional Herfindahl-Hirschman `0..10000`",
+        "HHI_raw = sum(w_i^2) * 10000",
+        "`risk_proxy.hhi_current = round6(HHI_current_raw)`",
+        "When no proposed values are available",
+        "A single valid position produces HHI `10000.0`",
+        "Equal weights across `N` valid positions produce `10000 / N`",
+        "Issuer enrichment coverage does not change `risk_proxy.hhi_*`",
+        "`include_cash_positions`",
+        "`top_n`",
+        "`issuer_grouping_level`",
+        "`risk_proxy.hhi_current = 3800.0`",
+        "`risk_proxy.hhi_proposed = 4450.0`",
+        "`risk_proxy.hhi_delta = 650.0`",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -70,6 +70,14 @@ posture, never-underwater zero-drawdown posture, duration-unit day counter behav
 boundary that episode-list filters do not change the summary maximum, average, ulcer-index, or
 time-under-water drawdown values.
 
+`ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI.
+The methodology is tied to the implemented `/analytics/risk/concentration` engine and states the
+stateless, stateful, and simulation source paths, positive numeric value extraction, market-value
+versus quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
+Herfindahl-Hirschman scaling, six-decimal response rounding, proposed-state fallback to current
+HHI when projected values are unavailable, input-universe option boundaries, and issuer-enrichment
+isolation from `risk_proxy.hhi_*` outputs.
+
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security
 scenario contribution rows alongside worst-case loss, threshold-breach posture, lineage, and
@@ -129,6 +137,8 @@ Audience notes:
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
+- Developers and downstream services must preserve `ConcentrationRiskReport:v1` position HHI and
+  related concentration outputs rather than recomputing concentration locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade POSITION_HHI methodology for ConcentrationRiskReport:v1 to implementation-aligned v3 detail
- clarify risk_proxy HHI contract descriptions and regenerate API vocabulary inventory
- add methodology and engine regression tests, plus repo context/wiki source updates

## Validation
- python -m pytest tests\\unit\\test_methodology_docs.py tests\\unit\\test_concentration_engine.py -q
- python -m ruff check src\\app\\contracts\\concentration.py tests\\unit\\test_methodology_docs.py tests\\unit\\test_concentration_engine.py
- python -m ruff format --check src\\app\\contracts\\concentration.py tests\\unit\\test_methodology_docs.py tests\\unit\\test_concentration_engine.py
- git diff --check
- make check
- make test-pyramid-gate
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- ..\\lotus-platform\\automation\\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected drift: Mesh-Data-Products.md from this PR wiki-source change)