### PR TITLE
docs(risk): pin concentration top-position methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -98,12 +98,13 @@ Current repository posture:
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
 14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
-    `POSITION_HHI`: the docs and tests pin stateless, stateful, and simulation source resolution,
-    positive numeric position-value extraction, market-value versus quantity fallback precedence,
-    decimal position-weight construction, conventional `0..10000` Herfindahl-Hirschman scaling,
-    six-decimal response rounding, proposed-state fallback to current HHI when projected values are
-    unavailable, input-universe option boundaries, and issuer-enrichment isolation from
-    `risk_proxy.hhi_*` outputs.
+    `POSITION_HHI` and `TOP_POSITION_WEIGHT`: the docs and tests pin stateless, stateful, and
+    simulation source resolution, positive numeric position-value extraction, market-value versus
+    quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
+    Herfindahl-Hirschman scaling for HHI, six-decimal response rounding, proposed-state fallback
+    to current values when projected values are unavailable, deterministic top-position driver
+    selection, input-universe option boundaries, and issuer-enrichment isolation from
+    `risk_proxy.hhi_*` and `single_position_concentration.top_position_*` outputs.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/concentration-top-position-weight.md
+++ b/docs/methodologies/metrics/concentration-top-position-weight.md
@@ -2,49 +2,125 @@
 
 ## Metric
 - metric_id: TOP_POSITION_WEIGHT
+- source_product: ConcentrationRiskReport:v1
+- methodology_version: concentration.top_position_weight.v1
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/concentration
 - supported_modes: stateless, stateful, simulation
+- output_family: `single_position_concentration`
 
 ## Inputs
-- Position value vectors for current and proposed states.
+- Current position rows.
+- Proposed position rows when the caller supplies or source state resolves a projected state.
+- Position `security_id` and `security_name` values are preserved in the top-position driver
+  payloads when available.
+- `top_n` is accepted by the endpoint for top-N cumulative concentration fields but does not
+  change `TOP_POSITION_WEIGHT`.
 
 ## Upstream Data Sources
-- Same source path as position HHI.
+- Stateless mode uses caller-provided `stateless_input.current_positions` and
+  `stateless_input.projected_positions`.
+- Stateful mode requests a lotus-core baseline snapshot and uses `positions_baseline` for both
+  current and proposed states.
+- Simulation mode creates or reuses a lotus-core simulation session, applies requested changes,
+  requests a simulation snapshot, and uses baseline positions as current state and projected
+  positions as proposed state.
+- There is no lotus-performance dependency for top-position weight.
 
 ## Unit Conventions
-- Position inputs are non-negative portfolio amounts:
-  - `market_value_base` when available
-  - `quantity` as fallback when market value is unavailable
-- Output weights are decimals in `[0, 1]`.
+- Position inputs are portfolio amount-like values, not return percentages.
+- Stateless current rows use `market_value_base` when present; otherwise they fall back to
+  `quantity`.
+- Stateless projected rows use `projected_market_value_base` when present; otherwise they fall
+  back to `proposed_quantity`.
+- Stateful and simulation snapshot rows use `market_value_base` when present; otherwise they fall
+  back to `quantity`.
+- Values are parsed through Decimal from the source value's string representation. Missing,
+  non-numeric, zero, and negative values are excluded before weight construction.
+- Output weights are decimal ratios in `[0, 1]` and are rounded to six decimal places by the
+  service response.
 
 ## Variable Dictionary
-- `v_i`: position value.
-- `w_i = |v_i|/sum|v|`.
-- `TOP_1 = max_i(w_i)`.
-- `V = sum_i |v_i|`: absolute denominator for weight normalization.
-- `TOP_1_current`, `TOP_1_proposed`, `TOP_1_delta`: output trio.
+- `C`: current extracted positive numeric position values.
+- `P`: proposed extracted positive numeric position values.
+- `x_i`: one extracted positive current value in `C`.
+- `y_i`: one extracted positive proposed value in `P`.
+- `V_C = sum_i(abs(x_i))`: current absolute exposure denominator.
+- `V_P = sum_i(abs(y_i))`: proposed absolute exposure denominator.
+- `w_i_current = abs(x_i) / V_C` when `V_C > 0`.
+- `w_i_proposed = abs(y_i) / V_P` when `V_P > 0`.
+- `TOP_current_raw = max_i(w_i_current)`.
+- `TOP_proposed_raw = max_i(w_i_proposed)`.
+- `TOP_delta_raw = TOP_proposed_raw - TOP_current_raw`.
+- `round6(z)`: Python `round(z, 6)` used by the service response.
 
 ## Methodology and Formulas
