### PR TITLE
docs(risk): pin concentration issuer HHI methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -98,14 +98,16 @@ Current repository posture:
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
 14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
-    `POSITION_HHI`, `TOP_POSITION_WEIGHT`, and `TOP_N_CUMULATIVE_WEIGHT`: the docs and tests pin
+    `POSITION_HHI`, `TOP_POSITION_WEIGHT`, `TOP_N_CUMULATIVE_WEIGHT`, and `ISSUER_HHI`: the docs and tests pin
     stateless, stateful, and simulation source resolution, positive numeric position-value
     extraction, market-value versus quantity fallback precedence, decimal position-weight
     construction, conventional `0..10000` Herfindahl-Hirschman scaling for HHI, decimal `0..1`
     top-position and top-N cumulative weight output, six-decimal response rounding,
     proposed-state fallback to current values when projected values are unavailable, deterministic
-    top-position driver selection, top-N cumulative summation, input-universe option boundaries,
-    and issuer-enrichment isolation from `risk_proxy.hhi_*` and
+    top-position driver selection, top-N cumulative summation, covered-subset issuer aggregation,
+    legal versus ultimate-parent issuer grouping, issuer-enrichment precedence, issuer coverage
+    and supportability posture, input-universe option boundaries, and issuer-enrichment isolation
+    from `risk_proxy.hhi_*` and
     `single_position_concentration.top_position_*` / `top_n_cumulative_weight_*` outputs.
 
 ## Architecture And Module Map

--- a/docs/methodologies/metrics/concentration-issuer-hhi.md
+++ b/docs/methodologies/metrics/concentration-issuer-hhi.md
@@ -2,63 +2,166 @@
 
 ## Metric
 - metric_id: ISSUER_HHI
+- source_product: ConcentrationRiskReport:v1
+- methodology_version: concentration.issuer_hhi.v1
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/concentration
 - supported_modes: stateless, stateful, simulation
+- output_family: `issuer_concentration`
 
 ## Inputs
-- Position values plus issuer mapping (issuer or ultimate parent).
-- Issuer enrichment policy and grouping level.
+- Current position rows.
+- Proposed position rows when the caller supplies or source state resolves a projected state.
+- Issuer identifiers supplied on stateless position rows, caller issuer mappings, and/or
+  lotus-core enrichment rows.
+- `issuer_grouping_level`, which chooses legal issuer grouping or ultimate-parent issuer grouping.
+- `enrichment_policy`, which chooses caller-only, core-only, or merged issuer-map precedence.
 
 ## Upstream Data Sources
-- Caller mapping and/or lotus-core enrichment.
-- Stateful/simulation snapshots from lotus-core.
+- Stateless mode uses caller-provided `stateless_input.current_positions` and
+  `stateless_input.projected_positions`.
+- Stateless mode may call lotus-core instrument enrichment when a core client is available and
+  `enrichment_policy` is not `use_caller_only`.
+- Stateful mode requests a lotus-core baseline snapshot with `positions_baseline`,
+  `portfolio_totals`, and `instrument_enrichment`; it uses baseline positions for both current
+  and proposed states.
+- Simulation mode creates or reuses a lotus-core simulation session, applies requested changes,
+  requests a simulation snapshot with `positions_baseline`, `positions_projected`,
+  `positions_delta`, `portfolio_totals`, and `instrument_enrichment`, and uses baseline positions
+  as current state and projected positions as proposed state.
+- There is no lotus-performance dependency for issuer HHI.
 
 ## Unit Conventions
-- Position inputs are non-negative portfolio amounts:
-  - `market_value_base` when available
-  - `quantity` as fallback when market value is unavailable
-- Issuer weights are decimals in `[0, 1]`.
-- Issuer HHI is reported on the conventional `0..10000` scale.
+- Position inputs are portfolio amount-like values, not return percentages.
+- Stateless current rows use `market_value_base` when present; otherwise they fall back to
+  `quantity`.
+- Stateless projected rows use `projected_market_value_base` when present; otherwise they fall
+  back to `proposed_quantity`.
+- Stateful and simulation snapshot rows use `market_value_base` when present; otherwise they fall
+  back to `quantity`.
+- Values are parsed through Decimal from the source value's string representation. Missing,
+  non-numeric, zero, and negative values are excluded before issuer aggregation and coverage
+  counting.
+- Issuer weights are decimal ratios in `[0, 1]`.
+- `issuer_concentration.hhi_*` values are emitted on the conventional Herfindahl-Hirschman
+  `0..10000` scale and rounded to six decimal places by the service response.
 
 ## Variable Dictionary
