### PR TITLE
docs(risk): pin concentration top-n methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -98,13 +98,15 @@ Current repository posture:
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
 14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
-    `POSITION_HHI` and `TOP_POSITION_WEIGHT`: the docs and tests pin stateless, stateful, and
-    simulation source resolution, positive numeric position-value extraction, market-value versus
-    quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
-    Herfindahl-Hirschman scaling for HHI, six-decimal response rounding, proposed-state fallback
-    to current values when projected values are unavailable, deterministic top-position driver
-    selection, input-universe option boundaries, and issuer-enrichment isolation from
-    `risk_proxy.hhi_*` and `single_position_concentration.top_position_*` outputs.
+    `POSITION_HHI`, `TOP_POSITION_WEIGHT`, and `TOP_N_CUMULATIVE_WEIGHT`: the docs and tests pin
+    stateless, stateful, and simulation source resolution, positive numeric position-value
+    extraction, market-value versus quantity fallback precedence, decimal position-weight
+    construction, conventional `0..10000` Herfindahl-Hirschman scaling for HHI, decimal `0..1`
+    top-position and top-N cumulative weight output, six-decimal response rounding,
+    proposed-state fallback to current values when projected values are unavailable, deterministic
+    top-position driver selection, top-N cumulative summation, input-universe option boundaries,
+    and issuer-enrichment isolation from `risk_proxy.hhi_*` and
+    `single_position_concentration.top_position_*` / `top_n_cumulative_weight_*` outputs.
 
 ## Architecture And Module Map
 

--- a/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
+++ b/docs/methodologies/metrics/concentration-top-n-cumulative-weight.md
@@ -2,67 +2,151 @@
 
 ## Metric
 - metric_id: TOP_N_CUMULATIVE_WEIGHT
+- source_product: ConcentrationRiskReport:v1
+- methodology_version: concentration.top_n_cumulative_weight.v1
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/concentration
 - supported_modes: stateless, stateful, simulation
+- output_family: `single_position_concentration`
 
 ## Inputs
-- Position value vectors for current and proposed states.
-- `top_n` parameter.
+- Current position rows.
+- Proposed position rows when the caller supplies or source state resolves a projected state.
+- `top_n` from `stateless_input.top_n`, `stateful_input.top_n`, or `simulation_input.top_n`.
+- The request contract constrains `top_n` to an integer in the inclusive range `1..50`.
 
 ## Upstream Data Sources
-- Same source path as concentration HHI.
+- Stateless mode uses caller-provided `stateless_input.current_positions` and
+  `stateless_input.projected_positions`.
+- Stateful mode requests a lotus-core baseline snapshot and uses `positions_baseline` for both
+  current and proposed states.
+- Simulation mode creates or reuses a lotus-core simulation session, applies requested changes,
+  requests a simulation snapshot, and uses baseline positions as current state and projected
+  positions as proposed state.
+- There is no lotus-performance dependency for top-N cumulative weight.
 
 ## Unit Conventions
-- Position inputs are non-negative portfolio amounts:
-  - `market_value_base` when available
-  - `quantity` as fallback when market value is unavailable
-- Output weights are decimals in `[0, 1]`.
+- Position inputs are portfolio amount-like values, not return percentages.
+- Stateless current rows use `market_value_base` when present; otherwise they fall back to
+  `quantity`.
+- Stateless projected rows use `projected_market_value_base` when present; otherwise they fall
+  back to `proposed_quantity`.
+- Stateful and simulation snapshot rows use `market_value_base` when present; otherwise they fall
+  back to `quantity`.
+- Values are parsed through Decimal from the source value's string representation. Missing,
+  non-numeric, zero, and negative values are excluded before weight construction.
+- Output weights are decimal ratios in `[0, 1]` and are rounded to six decimal places by the
+  service response.
 
 ## Variable Dictionary