-1. Compute absolute-normalized weights for each state.
-2. Select maximum weight for each state.
-3. Compute delta between proposed and current top weights.
+For each state:
+
+1. Extract one positive numeric value per usable position row according to the mode-specific
+   field precedence.
+2. Compute the denominator:
+   `V = sum(abs(v_i))`.
+3. If `V <= 0`, set the top-position weight to `0.0`.
+4. Otherwise compute normalized weights:
+   `w_i = abs(v_i) / V`.
+5. Select the largest weight:
+   `TOP_raw = max_i(w_i)`.
+6. Emit:
+   - `single_position_concentration.top_position_weight_current = round6(TOP_current_raw)`
+   - `single_position_concentration.top_position_weight_proposed = round6(TOP_proposed_raw)`
+   - `single_position_concentration.top_position_weight_delta = round6(TOP_proposed_raw - TOP_current_raw)`
+
+When no proposed values are available, the implemented service sets
+`TOP_proposed_raw = TOP_current_raw`; the emitted delta is therefore `0.0`.
+
+Driver payloads use the same denominator and select the position row with the largest absolute
+value. If multiple rows have the same absolute value, the current implementation selects the row
+with the lexicographically largest `security_id` among tied values.
 
 ## Step-by-Step Computation
-1. Build value vectors.
-2. Normalize to absolute weights.
-3. Take max weight per state.
-4. Emit current/proposed/delta fields.
+1. Resolve request mode.
+2. Build current position entries:
+   - stateless: caller current positions,
+   - stateful: lotus-core baseline positions,
+   - simulation: lotus-core baseline positions.
+3. Build proposed position entries:
+   - stateless: caller projected positions,
+   - stateful: same baseline positions as current,
+   - simulation: lotus-core projected positions when available.
+4. For each row, parse the preferred value field, fall back to the secondary value field, and keep
+   only positive numeric values.
+5. Compute current top-position weight from current values.
+6. Compute proposed top-position weight from proposed values, or reuse current top-position weight
+   when proposed values are empty.
+7. Compute proposed-minus-current delta.
+8. Build `top_position_current` and `top_position_proposed` driver payloads from the selected
+   current/proposed rows.
+9. Round each emitted weight and delta to six decimal places.
 
 ## Validation and Failure Behavior
-- If denominator is zero, top weight returns `0`.
-- Non-numeric position values are ignored/rejected upstream.
+- Empty current values produce `single_position_concentration.top_position_weight_current = 0.0`.
+- Empty proposed values do not create an error; proposed top-position weight and driver fall back
+  to current state.
+- Missing, non-numeric, zero, and negative values are excluded from the value vector.
+- A single valid position produces top-position weight `1.0`.
+- Equal weights across `N` valid positions produce top-position weight `1 / N`.
+- Issuer enrichment coverage does not change `single_position_concentration.top_position_*`;
+  issuer coverage applies to `issuer_concentration`, not single-position concentration.
+- The endpoint may still emit degraded calculation supportability for issuer coverage gaps, but
+  top-position weight remains calculated from the available position values.
 
 ## Configuration Options
-- No dedicated formula option exists beyond the underlying portfolio state:
-  - `top_n` does not affect this metric
-  - `include_cash_positions` and `include_zero_quantity_positions` can change the input universe
+- No direct request option changes the top-position formula.
+- Options that can change the source position universe:
+  - `include_cash_positions`
+  - `include_zero_quantity_positions`
+  - `reporting_currency`
+- Options that do not change the top-position formula:
+  - `top_n`
+  - `issuer_grouping_level`
+  - `enrichment_policy`
 
 ## Outputs
 - `single_position_concentration.top_position_weight_current`
@@ -54,14 +130,21 @@
 - `single_position_concentration.top_position_proposed`
 
 ## Worked Example
-Values current `[50,30,20]`, proposed `[60,25,15]`.
-| State | Weights | Selected Top Position | Top Position Weight |
-|---|---|---|---:|
-| Current | `[0.50,0.30,0.20]` | position 1 | `0.50` |
-| Proposed | `[0.60,0.25,0.15]` | position 1 | `0.60` |
-Delta: `0.60 - 0.50 = 0.10`.
+Current values `[50, 30, 20]`; proposed values `[60, 25, 15]`.
+
+| State | Values | Denominator | Weights | Selected Position | Top Position Weight |
+|---|---|---:|---|---|---:|
+| Current | `[50, 30, 20]` | `100` | `[0.50, 0.30, 0.20]` | first position | `0.50` |
+| Proposed | `[60, 25, 15]` | `100` | `[0.60, 0.25, 0.15]` | first position | `0.60` |
+
+Delta:
+
+`single_position_concentration.top_position_weight_delta = 0.60 - 0.50 = 0.10`.
+
 Output mapping:
-- `single_position_concentration.top_position_weight_current=0.50`
-- `single_position_concentration.top_position_weight_proposed=0.60`
-- `single_position_concentration.top_position_weight_delta=0.10`
+
+- `single_position_concentration.top_position_weight_current = 0.50`
+- `single_position_concentration.top_position_weight_proposed = 0.60`
+- `single_position_concentration.top_position_weight_delta = 0.10`
 - `single_position_concentration.top_position_current` identifies the current top position
+- `single_position_concentration.top_position_proposed` identifies the proposed top position

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-15T07:39:13.884277+00:00",
+  "generatedAt": "2026-05-15T10:18:10.183436+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -2702,7 +2702,7 @@
       "semanticId": "lotus.top_position_weight_current",
       "canonicalTerm": "top_position_weight_current",
       "preferredName": "top_position_weight_current",
-      "description": "Highest single-position weight in baseline state.",
+      "description": "Highest single-position weight in the baseline state, computed from positive extracted position values as a decimal ratio in the 0..1 range.",
       "example": 0.1245,
       "type": "number",
       "locations": [
@@ -2716,7 +2716,7 @@
       "semanticId": "lotus.top_position_weight_delta",
       "canonicalTerm": "top_position_weight_delta",
       "preferredName": "top_position_weight_delta",
-      "description": "Difference between proposed and baseline top-position weights.",
+      "description": "Proposed-minus-baseline top-position weight change as a decimal ratio.",
       "example": 0.0175,
       "type": "number",
       "locations": [
@@ -2730,7 +2730,7 @@
       "semanticId": "lotus.top_position_weight_proposed",
       "canonicalTerm": "top_position_weight_proposed",
       "preferredName": "top_position_weight_proposed",
-      "description": "Highest single-position weight in proposed state.",
+      "description": "Highest single-position weight in the proposed state as a decimal ratio in the 0..1 range; falls back to the baseline top-position weight when no proposed position values are available.",
       "example": 0.142,
       "type": "number",
       "locations": [

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -449,15 +449,22 @@ class ConcentrationRiskProxy(BaseModel):
 
 class SinglePositionConcentration(BaseModel):
     top_position_weight_current: float = Field(
-        description="Highest single-position weight in baseline state.",
+        description=(
+            "Highest single-position weight in the baseline state, computed from positive "
+            "extracted position values as a decimal ratio in the 0..1 range."
+        ),
         json_schema_extra={"example": 0.1245},
     )
     top_position_weight_proposed: float = Field(
-        description="Highest single-position weight in proposed state.",
+        description=(
+            "Highest single-position weight in the proposed state as a decimal ratio in the 0..1 "
+            "range; falls back to the baseline top-position weight when no proposed position "
+            "values are available."
+        ),
         json_schema_extra={"example": 0.142},
     )
     top_position_weight_delta: float = Field(
-        description="Difference between proposed and baseline top-position weights.",
+        description="Proposed-minus-baseline top-position weight change as a decimal ratio.",
         json_schema_extra={"example": 0.0175},
     )
     top_n_cumulative_weight_current: float = Field(

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -155,6 +155,63 @@ async def test_position_hhi_matches_documented_stateless_methodology_example() -
 
 
 @pytest.mark.asyncio
+async def test_top_position_weight_matches_documented_stateless_methodology_example() -> None:
+    request = ConcentrationRequest.model_validate(
+        {
+            "input_mode": "stateless",
+            "stateless_input": {
+                "current_positions": [
+                    {
+                        "security_id": "A",
+                        "security_name": "Alpha",
+                        "market_value_base": 50,
+                    },
+                    {"security_id": "B", "security_name": "Beta", "market_value_base": 30},
+                    {"security_id": "C", "security_name": "Core", "market_value_base": 20},
+                    {"security_id": "IGNORED_ZERO", "market_value_base": 0},
+                    {"security_id": "IGNORED_NEGATIVE", "market_value_base": -10},
+                ],
+                "projected_positions": [
+                    {
+                        "security_id": "A",
+                        "security_name": "Alpha",
+                        "projected_market_value_base": 60,
+                    },
+                    {
+                        "security_id": "B",
+                        "security_name": "Beta",
+                        "projected_market_value_base": 25,
+                    },
+                    {
+                        "security_id": "C",
+                        "security_name": "Core",
+                        "projected_market_value_base": 15,
+                    },
+                ],
+                "top_n": 2,
+            },
+        }
+    )
+
+    response = (await calculate_concentration(request)).model_dump()
+
+    single_position = response["single_position_concentration"]
+    assert single_position["top_position_weight_current"] == 0.5
+    assert single_position["top_position_weight_proposed"] == 0.6
+    assert single_position["top_position_weight_delta"] == 0.1
+    assert single_position["top_position_current"] == {
+        "security_id": "A",
+        "security_name": "Alpha",
+        "weight": 0.5,
+    }
+    assert single_position["top_position_proposed"] == {
+        "security_id": "A",
+        "security_name": "Alpha",
+        "weight": 0.6,
+    }
+
+
+@pytest.mark.asyncio
 async def test_calculate_concentration_rejects_legacy_payload() -> None:
     with pytest.raises(ValidationError):
         ConcentrationRequest.model_validate(

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -29,6 +29,9 @@ DRAWDOWN_TIME_UNDER_WATER_DOC = (
 CONCENTRATION_POSITION_HHI_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-hhi.md"
 )
+CONCENTRATION_TOP_POSITION_WEIGHT_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-top-position-weight.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -361,6 +364,44 @@ def test_concentration_position_hhi_methodology_is_auditable_against_engine_cont
         "`risk_proxy.hhi_current = 3800.0`",
         "`risk_proxy.hhi_proposed = 4450.0`",
         "`risk_proxy.hhi_delta = 650.0`",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_concentration_top_position_weight_methodology_is_auditable_against_engine_contract() -> (
+    None
+):
+    text = CONCENTRATION_TOP_POSITION_WEIGHT_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: TOP_POSITION_WEIGHT",
+        "source_product: ConcentrationRiskReport:v1",
+        "/analytics/risk/concentration",
+        "`single_position_concentration`",
+        "lotus-core baseline snapshot",
+        "lotus-core simulation session",
+        "There is no lotus-performance dependency for top-position weight",
+        "market_value_base` when present",
+        "projected_market_value_base` when present",
+        "Missing, non-numeric, zero, and negative values are excluded",
+        "Output weights are decimal ratios in `[0, 1]`",
+        "TOP_raw = max_i(w_i)",
+        "`single_position_concentration.top_position_weight_current = round6(TOP_current_raw)`",
+        "When no proposed values are available",
+        "lexicographically largest `security_id`",
+        "A single valid position produces top-position weight `1.0`",
+        "Equal weights across `N` valid positions produce top-position weight `1 / N`",
+        "Issuer enrichment coverage does not change `single_position_concentration.top_position_*`",
+        "`include_cash_positions`",
+        "`top_n`",
+        "`issuer_grouping_level`",
+        "`single_position_concentration.top_position_weight_current = 0.50`",
+        "`single_position_concentration.top_position_weight_proposed = 0.60`",
+        "`single_position_concentration.top_position_weight_delta = 0.10`",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -70,13 +70,16 @@ posture, never-underwater zero-drawdown posture, duration-unit day counter behav
 boundary that episode-list filters do not change the summary maximum, average, ulcer-index, or
 time-under-water drawdown values.
 
-`ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI.
+`ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI and
+top-position weight.
 The methodology is tied to the implemented `/analytics/risk/concentration` engine and states the
 stateless, stateful, and simulation source paths, positive numeric value extraction, market-value
 versus quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
-Herfindahl-Hirschman scaling, six-decimal response rounding, proposed-state fallback to current
-HHI when projected values are unavailable, input-universe option boundaries, and issuer-enrichment
-isolation from `risk_proxy.hhi_*` outputs.
+Herfindahl-Hirschman scaling for HHI, decimal `0..1` top-position weight output, six-decimal
+response rounding, proposed-state fallback to current values when projected values are
+unavailable, deterministic top-position driver selection, input-universe option boundaries, and
+issuer-enrichment isolation from `risk_proxy.hhi_*` and
+`single_position_concentration.top_position_*` outputs.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security


### PR DESCRIPTION
## Summary
- pins `TOP_POSITION_WEIGHT` methodology for `ConcentrationRiskReport:v1` to implementation behavior
- clarifies top-position contract descriptions and regenerates the API vocabulary inventory
- updates risk repo context and wiki source with source-owner concentration methodology truth

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py -q` -> 27 passed
- `python -m ruff check src\app\contracts\concentration.py tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py`
- `python -m ruff format --check src\app\contracts\concentration.py tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py`
- `git diff --check`
- `make check` -> 352 unit tests passed
- `make test-pyramid-gate` -> unit 352 (74.89%), integration 94 (20.00%), e2e 24 (5.11%)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift: `Mesh-Data-Products.md`

## Branch Hygiene
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches
- `gh pr list --state open --json number,title,headRefName,url,statusCheckRollup` -> `[]`