### PR TITLE
docs(risk): pin concentration top issuer methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -98,7 +98,8 @@ Current repository posture:
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
 14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
-    `POSITION_HHI`, `TOP_POSITION_WEIGHT`, `TOP_N_CUMULATIVE_WEIGHT`, and `ISSUER_HHI`: the docs and tests pin
+    `POSITION_HHI`, `TOP_POSITION_WEIGHT`, `TOP_N_CUMULATIVE_WEIGHT`, `ISSUER_HHI`, and
+    `TOP_ISSUER_WEIGHT`: the docs and tests pin
     stateless, stateful, and simulation source resolution, positive numeric position-value
     extraction, market-value versus quantity fallback precedence, decimal position-weight
     construction, conventional `0..10000` Herfindahl-Hirschman scaling for HHI, decimal `0..1`
@@ -106,7 +107,8 @@ Current repository posture:
     proposed-state fallback to current values when projected values are unavailable, deterministic
     top-position driver selection, top-N cumulative summation, covered-subset issuer aggregation,
     legal versus ultimate-parent issuer grouping, issuer-enrichment precedence, issuer coverage
-    and supportability posture, input-universe option boundaries, and issuer-enrichment isolation
+    and supportability posture, deterministic top-issuer driver selection, top-issuer
+    proposed-state fallback, input-universe option boundaries, and issuer-enrichment isolation
     from `risk_proxy.hhi_*` and
     `single_position_concentration.top_position_*` / `top_n_cumulative_weight_*` outputs.
 

--- a/docs/methodologies/metrics/concentration-top-issuer-weight.md
+++ b/docs/methodologies/metrics/concentration-top-issuer-weight.md
@@ -2,52 +2,172 @@
 
 ## Metric
 - metric_id: TOP_ISSUER_WEIGHT
+- source_product: ConcentrationRiskReport:v1
+- methodology_version: concentration.top_issuer_weight.v1
 
 ## Endpoint and Mode Coverage
 - endpoint: /analytics/risk/concentration
 - supported_modes: stateless, stateful, simulation
+- output_family: `issuer_concentration`
 
 ## Inputs
-- Issuer-bucketed values for current/proposed states.
+- Current position rows.
+- Proposed position rows when the caller supplies or source state resolves a projected state.
+- Issuer identifiers supplied on stateless position rows, caller issuer mappings, and/or
+  lotus-core enrichment rows.
+- `issuer_grouping_level`, which chooses legal issuer grouping or ultimate-parent issuer grouping.
+- `enrichment_policy`, which chooses caller-only, core-only, or merged issuer-map precedence.
 
 ## Upstream Data Sources
-- Derived from issuer mapping and issuer aggregation path.
+- Stateless mode uses caller-provided `stateless_input.current_positions` and
+  `stateless_input.projected_positions`.
+- Stateless mode may call lotus-core instrument enrichment when a core client is available and
+  `enrichment_policy` is not `use_caller_only`.
+- Stateful mode requests a lotus-core baseline snapshot with `positions_baseline`,
+  `portfolio_totals`, and `instrument_enrichment`; it uses baseline positions for both current
+  and proposed states.
+- Simulation mode creates or reuses a lotus-core simulation session, applies requested changes,
+  requests a simulation snapshot with `positions_baseline`, `positions_projected`,
+  `positions_delta`, `portfolio_totals`, and `instrument_enrichment`, and uses baseline positions
+  as current state and projected positions as proposed state.
+- There is no lotus-performance dependency for top issuer weight.
 
 ## Unit Conventions
-- Position inputs are non-negative portfolio amounts:
-  - `market_value_base` when available
-  - `quantity` as fallback when market value is unavailable
-- Issuer weights are decimals in `[0, 1]`.
+- Position inputs are portfolio amount-like values, not return percentages.
+- Stateless current rows use `market_value_base` when present; otherwise they fall back to
+  `quantity`.
+- Stateless projected rows use `projected_market_value_base` when present; otherwise they fall
+  back to `proposed_quantity`.
+- Stateful and simulation snapshot rows use `market_value_base` when present; otherwise they fall
+  back to `quantity`.
+- Values are parsed through Decimal from the source value's string representation. Missing,
+  non-numeric, zero, and negative values are excluded before issuer aggregation and coverage
+  counting.
+- Top issuer weights are decimal ratios in `[0, 1]` and are rounded to six decimal places by the
+  service response.
 
 ## Variable Dictionary