-- `security_id`: instrument identifier in position rows.
-- `issuer_key`: issuer bucket key chosen by grouping level.
-- `issuer_value_k`: aggregate value for issuer bucket `k`.
-- `W_issuer = sum_k |issuer_value_k|`: absolute issuer total.
-- `w_k = |issuer_value_k|/W_issuer`: issuer weight.
-- `ISSUER_HHI = sum_k(w_k^2)*10000`.
-- Coverage counters: covered vs total position count for each state.
-- `coverage_ratio = covered_position_count / total_position_count` when total count is non-zero, else `0`.
+- `G`: requested issuer grouping level, either legal issuer or ultimate-parent issuer.
+- `M`: resolved issuer map keyed by `security_id` after enrichment-policy precedence.
+- `C`: current extracted positive numeric position rows.
+- `P`: proposed extracted positive numeric position rows.
+- `x_i`: one extracted positive current position value in `C`.
+- `y_i`: one extracted positive proposed position value in `P`.
+- `issuer(i, G, M)`: issuer bucket selected for position `i` under grouping level `G` from map
+  `M`.
+- `K_C`: issuer buckets with at least one covered current position.
+- `K_P`: issuer buckets with at least one covered proposed position.
+- `I_{C,k} = sum(abs(x_i)) for covered current positions mapped to issuer bucket k`.
+- `I_{P,k} = sum(abs(y_i)) for covered proposed positions mapped to issuer bucket k`.
+- `V_C_issuer = sum_k(abs(I_{C,k}))`: covered current issuer denominator.
+- `V_P_issuer = sum_k(abs(I_{P,k}))`: covered proposed issuer denominator.
+- `w_{C,k} = abs(I_{C,k}) / V_C_issuer` when `V_C_issuer > 0`.
+- `w_{P,k} = abs(I_{P,k}) / V_P_issuer` when `V_P_issuer > 0`.
+- `ISSUER_HHI_current_raw = sum_k(w_{C,k}^2) * 10000`.
+- `ISSUER_HHI_proposed_raw = sum_k(w_{P,k}^2) * 10000`.
+- `ISSUER_HHI_delta_raw = ISSUER_HHI_proposed_raw - ISSUER_HHI_current_raw`.
+- `covered_position_count_state`: count of extracted positive position rows with a resolved issuer
+  bucket in that state.
+- `total_position_count_state`: count of extracted positive position rows evaluated for issuer
+  coverage in that state.
+- `coverage_ratio_state = covered_position_count_state / total_position_count_state` when the
+  denominator is non-zero, else `0.0`.
+- `round6(z)`: Python `round(z, 6)` used by the service response.
 
 ## Methodology and Formulas