-- `v_i`: position value.
-- `w_i = |v_i|/sum|v|`.
-- `w_(i)`: weights sorted descending.
-- `N = top_n`.
-- `TOP_N = sum_{i=1..N}(w_(i))`.
-- `TOP_N_delta = TOP_N_proposed - TOP_N_current`.
+- `N`: requested top-N integer from the mode input.
+- `C`: current extracted positive numeric position values.
+- `P`: proposed extracted positive numeric position values.
+- `x_i`: one extracted positive current value in `C`.
+- `y_i`: one extracted positive proposed value in `P`.
+- `V_C = sum_i(abs(x_i))`: current absolute exposure denominator.
+- `V_P = sum_i(abs(y_i))`: proposed absolute exposure denominator.
+- `w_i_current = abs(x_i) / V_C` when `V_C > 0`.
+- `w_i_proposed = abs(y_i) / V_P` when `V_P > 0`.
+- `sort_desc(W)`: weights sorted from largest to smallest.
+- `TOP_N_current_raw = sum(first N values of sort_desc(w_current))`.
+- `TOP_N_proposed_raw = sum(first N values of sort_desc(w_proposed))`.
+- `TOP_N_delta_raw = TOP_N_proposed_raw - TOP_N_current_raw`.
+- `round6(z)`: Python `round(z, 6)` used by the service response.
 
 ## Methodology and Formulas
-1. Compute normalized weights.
-2. Sort descending.
-3. Sum first N values for each state.
-4. Compute delta.
+For each state:
+
+1. Extract one positive numeric value per usable position row according to the mode-specific
+   field precedence.
+2. Compute the denominator:
+   `V = sum(abs(v_i))`.
+3. If `V <= 0`, set the top-N cumulative weight to `0.0`.
+4. Otherwise compute normalized weights:
+   `w_i = abs(v_i) / V`.
+5. Sort weights descending:
+   `W_sorted = sort_desc(w)`.
+6. Sum the first `N` sorted weights:
+   `TOP_N_raw = sum(W_sorted[0:N])`.
+7. Emit:
+   - `single_position_concentration.top_n_cumulative_weight_current = round6(TOP_N_current_raw)`
+   - `single_position_concentration.top_n_cumulative_weight_proposed = round6(TOP_N_proposed_raw)`
+   - `single_position_concentration.top_n_cumulative_weight_delta = round6(TOP_N_proposed_raw - TOP_N_current_raw)`
+   - `single_position_concentration.top_n = N`
+
+When no proposed values are available, the implemented service sets
+`TOP_N_proposed_raw = TOP_N_current_raw`; the emitted delta is therefore `0.0`.
 
 ## Step-by-Step Computation
-1. Build current/proposed weight vectors.
-2. Apply top-n aggregation.
-3. Emit current/proposed/delta and top_n.
+1. Resolve request mode.
+2. Build current position entries:
+   - stateless: caller current positions,
+   - stateful: lotus-core baseline positions,
+   - simulation: lotus-core baseline positions.
+3. Build proposed position entries:
+   - stateless: caller projected positions,
+   - stateful: same baseline positions as current,
+   - simulation: lotus-core projected positions when available.
+4. For each row, parse the preferred value field, fall back to the secondary value field, and keep
+   only positive numeric values.
+5. Normalize current values into current position weights.
+6. Normalize proposed values into proposed position weights, or reuse current top-N cumulative
+   weight when proposed values are empty.
+7. Sort each state's weights descending.
+8. Sum at most `N` sorted weights for each state.
+9. Compute proposed-minus-current delta.
+10. Round each emitted top-N weight and delta to six decimal places.
 
 ## Validation and Failure Behavior
-- If `top_n` exceeds position count, sum all available weights.
-- Zero denominator yields `0`.
+- `top_n` less than `1` or greater than `50` is rejected by the request contract before
+  calculation.
+- Empty current values produce
+  `single_position_concentration.top_n_cumulative_weight_current = 0.0`.
+- Empty proposed values do not create an error; proposed top-N cumulative weight falls back to
+  current state.
+- Missing, non-numeric, zero, and negative values are excluded from the value vector.
+- A single valid position produces top-N cumulative weight `1.0` for any valid `N`.
+- If `N` exceeds the number of valid positions, the service sums all available sorted weights.
+- Equal weights across `M` valid positions produce top-N cumulative weight `min(N, M) / M`.
+- Issuer enrichment coverage does not change
+  `single_position_concentration.top_n_cumulative_weight_*`; issuer coverage applies to
+  `issuer_concentration`, not single-position concentration.
+- The endpoint may still emit degraded calculation supportability for issuer coverage gaps, but
+  top-N cumulative weight remains calculated from the available position values.
 
 ## Configuration Options