-- `issuer_value_k`: aggregate value for issuer `k`.
-- `W_issuer = sum_k |issuer_value_k|`.
-- `w_k = |issuer_value_k|/W_issuer`.
-- `TOP_ISSUER = max_k(w_k)`.
-- `TOP_ISSUER_delta = TOP_ISSUER_proposed - TOP_ISSUER_current`.
+- `G`: requested issuer grouping level, either legal issuer or ultimate-parent issuer.
+- `M`: resolved issuer map keyed by `security_id` after enrichment-policy precedence.
+- `C`: current extracted positive numeric position rows.
+- `P`: proposed extracted positive numeric position rows.
+- `x_i`: one extracted positive current position value in `C`.
+- `y_i`: one extracted positive proposed position value in `P`.
+- `issuer(i, G, M)`: issuer bucket selected for position `i` under grouping level `G` from map
+  `M`.
+- `K_C`: issuer buckets with at least one covered current position.
+- `K_P`: issuer buckets with at least one covered proposed position.
+- `I_{C,k} = sum(abs(x_i)) for covered current positions mapped to issuer bucket k`.
+- `I_{P,k} = sum(abs(y_i)) for covered proposed positions mapped to issuer bucket k`.
+- `V_C_issuer = sum_k(abs(I_{C,k}))`: covered current issuer denominator.
+- `V_P_issuer = sum_k(abs(I_{P,k}))`: covered proposed issuer denominator.
+- `w_{C,k} = abs(I_{C,k}) / V_C_issuer` when `V_C_issuer > 0`.
+- `w_{P,k} = abs(I_{P,k}) / V_P_issuer` when `V_P_issuer > 0`.
+- `TOP_ISSUER_current_raw = max_k(w_{C,k})` when current issuer buckets exist, else `0.0`.
+- `TOP_ISSUER_proposed_raw = max_k(w_{P,k})` when proposed issuer buckets exist, else the current
+  top issuer weight.
+- `TOP_ISSUER_delta_raw = TOP_ISSUER_proposed_raw - TOP_ISSUER_current_raw`.
+- `top_issuer_current`: the current issuer bucket with the largest absolute aggregate issuer
+  value; ties choose the lexicographically largest `issuer_id`.
+- `top_issuer_proposed`: the proposed issuer bucket with the largest absolute aggregate issuer
+  value; when proposed issuer buckets are unavailable it falls back to `top_issuer_current`.
+- `round6(z)`: Python `round(z, 6)` used by the service response.
 
 ## Methodology and Formulas
-1. Aggregate values by issuer.
-2. Normalize to issuer weights.
-3. Take max issuer weight for each state.
-4. Compute delta.
+For each state:
+
+1. Extract one positive numeric value per usable position row according to the mode-specific
+   field precedence.
+2. Resolve the issuer map:
+   - legal issuer grouping uses `issuer_id`,
+   - ultimate-parent grouping uses `ultimate_parent_issuer_id` when present and falls back to
+     `issuer_id`,
+   - `use_caller_only` uses only caller-supplied issuer identity,
+   - `core_only` uses only lotus-core enrichment identity,
+   - merged policy starts with lotus-core identity and lets caller identity override by
+     `security_id`.
+3. Aggregate covered rows by issuer bucket.
+4. Compute the covered issuer denominator:
+   `V_issuer = sum_k(abs(I_k))`.
+5. If `V_issuer <= 0`, set top issuer weight to `0.0` and emit an empty top issuer driver.
+6. Otherwise compute issuer weights:
+   `w_k = abs(I_k) / V_issuer`.
+7. Select the largest issuer weight:
+   `TOP_ISSUER_raw = max_k(w_k)`.
+8. Select the top issuer driver from issuer aggregate values using:
+   `max(abs(I_k), issuer_id)`; the secondary `issuer_id` sort makes ties deterministic.
+9. Emit:
+   - `issuer_concentration.top_issuer_weight_current = round6(TOP_ISSUER_current_raw)`
+   - `issuer_concentration.top_issuer_weight_proposed = round6(TOP_ISSUER_proposed_raw)`
+   - `issuer_concentration.top_issuer_weight_delta = round6(TOP_ISSUER_proposed_raw - TOP_ISSUER_current_raw)`
+   - `issuer_concentration.top_issuer_current.weight = round6(TOP_ISSUER_current_raw)`
+   - `issuer_concentration.top_issuer_proposed.weight = round6(TOP_ISSUER_proposed_raw)`
+
+When no proposed issuer buckets are available, the implemented service sets
+`TOP_ISSUER_proposed_raw = TOP_ISSUER_current_raw` and reuses the current top issuer driver; the
+emitted delta is therefore `0.0`.
 
 ## Step-by-Step Computation