-1. Resolve issuer key per position.
-2. Aggregate values per issuer.
-3. Compute issuer weights.
-4. Compute `ISSUER_HHI = sum_k (w_k^2) * 10000`.
-5. Compute issuer HHI delta.
+For each state:
+
+1. Extract one positive numeric value per usable position row according to the mode-specific
+   field precedence.
+2. Resolve the issuer map:
+   - legal issuer grouping uses `issuer_id`,
+   - ultimate-parent grouping uses `ultimate_parent_issuer_id` when present and falls back to
+     `issuer_id`,
+   - `use_caller_only` uses only caller-supplied issuer identity,
+   - `core_only` uses only lotus-core enrichment identity,
+   - merged policy starts with lotus-core identity and lets caller identity override by
+     `security_id`.
+3. Count every extracted positive position row in `total_position_count_state`.
+4. For rows with a resolved issuer bucket, add the row value to that issuer bucket and increment
+   `covered_position_count_state`.
+5. Compute the covered issuer denominator:
+   `V_issuer = sum_k(abs(I_k))`.
+6. If `V_issuer <= 0`, set issuer HHI to `0.0`.
+7. Otherwise compute issuer weights:
+   `w_k = abs(I_k) / V_issuer`.
+8. Compute issuer HHI:
+   `ISSUER_HHI_raw = sum_k(w_k^2) * 10000`.
+9. Emit:
+   - `issuer_concentration.hhi_current = round6(ISSUER_HHI_current_raw)`
+   - `issuer_concentration.hhi_proposed = round6(ISSUER_HHI_proposed_raw)`
+   - `issuer_concentration.hhi_delta = round6(ISSUER_HHI_proposed_raw - ISSUER_HHI_current_raw)`
+
+When no proposed issuer buckets are available, the implemented service sets
+`ISSUER_HHI_proposed_raw = ISSUER_HHI_current_raw`; the emitted delta is therefore `0.0`.
 
 ## Step-by-Step Computation
-1. Resolve issuer map and coverage counts.
-2. Build current/proposed issuer totals.
-3. Normalize to weights.
-4. Compute HHI current/proposed/delta.
-5. Emit coverage status and counts.
-6. Emit coverage ratios for current and proposed states.
+1. Resolve request mode.
+2. Build current position entries:
+   - stateless: caller current positions,
+   - stateful: lotus-core baseline positions,
+   - simulation: lotus-core baseline positions.
+3. Build proposed position entries:
+   - stateless: caller projected positions,
+   - stateful: same baseline positions as current,
+   - simulation: lotus-core projected positions when available.
+4. Resolve issuer identities from stateless row fields, caller `issuer_mappings`, and/or lotus-core
+   enrichment according to grouping and enrichment policy.
+5. Parse each state's preferred value field, fall back to the secondary value field, and keep only
+   positive numeric values.
+6. Aggregate only covered position values by issuer bucket.
+7. Compute current and proposed covered-issuer weights.
+8. Compute current and proposed issuer HHI on the covered issuer buckets.
+9. If proposed issuer buckets are empty, reuse current issuer HHI for proposed issuer HHI.
+10. Compute proposed-minus-current delta.
+11. Round emitted HHI values, coverage ratios, and delta fields to six decimal places.
+12. Emit issuer coverage counts, coverage ratios, coverage status, supportability, note, and top
+    issuer driver metadata alongside issuer HHI.
 
 ## Validation and Failure Behavior
-- Partial mapping yields `coverage_status=PARTIAL`.
-- No mapped issuer values produce HHI `0` with non-complete coverage.
-- The metric is computed on the covered subset only; coverage counters explain data quality.
-- If total position count is `0`, coverage ratio is emitted as `0`.
+- Missing, non-numeric, zero, and negative values are excluded before issuer aggregation and before
+  issuer coverage counts.
+- Positions without resolved issuer identity are excluded from issuer HHI but included in issuer
+  coverage totals.
+- Empty current issuer buckets produce `issuer_concentration.hhi_current = 0.0`.
+- Empty proposed issuer buckets do not create an error; proposed issuer HHI falls back to current
+  issuer HHI.
+- A single covered issuer bucket produces issuer HHI `10000.0`.
+- Equal weights across `N` covered issuer buckets produce issuer HHI `10000 / N`.
+- Partial issuer mapping yields `coverage_status = partial` when at least one current or proposed
+  position is covered and at least one evaluated position is uncovered.
+- Fully covered current and proposed states yield `coverage_status = complete`.
+- No evaluated positions yield `coverage_status = unavailable` and empty calculation
+  supportability.
+- Evaluated positions with no covered issuer buckets, or an issuer enrichment note, yield degraded
+  calculation supportability with reason `calculation_quality_issue`.
+- Issuer HHI is computed from the covered subset only; coverage counts, coverage ratios,
+  `coverage_status`, `note`, and `metadata.calculation_supportability` carry the data-quality
+  posture.
+- The position-HHI and single-position outputs are independent; issuer enrichment coverage does
+  not change `risk_proxy.hhi_*` or `single_position_concentration.*` outputs.
 
 ## Configuration Options