-- `stateless_input.top_n`
-- `stateful_input.top_n`
-- `simulation_input.top_n`
+- Direct formula option:
+  - `top_n`
+- Options that can change the source position universe:
+  - `include_cash_positions`
+  - `include_zero_quantity_positions`
+  - `reporting_currency`
+- Options that do not change the top-N cumulative formula:
+  - `issuer_grouping_level`
+  - `enrichment_policy`
 
 ## Outputs
 - `single_position_concentration.top_n_cumulative_weight_current`
-- `..._proposed`
-- `..._delta`
+- `single_position_concentration.top_n_cumulative_weight_proposed`
+- `single_position_concentration.top_n_cumulative_weight_delta`
 - `single_position_concentration.top_n`
 
 ## Worked Example
-Current weights `[0.50,0.30,0.20]`, proposed `[0.60,0.25,0.15]`, `top_n=2`.
-| State | Sorted Weights | Sum of Largest 2 Weights | Top-2 Cumulative Weight |
-|---|---|---|---:|
-| Current | `[0.50,0.30,0.20]` | `0.50 + 0.30` | `0.80` |
-| Proposed | `[0.60,0.25,0.15]` | `0.60 + 0.25` | `0.85` |
-Delta: `0.05`.
+Current values `[50, 30, 20]`; proposed values `[60, 25, 15]`; `top_n = 2`.
+
+| State | Values | Denominator | Sorted Weights | Sum of First 2 | Top-N Cumulative Weight |
+|---|---|---:|---|---|---:|
+| Current | `[50, 30, 20]` | `100` | `[0.50, 0.30, 0.20]` | `0.50 + 0.30` | `0.80` |
+| Proposed | `[60, 25, 15]` | `100` | `[0.60, 0.25, 0.15]` | `0.60 + 0.25` | `0.85` |
+
+Delta:
+
+`single_position_concentration.top_n_cumulative_weight_delta = 0.85 - 0.80 = 0.05`.
+
 Output mapping:
-- `single_position_concentration.top_n_cumulative_weight_current=0.80`
-- `single_position_concentration.top_n_cumulative_weight_proposed=0.85`
-- `single_position_concentration.top_n_cumulative_weight_delta=0.05`
-- `single_position_concentration.top_n=2`
+
+- `single_position_concentration.top_n_cumulative_weight_current = 0.80`
+- `single_position_concentration.top_n_cumulative_weight_proposed = 0.85`
+- `single_position_concentration.top_n_cumulative_weight_delta = 0.05`
+- `single_position_concentration.top_n = 2`

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-15T10:18:10.183436+00:00",
+  "generatedAt": "2026-05-15T11:26:32.002005+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -2600,7 +2600,7 @@
       "semanticId": "lotus.top_n",
       "canonicalTerm": "top_n",
       "preferredName": "top_n",