-1. Resolve issuer buckets.
-2. Compute issuer weights.
-3. Select max weight current/proposed.
-4. Emit delta and coverage context.
+1. Resolve request mode.
+2. Build current position entries:
+   - stateless: caller current positions,
+   - stateful: lotus-core baseline positions,
+   - simulation: lotus-core baseline positions.
+3. Build proposed position entries:
+   - stateless: caller projected positions,
+   - stateful: same baseline positions as current,
+   - simulation: lotus-core projected positions when available.
+4. Resolve issuer identities from stateless row fields, caller `issuer_mappings`, and/or lotus-core
+   enrichment according to grouping and enrichment policy.
+5. Parse each state's preferred value field, fall back to the secondary value field, and keep only
+   positive numeric values.
+6. Aggregate only covered position values by issuer bucket.
+7. Normalize current and proposed issuer aggregates into covered-issuer weights.
+8. Select current and proposed top issuer weight from the maximum covered-issuer weight.
+9. Select current and proposed top issuer driver metadata from the same issuer aggregate universe,
+   using issuer id as the deterministic tie-breaker.
+10. If proposed issuer buckets are empty, reuse current top issuer weight and current top issuer
+    driver for proposed output.
+11. Compute proposed-minus-current delta.
+12. Round emitted top issuer weights and delta fields to six decimal places.
+13. Emit issuer coverage counts, coverage ratios, coverage status, supportability, and note
+    alongside top issuer weight.
 
 ## Validation and Failure Behavior
-- Empty issuer buckets yield top issuer weight `0`.
-- Coverage flags indicate mapping completeness.
+- Missing, non-numeric, zero, and negative values are excluded before issuer aggregation and before
+  issuer coverage counts.
+- Positions without resolved issuer identity are excluded from top issuer weight but included in
+  issuer coverage totals.
+- Empty current issuer buckets produce `issuer_concentration.top_issuer_weight_current = 0.0` and
+  `issuer_concentration.top_issuer_current.issuer_id = null`.
+- Empty proposed issuer buckets do not create an error; proposed top issuer weight and proposed
+  top issuer driver fall back to current state.
+- A single covered issuer bucket produces top issuer weight `1.0`.
+- Equal weights across `N` covered issuer buckets produce top issuer weight `1 / N`; top issuer
+  driver identity uses the lexicographically largest `issuer_id` as the tie-breaker.
+- Partial issuer mapping yields `coverage_status = partial` when at least one current or proposed
+  position is covered and at least one evaluated position is uncovered.
+- Fully covered current and proposed states yield `coverage_status = complete`.
+- No evaluated positions yield `coverage_status = unavailable` and empty calculation
+  supportability.
+- Evaluated positions with no covered issuer buckets, or an issuer enrichment note, yield degraded
+  calculation supportability with reason `calculation_quality_issue`.
+- Top issuer weight is computed from the covered subset only; coverage counts, coverage ratios,
+  `coverage_status`, `note`, and `metadata.calculation_supportability` carry the data-quality
+  posture.
+- The position-HHI and single-position outputs are independent; issuer enrichment coverage does
+  not change `risk_proxy.hhi_*` or `single_position_concentration.*` outputs.
 
 ## Configuration Options
-- `issuer_grouping_level`
-- `enrichment_policy`
-- Stateful and simulation portfolio-state options can change the covered universe:
+- Direct top-issuer options:
+  - `issuer_grouping_level`
+  - `enrichment_policy`
+- Options that can change the source position universe:
   - `include_cash_positions`
   - `include_zero_quantity_positions`
+  - `reporting_currency`
+- Options that do not change the top-issuer formula:
+  - `top_n`
 
 ## Outputs
 - `issuer_concentration.top_issuer_weight_current`