-- `issuer_grouping_level`
-- `enrichment_policy`
-- Stateful and simulation input options may also change the covered universe:
+- Direct issuer-HHI options:
+  - `issuer_grouping_level`
+  - `enrichment_policy`
+- Options that can change the source position universe:
   - `include_cash_positions`
   - `include_zero_quantity_positions`
+  - `reporting_currency`
+- Options that do not change the issuer-HHI formula:
+  - `top_n`
 
 ## Outputs
 - `issuer_concentration.hhi_current`
@@ -69,23 +172,37 @@
 - `issuer_concentration.covered_position_count_proposed`
 - `issuer_concentration.total_position_count_current`
 - `issuer_concentration.total_position_count_proposed`
+- `issuer_concentration.uncovered_position_count_current`
+- `issuer_concentration.uncovered_position_count_proposed`
 - `issuer_concentration.coverage_ratio_current`
 - `issuer_concentration.coverage_ratio_proposed`
 - `issuer_concentration.note`
 - `issuer_concentration.top_issuer_current`
 - `issuer_concentration.top_issuer_proposed`
+- `metadata.calculation_supportability`
 
 ## Worked Example
-Issuer totals current: X=80, Y=20; proposed: X=70, Y=30.
-| State | Issuer Totals | Issuer Weights | Squared Weights | Issuer HHI |
-|---|---|---|---:|
-| Current | `X:80, Y:20` | `X:0.80, Y:0.20` | `X:0.6400, Y:0.0400` | `6800` |
-| Proposed | `X:70, Y:30` | `X:0.70, Y:0.30` | `X:0.4900, Y:0.0900` | `5800` |
-Delta: `5800 - 6800 = -1000`.
+Current positions: A=50 and B=30 map to issuer X; C=20 maps to issuer Y.
+Proposed positions: A=60 and B=10 map to issuer X; C=30 maps to issuer Y.
+
+| State | Covered Issuer Totals | Covered Denominator | Issuer Weights | Squared Weights | Issuer HHI |
+|---|---|---:|---|---|---:|
+| Current | `X:80, Y:20` | `100` | `X:0.80, Y:0.20` | `0.6400 + 0.0400` | `6800` |
+| Proposed | `X:70, Y:30` | `100` | `X:0.70, Y:0.30` | `0.4900 + 0.0900` | `5800` |
+
+Delta:
+
+`issuer_concentration.hhi_delta = 5800 - 6800 = -1000`.
+
 Output mapping:
-- `issuer_concentration.hhi_current=6800`
-- `issuer_concentration.hhi_proposed=5800`
-- `issuer_concentration.hhi_delta=-1000`
-- `issuer_concentration.coverage_ratio_current=1.0`
-- `issuer_concentration.coverage_ratio_proposed=1.0`
-- if both issuer buckets are fully mapped, `issuer_concentration.coverage_status=complete`
+
+- `issuer_concentration.hhi_current = 6800.0`
+- `issuer_concentration.hhi_proposed = 5800.0`
+- `issuer_concentration.hhi_delta = -1000.0`
+- `issuer_concentration.coverage_status = complete`
+- `issuer_concentration.covered_position_count_current = 3`
+- `issuer_concentration.covered_position_count_proposed = 3`
+- `issuer_concentration.total_position_count_current = 3`
+- `issuer_concentration.total_position_count_proposed = 3`
+- `issuer_concentration.coverage_ratio_current = 1.0`
+- `issuer_concentration.coverage_ratio_proposed = 1.0`

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-15T11:26:32.002005+00:00",
+  "generatedAt": "2026-05-15T11:48:59.116122+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -554,11 +554,17 @@ class IssuerCoverageStatus(str, Enum):
 
 class IssuerConcentration(BaseModel):
     hhi_current: float = Field(
-        description="Issuer-level baseline HHI concentration (0 to 10000).",
+        description=(
+            "Issuer-level baseline HHI concentration on the conventional 0 to 10000 scale, "
+            "computed from covered mapped issuer buckets."
+        ),
         json_schema_extra={"example": 3200.0},
     )
     hhi_proposed: float = Field(
-        description="Issuer-level proposed HHI concentration (0 to 10000).",
+        description=(
+            "Issuer-level proposed HHI concentration on the conventional 0 to 10000 scale, "
+            "falling back to baseline issuer HHI when proposed issuer buckets are unavailable."
+        ),
         json_schema_extra={"example": 3475.0},
     )
     hhi_delta: float = Field(

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -244,6 +244,65 @@ async def test_top_n_cumulative_weight_matches_documented_stateless_methodology_
 
 
 @pytest.mark.asyncio
+async def test_issuer_hhi_matches_documented_stateless_methodology_example() -> None:
+    request = ConcentrationRequest.model_validate(
+        {
+            "input_mode": "stateless",
+            "stateless_input": {
+                "current_positions": [
+                    {"security_id": "A", "market_value_base": 50, "issuer_id": "ISSUER_X"},
+                    {"security_id": "B", "market_value_base": 30, "issuer_id": "ISSUER_X"},
+                    {"security_id": "C", "market_value_base": 20, "issuer_id": "ISSUER_Y"},
+                    {"security_id": "IGNORED_ZERO", "market_value_base": 0},
+                    {"security_id": "IGNORED_NEGATIVE", "market_value_base": -10},
+                ],
+                "projected_positions": [
+                    {
+                        "security_id": "A",
+                        "projected_market_value_base": 60,
+                        "issuer_id": "ISSUER_X",
+                    },
+                    {
+                        "security_id": "B",
+                        "projected_market_value_base": 10,
+                        "issuer_id": "ISSUER_X",
+                    },
+                    {
+                        "security_id": "C",
+                        "projected_market_value_base": 30,
+                        "issuer_id": "ISSUER_Y",
+                    },
+                ],
+            },
+        }
+    )
+
+    response = (await calculate_concentration(request)).model_dump()
+
+    issuer_concentration = response["issuer_concentration"]
+    assert issuer_concentration["hhi_current"] == 6800.0
+    assert issuer_concentration["hhi_proposed"] == 5800.0
+    assert issuer_concentration["hhi_delta"] == -1000.0
+    assert issuer_concentration["coverage_status"] == "complete"
+    assert issuer_concentration["covered_position_count_current"] == 3
+    assert issuer_concentration["covered_position_count_proposed"] == 3
+    assert issuer_concentration["total_position_count_current"] == 3
+    assert issuer_concentration["total_position_count_proposed"] == 3
+    assert issuer_concentration["coverage_ratio_current"] == 1.0
+    assert issuer_concentration["coverage_ratio_proposed"] == 1.0
+    assert issuer_concentration["top_issuer_current"] == {
+        "issuer_id": "ISSUER_X",
+        "issuer_name": None,
+        "weight": 0.8,
+    }
+    assert issuer_concentration["top_issuer_proposed"] == {
+        "issuer_id": "ISSUER_X",
+        "issuer_name": None,
+        "weight": 0.7,
+    }
+
+
+@pytest.mark.asyncio
 async def test_calculate_concentration_rejects_legacy_payload() -> None:
     with pytest.raises(ValidationError):
         ConcentrationRequest.model_validate(

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -35,6 +35,9 @@ CONCENTRATION_TOP_POSITION_WEIGHT_DOC = (
 CONCENTRATION_TOP_N_CUMULATIVE_WEIGHT_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-top-n-cumulative-weight.md"
 )
+CONCENTRATION_ISSUER_HHI_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-issuer-hhi.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -445,6 +448,49 @@ def test_concentration_top_n_cumulative_weight_methodology_is_auditable_against_
         "`single_position_concentration.top_n_cumulative_weight_proposed = 0.85`",
         "`single_position_concentration.top_n_cumulative_weight_delta = 0.05`",
         "`single_position_concentration.top_n = 2`",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_concentration_issuer_hhi_methodology_is_auditable_against_engine_contract() -> None:
+    text = CONCENTRATION_ISSUER_HHI_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: ISSUER_HHI",
+        "source_product: ConcentrationRiskReport:v1",
+        "/analytics/risk/concentration",
+        "`issuer_concentration`",
+        "lotus-core instrument enrichment",
+        "lotus-core baseline snapshot",
+        "lotus-core simulation session",
+        "There is no lotus-performance dependency for issuer HHI",
+        "legal issuer grouping uses `issuer_id`",
+        "ultimate-parent grouping uses `ultimate_parent_issuer_id`",
+        "merged policy starts with lotus-core identity and lets caller identity override",
+        "market_value_base` when present",
+        "projected_market_value_base` when present",
+        "Missing, non-numeric, zero, and negative values are excluded",
+        "`issuer_concentration.hhi_*` values are emitted on the conventional Herfindahl-Hirschman",
+        "ISSUER_HHI_raw = sum_k(w_k^2) * 10000",
+        "`issuer_concentration.hhi_current = round6(ISSUER_HHI_current_raw)`",
+        "When no proposed issuer buckets are available",
+        "A single covered issuer bucket produces issuer HHI `10000.0`",
+        "Equal weights across `N` covered issuer buckets produce issuer HHI `10000 / N`",
+        "Positions without resolved issuer identity are excluded from issuer HHI",
+        "`coverage_status = partial`",
+        "`metadata.calculation_supportability`",
+        "issuer enrichment coverage does",
+        "not change `risk_proxy.hhi_*`",
+        "`include_cash_positions`",
+        "`top_n`",
+        "`issuer_concentration.hhi_current = 6800.0`",
+        "`issuer_concentration.hhi_proposed = 5800.0`",
+        "`issuer_concentration.hhi_delta = -1000.0`",
+        "`issuer_concentration.coverage_status = complete`",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -71,14 +71,16 @@ boundary that episode-list filters do not change the summary maximum, average, u
 time-under-water drawdown values.
 
 `ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI,
-top-position weight, and top-N cumulative weight.
+top-position weight, top-N cumulative weight, and issuer HHI.
 The methodology is tied to the implemented `/analytics/risk/concentration` engine and states the
 stateless, stateful, and simulation source paths, positive numeric value extraction, market-value
 versus quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
 Herfindahl-Hirschman scaling for HHI, decimal `0..1` top-position and top-N cumulative weight
 output, six-decimal response rounding, proposed-state fallback to current values when projected
 values are unavailable, deterministic top-position driver selection, top-N cumulative summation,
-input-universe option boundaries, and issuer-enrichment isolation from `risk_proxy.hhi_*`,
+covered-subset issuer aggregation, legal versus ultimate-parent issuer grouping,
+issuer-enrichment precedence, issuer coverage and supportability posture, input-universe option
+boundaries, and issuer-enrichment isolation from `risk_proxy.hhi_*`,
 `single_position_concentration.top_position_*`, and
 `single_position_concentration.top_n_cumulative_weight_*` outputs.
 
@@ -141,8 +143,8 @@ Audience notes:
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
-- Developers and downstream services must preserve `ConcentrationRiskReport:v1` position HHI and
-  related concentration outputs rather than recomputing concentration locally.
+- Developers and downstream services must preserve `ConcentrationRiskReport:v1` position HHI,
+  issuer HHI, and related concentration outputs rather than recomputing concentration locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `ISSUER_HHI` methodology truth for `ConcentrationRiskReport:v1` to the strict v3 structure
- pin covered-subset issuer aggregation, legal versus ultimate-parent grouping, enrichment precedence, proposed-state fallback, coverage/supportability behavior, and six-decimal response rounding
- add executable stateless issuer-HHI example and current-state methodology assertions
- refresh contract wording, API vocabulary inventory, repo context, and repo-authored wiki source

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py -q` -> 31 passed
- `make check` -> 356 unit tests passed
- `make test-pyramid-gate` -> unit 356 (75.11%), integration 94 (19.83%), e2e 24 (5.06%)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected drift in `Mesh-Data-Products.md` from this branch's repo-authored wiki update
- `git diff --check`

## Notes
- No gateway or workbench files touched.
- This advances RFC42-WTBD-006 source-owner methodology truth but does not close all remaining concentration methodology work.