-      "description": "Top-N parameter used for cumulative concentration calculations.",
+      "description": "Top-N parameter used for cumulative single-position concentration calculations.",
       "example": 10,
       "type": "integer",
       "locations": [
@@ -2614,7 +2614,7 @@
       "semanticId": "lotus.top_n_cumulative_weight_current",
       "canonicalTerm": "top_n_cumulative_weight_current",
       "preferredName": "top_n_cumulative_weight_current",
-      "description": "Cumulative baseline weight of top-N positions.",
+      "description": "Cumulative baseline weight of the largest N positive extracted position values as a decimal ratio in the 0..1 range.",
       "example": 0.4123,
       "type": "number",
       "locations": [
@@ -2628,7 +2628,7 @@
       "semanticId": "lotus.top_n_cumulative_weight_delta",
       "canonicalTerm": "top_n_cumulative_weight_delta",
       "preferredName": "top_n_cumulative_weight_delta",
-      "description": "Difference between proposed and baseline top-N cumulative weights.",
+      "description": "Proposed-minus-baseline top-N cumulative weight change as a decimal ratio.",
       "example": 0.0428,
       "type": "number",
       "locations": [
@@ -2642,7 +2642,7 @@
       "semanticId": "lotus.top_n_cumulative_weight_proposed",
       "canonicalTerm": "top_n_cumulative_weight_proposed",
       "preferredName": "top_n_cumulative_weight_proposed",
-      "description": "Cumulative proposed weight of top-N positions.",
+      "description": "Cumulative proposed weight of the largest N positive extracted position values as a decimal ratio in the 0..1 range; falls back to the baseline top-N cumulative weight when no proposed position values are available.",
       "example": 0.4551,
       "type": "number",
       "locations": [

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -468,19 +468,26 @@ class SinglePositionConcentration(BaseModel):
         json_schema_extra={"example": 0.0175},
     )
     top_n_cumulative_weight_current: float = Field(
-        description="Cumulative baseline weight of top-N positions.",
+        description=(
+            "Cumulative baseline weight of the largest N positive extracted position values as "
+            "a decimal ratio in the 0..1 range."
+        ),
         json_schema_extra={"example": 0.4123},
     )
     top_n_cumulative_weight_proposed: float = Field(
-        description="Cumulative proposed weight of top-N positions.",
+        description=(
+            "Cumulative proposed weight of the largest N positive extracted position values as "
+            "a decimal ratio in the 0..1 range; falls back to the baseline top-N cumulative "
+            "weight when no proposed position values are available."
+        ),
         json_schema_extra={"example": 0.4551},
     )
     top_n_cumulative_weight_delta: float = Field(
-        description="Difference between proposed and baseline top-N cumulative weights.",
+        description="Proposed-minus-baseline top-N cumulative weight change as a decimal ratio.",
         json_schema_extra={"example": 0.0428},
     )
     top_n: int = Field(
-        description="Top-N parameter used for cumulative concentration calculations.",
+        description="Top-N parameter used for cumulative single-position concentration calculations.",
         json_schema_extra={"example": 10},
     )
     top_position_current: "TopPositionDriver" = Field(

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -212,6 +212,38 @@ async def test_top_position_weight_matches_documented_stateless_methodology_exam
 
 
 @pytest.mark.asyncio
+async def test_top_n_cumulative_weight_matches_documented_stateless_methodology_example() -> None:
+    request = ConcentrationRequest.model_validate(
+        {
+            "input_mode": "stateless",
+            "stateless_input": {
+                "current_positions": [
+                    {"security_id": "A", "market_value_base": 50},
+                    {"security_id": "B", "market_value_base": 30},
+                    {"security_id": "C", "market_value_base": 20},
+                    {"security_id": "IGNORED_ZERO", "market_value_base": 0},
+                    {"security_id": "IGNORED_NEGATIVE", "market_value_base": -10},
+                ],
+                "projected_positions": [
+                    {"security_id": "A", "projected_market_value_base": 60},
+                    {"security_id": "B", "projected_market_value_base": 25},
+                    {"security_id": "C", "projected_market_value_base": 15},
+                ],
+                "top_n": 2,
+            },
+        }
+    )
+
+    response = (await calculate_concentration(request)).model_dump()
+
+    single_position = response["single_position_concentration"]
+    assert single_position["top_n_cumulative_weight_current"] == 0.8
+    assert single_position["top_n_cumulative_weight_proposed"] == 0.85
+    assert single_position["top_n_cumulative_weight_delta"] == 0.05
+    assert single_position["top_n"] == 2
+
+
+@pytest.mark.asyncio
 async def test_calculate_concentration_rejects_legacy_payload() -> None:
     with pytest.raises(ValidationError):
         ConcentrationRequest.model_validate(

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -32,6 +32,9 @@ CONCENTRATION_POSITION_HHI_DOC = (
 CONCENTRATION_TOP_POSITION_WEIGHT_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-top-position-weight.md"
 )
+CONCENTRATION_TOP_N_CUMULATIVE_WEIGHT_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-top-n-cumulative-weight.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -402,6 +405,46 @@ def test_concentration_top_position_weight_methodology_is_auditable_against_engi
         "`single_position_concentration.top_position_weight_current = 0.50`",
         "`single_position_concentration.top_position_weight_proposed = 0.60`",
         "`single_position_concentration.top_position_weight_delta = 0.10`",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_concentration_top_n_cumulative_weight_methodology_is_auditable_against_engine_contract() -> (
+    None
+):
+    text = CONCENTRATION_TOP_N_CUMULATIVE_WEIGHT_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: TOP_N_CUMULATIVE_WEIGHT",
+        "source_product: ConcentrationRiskReport:v1",
+        "/analytics/risk/concentration",
+        "`single_position_concentration`",
+        "lotus-core baseline snapshot",
+        "lotus-core simulation session",
+        "There is no lotus-performance dependency for top-N cumulative weight",
+        "`top_n` to an integer in the inclusive range `1..50`",
+        "market_value_base` when present",
+        "projected_market_value_base` when present",
+        "Missing, non-numeric, zero, and negative values are excluded",
+        "Output weights are decimal ratios in `[0, 1]`",
+        "TOP_N_raw = sum(W_sorted[0:N])",
+        "`single_position_concentration.top_n_cumulative_weight_current = round6(TOP_N_current_raw)`",
+        "When no proposed values are available",
+        "A single valid position produces top-N cumulative weight `1.0`",
+        "If `N` exceeds the number of valid positions",
+        "Equal weights across `M` valid positions produce top-N cumulative weight `min(N, M) / M`",
+        "Issuer enrichment coverage does not change",
+        "`single_position_concentration.top_n_cumulative_weight_*`",
+        "`include_cash_positions`",
+        "`issuer_grouping_level`",
+        "`single_position_concentration.top_n_cumulative_weight_current = 0.80`",
+        "`single_position_concentration.top_n_cumulative_weight_proposed = 0.85`",
+        "`single_position_concentration.top_n_cumulative_weight_delta = 0.05`",
+        "`single_position_concentration.top_n = 2`",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -70,16 +70,17 @@ posture, never-underwater zero-drawdown posture, duration-unit day counter behav
 boundary that episode-list filters do not change the summary maximum, average, ulcer-index, or
 time-under-water drawdown values.
 
-`ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI and
-top-position weight.
+`ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI,
+top-position weight, and top-N cumulative weight.
 The methodology is tied to the implemented `/analytics/risk/concentration` engine and states the
 stateless, stateful, and simulation source paths, positive numeric value extraction, market-value
 versus quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
-Herfindahl-Hirschman scaling for HHI, decimal `0..1` top-position weight output, six-decimal
-response rounding, proposed-state fallback to current values when projected values are
-unavailable, deterministic top-position driver selection, input-universe option boundaries, and
-issuer-enrichment isolation from `risk_proxy.hhi_*` and
-`single_position_concentration.top_position_*` outputs.
+Herfindahl-Hirschman scaling for HHI, decimal `0..1` top-position and top-N cumulative weight
+output, six-decimal response rounding, proposed-state fallback to current values when projected
+values are unavailable, deterministic top-position driver selection, top-N cumulative summation,
+input-universe option boundaries, and issuer-enrichment isolation from `risk_proxy.hhi_*`,
+`single_position_concentration.top_position_*`, and
+`single_position_concentration.top_n_cumulative_weight_*` outputs.
 
 `RegimeScenarioPackEvaluation:v1` now carries source-owned scenario-pack evidence beyond aggregate
 loss. When callers provide reconciled `exposure_components`, the product emits per-security


### PR DESCRIPTION
## Summary
- pins `TOP_N_CUMULATIVE_WEIGHT` methodology for `ConcentrationRiskReport:v1` to implementation behavior
- clarifies top-N cumulative contract descriptions and regenerates the API vocabulary inventory
- updates risk repo context and wiki source with source-owner concentration methodology truth

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py -q` -> 29 passed
- `python -m ruff check src\app\contracts\concentration.py tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py`
- `python -m ruff format --check src\app\contracts\concentration.py tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py`
- `git diff --check`
- `make check` -> 354 unit tests passed
- `make test-pyramid-gate` -> unit 354 (75.00%), integration 94 (19.92%), e2e 24 (5.08%)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected pre-merge drift: `Mesh-Data-Products.md`

## Branch Hygiene
- `git fetch origin --prune`
- `git branch -r --no-merged origin/main` -> no unmerged remote branches
- `gh pr list --state open --json number,title,headRefName,url,statusCheckRollup` -> `[]`