@@ -55,16 +175,37 @@
 - `issuer_concentration.top_issuer_weight_delta`
 - `issuer_concentration.top_issuer_current`
 - `issuer_concentration.top_issuer_proposed`
+- `issuer_concentration.coverage_status`
+- `issuer_concentration.covered_position_count_current`
+- `issuer_concentration.covered_position_count_proposed`
+- `issuer_concentration.total_position_count_current`
+- `issuer_concentration.total_position_count_proposed`
+- `issuer_concentration.uncovered_position_count_current`
+- `issuer_concentration.uncovered_position_count_proposed`
+- `issuer_concentration.coverage_ratio_current`
+- `issuer_concentration.coverage_ratio_proposed`
+- `issuer_concentration.note`
+- `metadata.calculation_supportability`
 
 ## Worked Example
-Issuer weights current `[0.80,0.20]`, proposed `[0.70,0.30]`.
-| State | Issuer Weights | Selected Top Issuer | Top Issuer Weight |
-|---|---|---|---:|
-| Current | `[0.80,0.20]` | issuer X | `0.80` |
-| Proposed | `[0.70,0.30]` | issuer X | `0.70` |
-Delta: `-0.10`.
+Current positions: A=50 and B=30 map to issuer X; C=20 maps to issuer Y.
+Proposed positions: A=60 and B=10 map to issuer X; C=30 maps to issuer Y.
+
+| State | Covered Issuer Totals | Covered Denominator | Issuer Weights | Top Issuer | Top Issuer Weight |
+|---|---|---:|---|---|---:|
+| Current | `X:80, Y:20` | `100` | `X:0.80, Y:0.20` | `X` | `0.80` |
+| Proposed | `X:70, Y:30` | `100` | `X:0.70, Y:0.30` | `X` | `0.70` |
+
+Delta:
+
+`issuer_concentration.top_issuer_weight_delta = 0.70 - 0.80 = -0.10`.
+
 Output mapping:
-- `issuer_concentration.top_issuer_weight_current=0.80`
-- `issuer_concentration.top_issuer_weight_proposed=0.70`
-- `issuer_concentration.top_issuer_weight_delta=-0.10`
-- `issuer_concentration.top_issuer_current` identifies the current top issuer
+
+- `issuer_concentration.top_issuer_weight_current = 0.80`
+- `issuer_concentration.top_issuer_weight_proposed = 0.70`
+- `issuer_concentration.top_issuer_weight_delta = -0.10`
+- `issuer_concentration.top_issuer_current.issuer_id = "ISSUER_X"`
+- `issuer_concentration.top_issuer_current.weight = 0.80`
+- `issuer_concentration.top_issuer_proposed.issuer_id = "ISSUER_X"`
+- `issuer_concentration.top_issuer_proposed.weight = 0.70`

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-15T11:48:59.116122+00:00",
+  "generatedAt": "2026-05-15T12:12:55.855350+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -2558,7 +2558,7 @@
       "semanticId": "lotus.top_issuer_weight_current",
       "canonicalTerm": "top_issuer_weight_current",
       "preferredName": "top_issuer_weight_current",
-      "description": "Highest issuer-level baseline concentration weight.",
+      "description": "Highest issuer-level baseline concentration weight from covered mapped issuer buckets.",
       "example": 0.18,
       "type": "number",
       "locations": [
@@ -2586,7 +2586,7 @@
       "semanticId": "lotus.top_issuer_weight_proposed",
       "canonicalTerm": "top_issuer_weight_proposed",
       "preferredName": "top_issuer_weight_proposed",
-      "description": "Highest issuer-level proposed concentration weight.",
+      "description": "Highest issuer-level proposed concentration weight from covered mapped issuer buckets, falling back to baseline top issuer weight when proposed issuer buckets are unavailable.",
       "example": 0.21,
       "type": "number",
       "locations": [

--- a/src/app/contracts/concentration.py
+++ b/src/app/contracts/concentration.py
@@ -572,11 +572,16 @@ class IssuerConcentration(BaseModel):
         json_schema_extra={"example": 275.0},
     )
     top_issuer_weight_current: float = Field(
-        description="Highest issuer-level baseline concentration weight.",
+        description=(
+            "Highest issuer-level baseline concentration weight from covered mapped issuer buckets."
+        ),
         json_schema_extra={"example": 0.18},
     )
     top_issuer_weight_proposed: float = Field(
-        description="Highest issuer-level proposed concentration weight.",
+        description=(
+            "Highest issuer-level proposed concentration weight from covered mapped issuer buckets, "
+            "falling back to baseline top issuer weight when proposed issuer buckets are unavailable."
+        ),
         json_schema_extra={"example": 0.21},
     )
     top_issuer_weight_delta: float = Field(

--- a/tests/unit/test_concentration_engine.py
+++ b/tests/unit/test_concentration_engine.py
@@ -303,6 +303,59 @@ async def test_issuer_hhi_matches_documented_stateless_methodology_example() -> 
 
 
 @pytest.mark.asyncio
+async def test_top_issuer_weight_matches_documented_stateless_methodology_example() -> None:
+    request = ConcentrationRequest.model_validate(
+        {
+            "input_mode": "stateless",
+            "stateless_input": {
+                "current_positions": [
+                    {"security_id": "A", "market_value_base": 50, "issuer_id": "ISSUER_X"},
+                    {"security_id": "B", "market_value_base": 30, "issuer_id": "ISSUER_X"},
+                    {"security_id": "C", "market_value_base": 20, "issuer_id": "ISSUER_Y"},
+                    {"security_id": "IGNORED_ZERO", "market_value_base": 0},
+                    {"security_id": "IGNORED_NEGATIVE", "market_value_base": -10},
+                ],
+                "projected_positions": [
+                    {
+                        "security_id": "A",
+                        "projected_market_value_base": 60,
+                        "issuer_id": "ISSUER_X",
+                    },
+                    {
+                        "security_id": "B",
+                        "projected_market_value_base": 10,
+                        "issuer_id": "ISSUER_X",
+                    },
+                    {
+                        "security_id": "C",
+                        "projected_market_value_base": 30,
+                        "issuer_id": "ISSUER_Y",
+                    },
+                ],
+            },
+        }
+    )
+
+    response = (await calculate_concentration(request)).model_dump()
+
+    issuer_concentration = response["issuer_concentration"]
+    assert issuer_concentration["top_issuer_weight_current"] == 0.8
+    assert issuer_concentration["top_issuer_weight_proposed"] == 0.7
+    assert issuer_concentration["top_issuer_weight_delta"] == -0.1
+    assert issuer_concentration["top_issuer_current"] == {
+        "issuer_id": "ISSUER_X",
+        "issuer_name": None,
+        "weight": 0.8,
+    }
+    assert issuer_concentration["top_issuer_proposed"] == {
+        "issuer_id": "ISSUER_X",
+        "issuer_name": None,
+        "weight": 0.7,
+    }
+    assert issuer_concentration["coverage_status"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_calculate_concentration_rejects_legacy_payload() -> None:
     with pytest.raises(ValidationError):
         ConcentrationRequest.model_validate(

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -38,6 +38,9 @@ CONCENTRATION_TOP_N_CUMULATIVE_WEIGHT_DOC = (
 CONCENTRATION_ISSUER_HHI_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-issuer-hhi.md"
 )
+CONCENTRATION_TOP_ISSUER_WEIGHT_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "concentration-top-issuer-weight.md"
+)
 RISK_VOLATILITY_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-volatility.md"
 RISK_DRAWDOWN_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-drawdown.md"
 RISK_SHARPE_DOC = REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-sharpe.md"
@@ -491,6 +494,51 @@ def test_concentration_issuer_hhi_methodology_is_auditable_against_engine_contra
         "`issuer_concentration.hhi_proposed = 5800.0`",
         "`issuer_concentration.hhi_delta = -1000.0`",
         "`issuer_concentration.coverage_status = complete`",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
+
+
+def test_concentration_top_issuer_weight_methodology_is_auditable_against_engine_contract() -> None:
+    text = CONCENTRATION_TOP_ISSUER_WEIGHT_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "metric_id: TOP_ISSUER_WEIGHT",
+        "source_product: ConcentrationRiskReport:v1",
+        "/analytics/risk/concentration",
+        "`issuer_concentration`",
+        "lotus-core instrument enrichment",
+        "lotus-core baseline snapshot",
+        "lotus-core simulation session",
+        "There is no lotus-performance dependency for top issuer weight",
+        "legal issuer grouping uses `issuer_id`",
+        "ultimate-parent grouping uses `ultimate_parent_issuer_id`",
+        "merged policy starts with lotus-core identity and lets caller identity override",
+        "market_value_base` when present",
+        "projected_market_value_base` when present",
+        "Missing, non-numeric, zero, and negative values are excluded",
+        "Top issuer weights are decimal ratios in `[0, 1]`",
+        "TOP_ISSUER_raw = max_k(w_k)",
+        "`issuer_concentration.top_issuer_weight_current = round6(TOP_ISSUER_current_raw)`",
+        "`issuer_concentration.top_issuer_current.weight = round6(TOP_ISSUER_current_raw)`",
+        "When no proposed issuer buckets are available",
+        "A single covered issuer bucket produces top issuer weight `1.0`",
+        "Equal weights across `N` covered issuer buckets produce top issuer weight `1 / N`",
+        "lexicographically largest `issuer_id`",
+        "Positions without resolved issuer identity are excluded from top issuer weight",
+        "`coverage_status = partial`",
+        "`metadata.calculation_supportability`",
+        "not change `risk_proxy.hhi_*`",
+        "`include_cash_positions`",
+        "`top_n`",
+        "`issuer_concentration.top_issuer_weight_current = 0.80`",
+        "`issuer_concentration.top_issuer_weight_proposed = 0.70`",
+        "`issuer_concentration.top_issuer_weight_delta = -0.10`",
+        '`issuer_concentration.top_issuer_current.issuer_id = "ISSUER_X"`',
+        "`issuer_concentration.top_issuer_current.weight = 0.80`",
     ]
 
     for phrase in required_truth:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -71,7 +71,7 @@ boundary that episode-list filters do not change the summary maximum, average, u
 time-under-water drawdown values.
 
 `ConcentrationRiskReport:v1` now has auditable source-owner methodology truth for position HHI,
-top-position weight, top-N cumulative weight, and issuer HHI.
+top-position weight, top-N cumulative weight, issuer HHI, and top issuer weight.
 The methodology is tied to the implemented `/analytics/risk/concentration` engine and states the
 stateless, stateful, and simulation source paths, positive numeric value extraction, market-value
 versus quantity fallback precedence, decimal position-weight construction, conventional `0..10000`
@@ -79,7 +79,8 @@ Herfindahl-Hirschman scaling for HHI, decimal `0..1` top-position and top-N cumu
 output, six-decimal response rounding, proposed-state fallback to current values when projected
 values are unavailable, deterministic top-position driver selection, top-N cumulative summation,
 covered-subset issuer aggregation, legal versus ultimate-parent issuer grouping,
-issuer-enrichment precedence, issuer coverage and supportability posture, input-universe option
+issuer-enrichment precedence, issuer coverage and supportability posture, deterministic
+top-issuer driver selection, top-issuer proposed-state fallback, input-universe option
 boundaries, and issuer-enrichment isolation from `risk_proxy.hhi_*`,
 `single_position_concentration.top_position_*`, and
 `single_position_concentration.top_n_cumulative_weight_*` outputs.
@@ -144,7 +145,8 @@ Audience notes:
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
 - Developers and downstream services must preserve `ConcentrationRiskReport:v1` position HHI,
-  issuer HHI, and related concentration outputs rather than recomputing concentration locally.
+  issuer HHI, top issuer weight, and related concentration outputs rather than recomputing
+  concentration locally.
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.


### PR DESCRIPTION
## Summary
- upgrade `TOP_ISSUER_WEIGHT` methodology truth for `ConcentrationRiskReport:v1` to the strict v3 structure
- pin covered-subset issuer aggregation, legal versus ultimate-parent grouping, enrichment precedence, deterministic top-issuer tie-break, proposed-state fallback, coverage/supportability behavior, and six-decimal rounding
- add executable stateless top-issuer example and current-state methodology assertions
- refresh contract wording, API vocabulary inventory, repo context, and repo-authored wiki source

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_concentration_engine.py -q` -> 33 passed
- `make check` -> 358 unit tests passed
- `make test-pyramid-gate` -> unit 358 (75.21%), integration 94 (19.75%), e2e 24 (5.04%)
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected drift in `Mesh-Data-Products.md` from this branch's repo-authored wiki update
- `git diff --check`

## Notes
- No gateway or workbench files touched.
- This advances RFC42-WTBD-006 source-owner methodology truth but does not close all remaining concentration methodology work.