### PR TITLE
feat: support stateful issuer active risk attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Important posture limits:
 3. risk-event affected-cohort evaluation is stateless and consumes caller-supplied candidate
    portfolios and source-supplied exposure weights against risk-owned event definitions; it does
    not create rebalance waves or own campaign approval workflow,
-4. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is intentionally gated,
+4. stateful historical attribution supports `ACTIVE_RISK + ISSUER` through lotus-performance benchmark exposure context issuer groups,
 5. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
 6. broader enterprise-bank claims require more seeded archetypes and attached evidence.
 
@@ -176,7 +176,7 @@ Important integration truths:
 1. `GET /integration/capabilities` is the source of truth for workflow support and mode support,
 2. concentration is the only supported simulation workflow,
 3. historical attribution support is intentionally `partial`,
-4. signed VaR semantics, attribution reconciliation fields, issuer gating, concentration-only simulation support, and audit lineage metadata must be preserved downstream,
+4. signed VaR semantics, attribution reconciliation fields, issuer active-risk support metadata, concentration-only simulation support, and audit lineage metadata must be preserved downstream,
 5. downstream consumers should derive affordances from the capability response and endpoint matrix rather than infer support from one successful endpoint call.
 
 The main integration references are:

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -144,7 +144,7 @@ Boundary rules:
 2. gateway and UI should not duplicate risk logic or narrative improperly,
 3. monetary-float governance applies only where money-bearing identifiers require it, not generic analytics terms,
 4. supportability and evidence posture should remain truthful and data-backed,
-5. downstream consumers must preserve signed VaR semantics, attribution reconciliation fields, issuer active-risk gating, concentration-only simulation support, and audit lineage metadata as documented in `docs/domain-apis/risk-product-surface-alignment.md`,
+5. downstream consumers must preserve signed VaR semantics, attribution reconciliation fields, issuer active-risk support metadata, concentration-only simulation support, and audit lineage metadata as documented in `docs/domain-apis/risk-product-surface-alignment.md`,
 6. `lotus-core` must be consumed as a governed source-data, analytics-input, snapshot/simulation, and support-metadata authority, while `lotus-performance` remains the authority for performance return and benchmark exposure context inputs.
 7. RFC-0108 calculation supportability is source-owned in this repository across `risk/calculate`,
    drawdown, rolling metrics, historical attribution, and concentration through
@@ -215,7 +215,7 @@ Most relevant current governance:
 3. risk evidence and supportability posture must remain data-backed, not decorative or speculative,
 4. when risk review flows change in Workbench or Gateway, this repo’s context should be checked for alignment,
 5. live validation defaults to `PB_SG_GLOBAL_BAL_001`; do not claim broader enterprise portfolio-archetype coverage until `docs/operations/live-risk-validation-matrix.md` has real seeded portfolio IDs and evidence,
-6. stateful historical attribution `ACTIVE_RISK + ISSUER` is intentionally gated until benchmark issuer exposure semantics are approved,
+6. stateful historical attribution `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups introduced in lotus-performance PR #165,
 7. transport optimization across upstream services should start with contract and retrieval-shape evidence before any gRPC proposal,
 8. `wiki/` inside the repository is the authored documentation source if a GitHub wiki is published later,
 9. RFC-0087 preparation should reuse repo-owned readiness, observability, and lineage signals before introducing any new trust publication surface.

--- a/docs/domain-apis/README.md
+++ b/docs/domain-apis/README.md
@@ -37,7 +37,7 @@ This package documents the current `lotus-risk` API surface and evaluates it aga
 - `POST /analytics/risk/drawdown`
 - `POST /analytics/risk/concentration`
 - `POST /analytics/risk/rolling-metrics`
-- `POST /analytics/risk/historical-attribution` (stateless plus approved stateful scope implemented; stateful `ACTIVE_RISK + ISSUER` remains intentionally gated)
+- `POST /analytics/risk/historical-attribution` (stateless plus approved stateful scope implemented, including stateful `ACTIVE_RISK + ISSUER` through lotus-performance benchmark exposure context issuer groups)
 - `POST /analytics/risk/regime-scenario-pack/evaluate` (stateless governed CIO scenario-pack
   evaluation with optional reconciled per-security contribution rows)
 - `POST /analytics/risk/risk-event-cohorts/evaluate`

--- a/docs/domain-apis/RFC-0082-upstream-contract-family-map.md
+++ b/docs/domain-apis/RFC-0082-upstream-contract-family-map.md
@@ -73,7 +73,7 @@ stateful mode is requested.
 3. canonical portfolio, instrument, simulation, and reference-data authority stays in `lotus-core`;
 4. stateful risk workflows consume governed REST/OpenAPI contracts, not direct databases or inferred private contracts;
 5. upstream failures remain mapped to deterministic Lotus error codes and structured categories;
-6. signed VaR semantics, attribution reconciliation fields, issuer active-risk gating, concentration-only simulation support, and audit lineage metadata remain preserved for downstream consumers;
+6. signed VaR semantics, attribution reconciliation fields, issuer active-risk support metadata, concentration-only simulation support, and audit lineage metadata remain preserved for downstream consumers;
 7. watchlist routes from `lotus-core` require explicit RFC-0082 review before their semantics are expanded.
 
 Route-specific downstream interpretations that must stay truthful:
@@ -108,7 +108,7 @@ Current test and implementation evidence:
 
 ## Current Gap Register
 
-1. Stateful `ACTIVE_RISK + ISSUER` remains intentionally gated until benchmark issuer exposure semantics are approved.
+1. Stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups.
 2. Risk-free coverage remains data-dependent by currency and window; unsupported windows must fail or degrade explicitly rather than fabricating Sharpe inputs.
 3. Transport optimization is deferred. The current concern is contract correctness and data authority, not gRPC adoption.
 4. Any future direct `lotus-core` source-data expansion must be checked against the `lotus-core` RFC-0082 contract-family inventory first.

--- a/docs/domain-apis/endpoint-matrix.md
+++ b/docs/domain-apis/endpoint-matrix.md
@@ -22,7 +22,7 @@ Status meanings:
 | `POST /analytics/risk/calculate` | Domain analytics | portfolio risk metrics | `stateless`, `stateful` | full | stateful return sourcing via lotus-performance; source-backed risk-free returns from lotus-core via returns-series when Sharpe is requested | simulation is intentionally unsupported |
 | `POST /analytics/risk/drawdown` | Domain analytics | realized drawdown analytics | `stateless`, `stateful` | full | stateful return sourcing via lotus-performance | simulation is intentionally unsupported |
 | `POST /analytics/risk/rolling-metrics` | Domain analytics | rolling historical risk diagnostics | `stateless`, `stateful` | full | lotus-performance for portfolio/benchmark returns; lotus-core for risk-free series and reporting-currency resolution | simulation is intentionally unsupported; broader enterprise archetype coverage still requires additional seeded live portfolios beyond the canonical baseline |
-| `POST /analytics/risk/historical-attribution` | Domain analytics | historical risk and active-risk attribution decomposition | `stateless`, `stateful` | partial | stateless caller-supplied returns/exposures; stateful sourcing uses lotus-performance for portfolio/benchmark returns and benchmark exposure context, and lotus-core for portfolio exposure history and instrument enrichment | stateful `ACTIVE_RISK` supports `POSITION`, `SECTOR`, and `ASSET_CLASS`; `ISSUER` remains gated by benchmark issuer exposure semantics; simulation is intentionally unsupported |
+| `POST /analytics/risk/historical-attribution` | Domain analytics | historical risk and active-risk attribution decomposition | `stateless`, `stateful` | partial | stateless caller-supplied returns/exposures; stateful sourcing uses lotus-performance for portfolio/benchmark returns and benchmark exposure context, and lotus-core for portfolio exposure history and instrument enrichment | stateful `ACTIVE_RISK` supports `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`; simulation is intentionally unsupported |
 | `POST /analytics/risk/concentration` | Domain analytics | concentration analytics and HHI metrics | `stateless`, `stateful`, `simulation` | full | lotus-core snapshot and simulation session contracts | none |
 | `POST /analytics/risk/regime-scenario-pack/evaluate` | Domain analytics | governed CIO regime scenario-pack evaluation with optional per-security contribution evidence | `stateless` | full | caller-supplied exposure weights, optional reconciled exposure components, and risk-owned scenario-pack definitions | does not forecast market states, perform full repricing, or accept browser-owned scenario methodology |
 
@@ -39,18 +39,16 @@ Status meanings:
 
 ## Highest-Value Remaining Gap
 
-The only remaining material functional gap inside the approved API surface is:
+The previously material functional gap inside the approved API surface is now implemented:
 
 - stateful `ACTIVE_RISK` historical attribution with `grouping_dimension=ISSUER`
 
 Current handling is intentional and explicit:
 
-- request validation rejects unsupported stateful issuer requests with HTTP `422`
-- `/integration/capabilities` marks historical attribution as `partial`
-- OpenAPI and domain docs describe the gate
-- live characterization proves:
-  - supported stateful `SECTOR` active-risk works
-  - upstream benchmark exposure context rejects `ISSUER`
+- request validation accepts issuer active-risk requests and rejects only `CUSTOM` stateful grouping
+- `/integration/capabilities` marks issuer active-risk as supported through workflow notes
+- response metadata publishes an empty `stateful_active_risk_gated_grouping_dimensions` list
+- live characterization should prove `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER` stateful active-risk against governed upstreams before broader portfolio-archetype claims
 
 ## Live Validation Breadth
 
@@ -85,7 +83,7 @@ See `docs/domain-apis/risk-observability.md`.
 ## Product-Surface Alignment
 
 Downstream gateway, Workbench, reporting, and AI consumers must preserve signed VaR semantics,
-historical attribution reconciliation fields, issuer active-risk gating, concentration-only
+historical attribution reconciliation fields, issuer active-risk support metadata, concentration-only
 simulation support, and audit metadata. These rules are part of the risk contract because otherwise
 correct calculations can become misleading at the product surface.
 

--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -59,7 +59,7 @@ This allows consumers to discover that:
 
 - concentration supports simulation
 - risk/calculate, drawdown, rolling, and historical attribution do not
-- historical attribution remains `partial` because stateful active-risk `ISSUER` is gated
+- historical attribution supports stateful active-risk `ISSUER` through lotus-performance benchmark exposure context issuer groups
 - historical-attribution response metadata is the authoritative active-risk support contract
 - risk snapshot VaR and expected shortfall are signed return-threshold metrics
 - historical attribution residual and `reconciled_sum` must be preserved with contributors
@@ -94,7 +94,7 @@ This allows consumers to discover that:
   - typed contract exists and is integration-tested.
   - vocabulary is centralized in constants to reduce drift.
   - workflow-level mode support is explicit enough for gateway and Workbench surfaces to avoid
-    unsupported simulation and issuer active-risk affordances.
+    unsupported simulation affordances and to expose issuer active-risk only through the governed risk contract.
   - risk calculation supportability is implementation-backed across `risk/calculate`, drawdown,
     rolling metrics, historical attribution, and concentration through
     `metadata.calculation_supportability` and `lotus_risk_calculation_supportability_total`, so

--- a/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
+++ b/docs/domain-apis/lotus-core-performance-requirements-for-historical-attribution.md
@@ -282,7 +282,7 @@ Required behavior:
 - needs `portfolio_returns` and `benchmark_returns` from lotus-performance
 - needs portfolio exposure timeseries from lotus-core
 - needs benchmark exposure context from lotus-performance as the performance-aligned derived view backed by lotus-core lineage
-- issuer active-risk remains gated until benchmark issuer exposure semantics are available
+- issuer active-risk consumes lotus-performance benchmark exposure context issuer groups
 
 3. `grouping_dimension=ISSUER`:
 - needs instrument enrichment-bulk from lotus-core
@@ -320,8 +320,8 @@ Required behavior:
 ## Acceptance Checklist
 
 1. Stateful `TOTAL_RISK` attribution succeeds end-to-end using upstream data only.
-2. Stateful `ACTIVE_RISK` attribution succeeds end-to-end for POSITION, SECTOR, and ASSET_CLASS using the lotus-performance benchmark exposure context.
-3. `ISSUER` grouping succeeds for `TOTAL_RISK` with enrichment-bulk and remains gated for `ACTIVE_RISK` until benchmark issuer exposure semantics are available.
+2. Stateful `ACTIVE_RISK` attribution succeeds end-to-end for POSITION, SECTOR, ASSET_CLASS, and ISSUER using the lotus-performance benchmark exposure context.
+3. `ISSUER` grouping succeeds for `TOTAL_RISK` with enrichment-bulk and for `ACTIVE_RISK` with lotus-performance benchmark exposure context issuer rows.
 4. Contract tests validate required fields and type/shape guarantees.
 5. Characterization tests lock numerical behavior for stable fixtures.
 6. OpenAPI docs include full descriptions and realistic examples for all attributes.

--- a/docs/domain-apis/risk-historical-attribution.md
+++ b/docs/domain-apis/risk-historical-attribution.md
@@ -20,8 +20,8 @@ Provide decomposition of historical realized risk and active risk into transpare
 - Status: implemented for approved v1 stateful scope
 - Current behavior:
   - `TOTAL_RISK` stateful path is implemented
-  - `ACTIVE_RISK` stateful path is implemented for `POSITION`, `SECTOR`, and `ASSET_CLASS` grouping dimensions through the lotus-performance benchmark exposure context derived view
-  - `ACTIVE_RISK` + `ISSUER` remains gated until benchmark issuer exposure semantics are explicitly available and is rejected at request validation
+  - `ACTIVE_RISK` stateful path is implemented for `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER` grouping dimensions through the lotus-performance benchmark exposure context derived view
+  - `ACTIVE_RISK` + `ISSUER` consumes lotus-performance benchmark exposure context issuer rows sourced from lotus-core index-catalog issuer labels
   - `CUSTOM` grouping remains unsupported in stateful mode and is rejected at request validation
 
 ### Simulation
@@ -54,7 +54,6 @@ Provide decomposition of historical realized risk and active risk into transpare
 
 - request validation rejects these combinations before any upstream call:
   - `grouping_dimensions=["CUSTOM"]`
-  - any stateful request that needs benchmark-relative attribution semantics and includes `ISSUER`
 - request validation currently returns:
   - HTTP `422`
   - `error.code = INVALID_REQUEST`
@@ -145,7 +144,7 @@ grouping does not fully explain active-risk dynamics.
 2. v1 grouping dimension set.
 3. residual tolerance policy.
 4. rolling-window attribution inclusion in v1 or v2.
-5. benchmark issuer exposure semantics for stateful `ACTIVE_RISK` + `ISSUER`.
+5. broader live portfolio-archetype validation for issuer active-risk beyond the canonical baseline.
 
 ## Current Stateful Active-Risk Support Matrix
 
@@ -153,16 +152,14 @@ grouping does not fully explain active-risk dynamics.
   - `POSITION`
   - `SECTOR`
   - `ASSET_CLASS`
-- gated:
   - `ISSUER`
-- gate reason:
-  - benchmark issuer exposure semantics unavailable from the lotus-performance benchmark exposure context
+- gated: none
+- gate reason: `none`
 
 ## Live Validation Note
 
 - live platform characterization currently confirms:
   - lotus-risk stateful `TOTAL_RISK` works live for `SECTOR` after aligning exposure history to trading-day return observations
-  - lotus-risk stateful `ACTIVE_RISK` works live for supported grouping dimensions `POSITION`, `SECTOR`, and `ASSET_CLASS`
-  - lotus-performance benchmark exposure context works for supported stateful dimensions `POSITION`, `SECTOR`, and `ASSET_CLASS`
-  - lotus-performance benchmark exposure context rejects `grouping_dimensions=["ISSUER"]`
-  - lotus-risk rejects stateful `ACTIVE_RISK` + `ISSUER` at request validation with HTTP `422`
+  - lotus-risk stateful `ACTIVE_RISK` works for supported grouping dimensions `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`
+  - lotus-performance benchmark exposure context works for supported stateful dimensions `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`
+  - lotus-risk rejects only `CUSTOM` stateful grouping at request validation

--- a/docs/domain-apis/risk-product-surface-alignment.md
+++ b/docs/domain-apis/risk-product-surface-alignment.md
@@ -60,21 +60,22 @@ If a compact UI cannot render all fields, it must preserve them in the backing A
 drawer. Hiding `residual` while showing only contributors can mislead users into believing the
 selected grouping fully explains the metric.
 
-### 3. Gate Unsupported Issuer Active-Risk Affordances
+### 3. Preserve Issuer Active-Risk Support Metadata
 
 Stateful historical attribution supports `ACTIVE_RISK` for these grouping dimensions:
 
 - `POSITION`
 - `SECTOR`
 - `ASSET_CLASS`
+- `ISSUER`
 
-Stateful `ACTIVE_RISK + ISSUER` remains intentionally unsupported until benchmark issuer exposure
-semantics are explicitly available and approved. Downstream surfaces must not offer issuer active-risk
-controls as supported. If they expose the disabled option for transparency, it must be disabled and
-explain that benchmark issuer exposure semantics are not currently supported.
+Stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context
+issuer groups. Downstream surfaces must derive issuer active-risk affordances from lotus-risk
+capabilities and historical-attribution metadata instead of maintaining a separate local support
+matrix.
 
-The runtime contract enforces this with request validation and `GET /integration/capabilities`, where
-historical attribution is published as `partial`.
+The runtime contract enforces unsupported `CUSTOM` grouping with request validation and publishes
+current support through `GET /integration/capabilities`.
 
 ### 4. Keep Simulation Concentration-Only
 

--- a/docs/operations/live-risk-validation-matrix.md
+++ b/docs/operations/live-risk-validation-matrix.md
@@ -9,7 +9,7 @@ The default live characterization suite validates one canonical portfolio:
 
 | Archetype | Portfolio ID | As Of Date | Status | Notes |
 | --- | --- | --- | --- | --- |
-| `global_balanced` | `PB_SG_GLOBAL_BAL_001` | `2026-03-31` | validated | Canonical private-banking portfolio used for the current live analytics baseline. Live proof includes concentration stateful HHI, top-position, top-issuer, and issuer-coverage reconciliation; rolling-metrics stateful `ROLLING_SHARPE` plus adjacent rolling volatility, beta, tracking error, information ratio, max drawdown, and multi-window time-series emission; and historical-attribution stateful `TOTAL_RISK` plus supported `ACTIVE_RISK` groupings `POSITION`, `SECTOR`, and `ASSET_CLASS`, with `ACTIVE_RISK + ISSUER` intentionally blocked. |
+| `global_balanced` | `PB_SG_GLOBAL_BAL_001` | `2026-03-31` | validated | Canonical private-banking portfolio used for the current live analytics baseline. Live proof includes concentration stateful HHI, top-position, top-issuer, and issuer-coverage reconciliation; rolling-metrics stateful `ROLLING_SHARPE` plus adjacent rolling volatility, beta, tracking error, information ratio, max drawdown, and multi-window time-series emission; and historical-attribution stateful `TOTAL_RISK` plus supported `ACTIVE_RISK` groupings `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`. |
 
 This is strong canonical evidence, but it is not a complete enterprise portfolio universe.
 Additional archetypes must be backed by real seeded portfolio IDs before they can be counted as

--- a/docs/rfcs/RFC-0007-final-production-readiness-and-integration-hardening.md
+++ b/docs/rfcs/RFC-0007-final-production-readiness-and-integration-hardening.md
@@ -2,18 +2,18 @@
 
 | Field | Value |
 | --- | --- |
-| Status | Implemented for lotus-risk scope; remaining functional gap is issuer active-risk benchmark semantics |
+| Status | Implemented for lotus-risk scope; issuer active-risk benchmark semantics added through lotus-performance benchmark exposure context issuer groups |
 | Created | 2026-04-07 |
 | Last Updated | 2026-04-07 |
 | Owners | lotus-risk |
 | Depends On | lotus-core, lotus-performance |
 | Related Standards | lotus-platform RFC-0067, RFC-0003, RFC-0005, RFC-0006 |
 | Scope | Cross-repo |
-| Implementation Classification | lotus-risk implementation complete for Slice 1, Slice 2, P0 benchmark exposure migration, dependency error hardening, ops/readiness hardening, and validation evidence; remaining functional gap is issuer active-risk benchmark semantics |
+| Implementation Classification | lotus-risk implementation complete for Slice 1, Slice 2, P0 benchmark exposure migration, dependency error hardening, ops/readiness hardening, issuer active-risk benchmark exposure consumption, and validation evidence |
 
 ## Executive Summary
 
-`lotus-risk` is materially stronger than before: the implemented endpoint surface is credible, the stateful integrations are real, and the test stack is substantially improved. The lotus-risk implementation work defined by this RFC is complete except for the intentionally gated issuer active-risk stateful path, which still requires benchmark issuer exposure semantics.
+`lotus-risk` is materially stronger than before: the implemented endpoint surface is credible, the stateful integrations are real, and the test stack is substantially improved. The issuer active-risk stateful path is now implemented by consuming lotus-performance benchmark exposure context issuer groups.
 
 The remaining work is no longer about adding arbitrary features. It is about finishing the contract, removing ambiguity, aligning upstream ownership to bounded contexts, hardening integration behavior, and proving readiness with evidence.
 
@@ -88,7 +88,7 @@ The user further clarified that benchmark exposure can reasonably be exposed by 
 4. `historical-attribution` does not support simulation.
 5. `historical-attribution` stateful `ACTIVE_RISK` now uses the lotus-performance benchmark exposure context for `POSITION`, `SECTOR`, and `ASSET_CLASS`.
 6. The active-risk attribution integration now follows the target architecture: benchmark returns and benchmark exposures are sourced through lotus-performance so they share the same effective date grid, benchmark version, and calculation lineage.
-7. `historical-attribution` stateful `ACTIVE_RISK` + `ISSUER` remains gated until benchmark issuer exposure semantics are explicitly available.
+7. `historical-attribution` stateful `ACTIVE_RISK` + `ISSUER` is supported through lotus-performance benchmark exposure context issuer groups.
 8. Stateful rolling Sharpe now uses `lotus-core` for risk-free series and passes live validation for the tested USD YTD path.
 
 ## Requirement-to-Implementation Traceability
@@ -98,7 +98,7 @@ The user further clarified that benchmark exposure can reasonably be exposed by 
 | Support simulation only where methodologically valid | Implemented on feature branch | Concentration supports simulation; risk/calculate, drawdown, rolling-metrics, and historical-attribution now expose stateless/stateful only | Keep and preserve |
 | Benchmark returns should come from `lotus-performance` | Achieved in current stateful rolling/risk design direction | lotus-performance returns-series contract and integration usage | Confirm and preserve |
 | Risk-free series should come from `lotus-core` | Implemented on feature branch for stateful rolling Sharpe | rolling adapter now sources risk-free reference series through lotus-core risk-free contract; live validation now succeeds for the tested USD YTD path | Complete for current validated path |
-| Stateful active-risk attribution needs benchmark exposure history | Implemented on feature branch for POSITION, SECTOR, and ASSET_CLASS via lotus-performance benchmark exposure context | lotus-performance `/integration/benchmarks/exposure-context` backed by lotus-core lineage | Preserve; issuer semantics remain gated |
+| Stateful active-risk attribution needs benchmark exposure history | Implemented for POSITION, SECTOR, ASSET_CLASS, and ISSUER via lotus-performance benchmark exposure context | lotus-performance `/integration/benchmarks/exposure-context` backed by lotus-core lineage | Preserve |
 | Unsupported modes must be explicit and deterministic | Implemented on feature branch | unsupported simulation modes are removed from non-concentration request schemas and rejected at validation boundary | Keep and preserve |
 | Production hardening of upstream behavior | Improved, not complete | better runtime wiring and tests exist, but no final service-wide readiness sign-off | Open |
 | Full integrated validation against real upstreams | Partial | live Docker validation passes for operational endpoints, stateful risk, drawdown, rolling including Sharpe for the validated USD YTD path, historical-attribution total/active risk, concentration stateful, and concentration simulation | Open until final issuer active-risk semantics are resolved and full release evidence is assembled |
@@ -192,7 +192,7 @@ Residual risk is now narrower: `lotus-risk` should continue to fail deterministi
 
 The original blocker was benchmark exposure history. The feature branch now sources benchmark exposure history from the lotus-performance benchmark exposure context endpoint, which exposes a performance-aligned derived view backed by lotus-core lineage. This removes direct benchmark assignment, market-series, and index-catalog orchestration from lotus-risk for active-risk attribution and keeps benchmark returns plus benchmark exposures on the same performance-aligned contract.
 
-The remaining functional gap is issuer-level active attribution. `lotus-risk` still needs benchmark issuer exposure semantics before it can support `ACTIVE_RISK` + `ISSUER` statefully.
+The previous issuer-level active attribution gap is resolved by consuming lotus-performance benchmark exposure context issuer rows.
 
 For issuer support, `lotus-risk` does not merely need benchmark metadata or current benchmark composition. It needs benchmark issuer exposure history over time:
 
@@ -202,7 +202,7 @@ For issuer support, `lotus-risk` does not merely need benchmark metadata or curr
 4. with semantics aligned to portfolio exposure history
 5. in a shape that supports deterministic reconciliation and auditability
 
-Until that issuer-specific mapping exists, stateful issuer active-risk attribution remains gated.
+Issuer-specific mapping now comes from lotus-performance benchmark exposure context issuer groups, backed by lotus-core index-catalog issuer labels.
 
 ### Gap D: Operational hardening is improved but not complete
 
@@ -280,7 +280,7 @@ After the `lotus-performance` benchmark exposure view became available, `lotus-r
 2. keeps lotus-core direct calls only where lotus-risk needs authoritative reference data not exposed through performance context
 3. validates lineage and preserves date-grid alignment expectations between benchmark returns and benchmark exposure rows
 4. preserves deterministic failure if benchmark exposure lineage or required grouping data is missing
-5. keeps issuer active-risk gated until issuer exposure semantics exist in the performance-aligned view
+5. keeps issuer active-risk backed by issuer exposure semantics in the performance-aligned view
 6. adds contract, characterization, and endpoint tests that lock the new `lotus-performance` request/response shape
 
 ### E. Complete integration hardening
@@ -345,7 +345,7 @@ This RFC should not be marked implemented based on intent alone. The required ev
 
 ## Open Questions
 
-1. What exact benchmark issuer exposure semantics should be used for stateful `ACTIVE_RISK` + `ISSUER` attribution?
+1. What broader live portfolio-archetype evidence should be required for stateful `ACTIVE_RISK` + `ISSUER` beyond the canonical baseline?
 2. Do we want unsupported-mode responses standardized on one specific Lotus error code across all analytics endpoints, or is the current per-endpoint validation mapping sufficient as long as it is deterministic and documented?
 3. Which currencies, tenors, and date ranges must lotus-core seed first so stateful rolling Sharpe has production-grade live coverage?
 
@@ -360,7 +360,7 @@ This RFC should not be marked implemented based on intent alone. The required ev
    - simulation remains concentration-only in the current `lotus-risk` production surface
    - `risk/calculate`, `drawdown`, `rolling-metrics`, and `historical-attribution` do not expose simulation in the current contract
 3. Approve hard rejection of unsupported modes.
-4. Approve `historical-attribution` stateful `ACTIVE_RISK` support for `POSITION`, `SECTOR`, and `ASSET_CLASS`, with `ISSUER` remaining gated until benchmark issuer exposure semantics are available.
+4. Approve `historical-attribution` stateful `ACTIVE_RISK` support for `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`.
 5. Approve the two-step benchmark exposure migration:
    - Slice P0-A: implemented the `lotus-performance` benchmark exposure context API backed by lotus-core lineage.
    - Slice P0-B: implemented the `lotus-risk` active-risk attribution migration from direct lotus-core benchmark exposure sourcing to the `lotus-performance` derived view.
@@ -372,7 +372,7 @@ This RFC should not be marked implemented based on intent alone. The required ev
 1. Preserve the finalized endpoint mode contracts and OpenAPI in PR review.
 2. Preserve the implemented `lotus-performance` benchmark exposure context API.
 3. Preserve the implemented `lotus-risk` active-risk attribution integration with the `lotus-performance` benchmark exposure context API.
-4. Verify benchmark issuer exposure semantics needed for stateful issuer active-risk attribution.
+4. Broaden live portfolio-archetype verification for stateful issuer active-risk attribution.
 5. Coordinate lotus-core risk-free data availability for the supported currencies/windows required by rolling Sharpe.
 
 ### P1

--- a/docs/rfcs/RFC-0008-enterprise-bank-readiness-and-live-risk-validation-baseline.md
+++ b/docs/rfcs/RFC-0008-enterprise-bank-readiness-and-live-risk-validation-baseline.md
@@ -77,7 +77,7 @@ Current branch reality:
 1. Define the enterprise-readiness target state for `lotus-risk`.
 2. Preserve the current live-validated analytics baseline with concrete evidence expectations.
 3. Make trading-day calculations a permanent methodology requirement.
-4. Keep `ACTIVE_RISK + ISSUER` intentionally unsupported until benchmark issuer exposure semantics exist.
+4. Keep `ACTIVE_RISK + ISSUER` backed by explicit benchmark issuer exposure semantics.
 5. Define implementation slices with clear acceptance criteria.
 6. Require documentation, agent context, skills guidance assessment, and branch hygiene as a final slice.
 7. Make GitHub-backed asynchronous validation part of the implementation posture.
@@ -88,7 +88,7 @@ Current branch reality:
 2. Claim regulatory market-risk capital model approval.
 3. Move benchmark, portfolio, issuer, risk-free, or performance data ownership into `lotus-risk`.
 4. Require `lotus-core` or `lotus-performance` changes in the first implementation slice.
-5. Support `ACTIVE_RISK + ISSUER` without a separate approved issuer benchmark exposure contract.
+5. Support `ACTIVE_RISK + ISSUER` without an approved issuer benchmark exposure contract.
 6. Approve unrestricted production rollout by publishing this RFC.
 
 ## Decision
@@ -206,9 +206,10 @@ For active-risk attribution:
 
 A material residual can be valid and must not be hidden.
 
-## Intentional Limitation: ACTIVE_RISK + ISSUER
+## Implemented Issuer Active-Risk Path: ACTIVE_RISK + ISSUER
 
-`historical-attribution` stateful `ACTIVE_RISK + ISSUER` is intentionally unsupported.
+`historical-attribution` stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance
+benchmark exposure context issuer groups.
 
 This limitation is part of the contract, not an accidental bug.
 
@@ -233,7 +234,7 @@ Unsupported active-risk grouping dimension:
 
 Required behavior:
 
-1. reject `ACTIVE_RISK + ISSUER` at request validation or deterministic contract boundary,
+1. accept `ACTIVE_RISK + ISSUER` only through lotus-performance benchmark exposure context issuer rows,
 2. document the limitation in OpenAPI, domain docs, and product guidance,
 3. prevent gateway and Workbench from exposing issuer active-risk controls,
 4. require a future RFC or approved slice before enabling issuer support.
@@ -246,7 +247,7 @@ Required behavior:
 | `drawdown` | Supported | Supported | Unsupported | Historical realized drawdown only. |
 | `concentration` | Supported | Supported | Supported | Simulation is valid for projected holdings/exposures. |
 | `rolling-metrics` | Supported | Supported | Unsupported | Historical rolling diagnostics only. |
-| `historical-attribution` | Supported | Supported | Unsupported | Historical attribution only; stateful issuer active-risk unsupported. |
+| `historical-attribution` | Supported | Supported | Unsupported | Historical attribution only; stateful issuer active-risk supported. |
 
 ## Upstream Ownership Model
 
@@ -424,7 +425,7 @@ Scope:
 2. Workbench risk panels,
 3. signed VaR labels,
 4. attribution residual display,
-5. unsupported issuer active-risk affordances,
+5. issuer active-risk affordances outside the governed risk contract,
 6. simulation mode affordances.
 
 Acceptance criteria:
@@ -438,7 +439,7 @@ Acceptance criteria:
 Implementation evidence:
 
 1. `docs/domain-apis/risk-product-surface-alignment.md` now defines the risk-owned downstream
-   contract for signed VaR, expected shortfall, attribution residuals, issuer active-risk gating,
+   contract for signed VaR, expected shortfall, attribution residuals, issuer active-risk support metadata,
    concentration-only simulation, and audit metadata preservation.
 2. `docs/domain-apis/integration-capabilities.md` and
    `docs/domain-apis/endpoint-matrix.md` link the downstream alignment contract and clarify that
@@ -551,7 +552,7 @@ This evidence proves the current analytics baseline and completes the `lotus-ris
 This RFC is done for the `lotus-risk`-owned implementation when:
 
 1. all seven implementation slices are complete,
-2. the intentional `ACTIVE_RISK + ISSUER` limitation remains documented unless superseded by a future approved issuer-exposure contract,
+2. `ACTIVE_RISK + ISSUER` remains documented as supported through the approved issuer-exposure contract,
 3. local repo-native checks pass,
 4. GitHub feature-lane and PR checks pass,
 5. live validation matrix evidence is current,
@@ -575,7 +576,7 @@ The implementation now satisfies items 1, 2, 3, 5, and 6 locally. Items 4 and 7 
 ## Open Questions
 
 1. Which additional seeded portfolios should become canonical for the live validation matrix?
-2. Should issuer active-risk remain permanently unsupported, or should a future RFC define benchmark issuer exposure semantics?
+2. What additional portfolio archetypes should be live-proven for issuer active-risk?
 3. Which service should persist calculation lineage for downstream audit evidence: `lotus-risk`, `lotus-gateway`, or reporting workflows?
 4. What endpoint-level latency SLOs should apply to private-banking risk analytics?
 5. Should platform context define canonical direct service ports for all live characterization tests, or should that remain repository-local?
@@ -588,4 +589,4 @@ The RFC-0008 `lotus-risk`-owned implementation is done, but the service is not y
 
 The remaining approval path is explicit: green GitHub merge governance, downstream gateway/Workbench proof against the product-surface contract, broader seeded live portfolio archetype evidence, and final branch hygiene.
 
-The `ACTIVE_RISK + ISSUER` limitation remains intentional and must stay documented until benchmark issuer exposure semantics are explicitly defined and approved.
+The `ACTIVE_RISK + ISSUER` path remains governed by benchmark issuer exposure semantics from lotus-performance and must not be locally recomputed in downstream consumers.

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-15T12:12:55.855350+00:00",
+  "generatedAt": "2026-05-16T00:50:34.746380+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -1489,8 +1489,8 @@
       "preferredName": "notes",
       "description": "Deterministic implementation notes or support boundaries for this workflow.",
       "example": [
-        "stateful active-risk supports POSITION, SECTOR, and ASSET_CLASS",
-        "stateful active-risk ISSUER remains gated"
+        "stateful active-risk supports POSITION, SECTOR, ASSET_CLASS, and ISSUER",
+        "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups"
       ],
       "type": "array",
       "locations": [
@@ -2339,7 +2339,7 @@
       "canonicalTerm": "stateful_active_risk_gate_reason",
       "preferredName": "stateful_active_risk_gate_reason",
       "description": "Deterministic reason for any gated stateful ACTIVE_RISK grouping dimensions.",
-      "example": "benchmark issuer exposure semantics unavailable",
+      "example": "none",
       "type": "string",
       "locations": [
         "body"
@@ -2353,9 +2353,7 @@
       "canonicalTerm": "stateful_active_risk_gated_grouping_dimensions",
       "preferredName": "stateful_active_risk_gated_grouping_dimensions",
       "description": "Grouping dimensions intentionally gated for stateful ACTIVE_RISK attribution.",
-      "example": [
-        "ISSUER"
-      ],
+      "example": [],
       "type": "array",
       "locations": [
         "body"
@@ -2372,7 +2370,8 @@
       "example": [
         "POSITION",
         "SECTOR",
-        "ASSET_CLASS"
+        "ASSET_CLASS",
+        "ISSUER"
       ],
       "type": "array",
       "locations": [
@@ -2386,7 +2385,7 @@
       "semanticId": "lotus.stateful_input",
       "canonicalTerm": "stateful_input",
       "preferredName": "stateful_input",
-      "description": "Stateful payload for returns/exposure sourcing through lotus-performance and lotus-core. Stateful ACTIVE_RISK currently supports POSITION, SECTOR, and ASSET_CLASS; ISSUER remains gated until benchmark issuer exposure semantics are available. CUSTOM grouping is not supported in stateful mode.",
+      "description": "Stateful payload for returns/exposure sourcing through lotus-performance and lotus-core. Stateful ACTIVE_RISK currently supports POSITION, SECTOR, ASSET_CLASS, and ISSUER; ISSUER is supported through lotus-performance benchmark exposure context issuer groups. CUSTOM grouping is not supported in stateful mode.",
       "example": {
         "as_of_date": "2026-02-28",
         "attribution_options": {

--- a/docs/standards/enterprise-readiness.md
+++ b/docs/standards/enterprise-readiness.md
@@ -34,5 +34,5 @@
 
 - Gateway and Workbench consumers must derive simulation and issuer active-risk affordances from `GET /integration/capabilities`.
 - Concentration is the only simulation-enabled risk flow in the current contract.
-- Stateful `ACTIVE_RISK + ISSUER` remains intentionally unsupported until benchmark issuer exposure semantics are approved.
+- Stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups; unsupported grouping posture now applies to `CUSTOM` stateful grouping.
 - See `docs/domain-apis/risk-product-surface-alignment.md`.

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,13 +1,13 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-04-30T06:29:12Z",
+  "generated_at": "2026-05-16T00:56:02Z",
   "allowlist": [
     {
-      "finding": "src/app/contracts/attribution.py:409:total_value: float | None = Field(",
+      "finding": "src/app/contracts/attribution.py:400:total_value: float | None = Field(",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
-      "review_by": "2026-10-27"
+      "review_by": "2026-11-12"
     },
     {
       "finding": "src/app/contracts/concentration.py:215:price: float | None = Field(",

--- a/src/app/contracts/attribution.py
+++ b/src/app/contracts/attribution.py
@@ -38,11 +38,11 @@ def _default_groupings() -> list[GroupingDimension]:
 
 
 def _default_stateful_active_risk_supported_groupings() -> list[GroupingDimension]:
-    return ["POSITION", "SECTOR", "ASSET_CLASS"]
+    return ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"]
 
 
 def _default_stateful_active_risk_gated_groupings() -> list[GroupingDimension]:
-    return ["ISSUER"]
+    return []
 
 
 class AttributionOptions(BaseModel):
@@ -265,15 +265,6 @@ class HistoricalAttributionStatefulInput(BaseModel):
                 "stateful historical-attribution does not support grouping_dimension=CUSTOM"
             )
 
-        requires_active = (
-            "ACTIVE_RISK" in self.attribution_options.attribution_types
-            or "TRACKING_ERROR" in self.attribution_options.metrics
-        )
-        if requires_active and "ISSUER" in grouping_dimensions:
-            raise ValueError(
-                "stateful ACTIVE_RISK/TRACKING_ERROR attribution does not support "
-                "grouping_dimension=ISSUER until benchmark issuer exposure semantics are available"
-            )
         return self
 
 
@@ -306,8 +297,8 @@ class HistoricalAttributionRequest(BaseModel):
         default=None,
         description=(
             "Stateful payload for returns/exposure sourcing through lotus-performance and lotus-core. "
-            "Stateful ACTIVE_RISK currently supports POSITION, SECTOR, and ASSET_CLASS; "
-            "ISSUER remains gated until benchmark issuer exposure semantics are available. "
+            "Stateful ACTIVE_RISK currently supports POSITION, SECTOR, ASSET_CLASS, and ISSUER; "
+            "ISSUER is supported through lotus-performance benchmark exposure context issuer groups. "
             "CUSTOM grouping is not supported in stateful mode."
         ),
         json_schema_extra={
@@ -519,17 +510,17 @@ class HistoricalAttributionMetadata(AuditMetadataFields):
     stateful_active_risk_supported_grouping_dimensions: list[GroupingDimension] = Field(
         default_factory=_default_stateful_active_risk_supported_groupings,
         description="Grouping dimensions currently supported for stateful ACTIVE_RISK attribution.",
-        json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS"]},
+        json_schema_extra={"example": ["POSITION", "SECTOR", "ASSET_CLASS", "ISSUER"]},
     )
     stateful_active_risk_gated_grouping_dimensions: list[GroupingDimension] = Field(
         default_factory=_default_stateful_active_risk_gated_groupings,
         description="Grouping dimensions intentionally gated for stateful ACTIVE_RISK attribution.",
-        json_schema_extra={"example": ["ISSUER"]},
+        json_schema_extra={"example": []},
     )
     stateful_active_risk_gate_reason: str = Field(
-        default="benchmark issuer exposure semantics unavailable",
+        default="none",
         description="Deterministic reason for any gated stateful ACTIVE_RISK grouping dimensions.",
-        json_schema_extra={"example": "benchmark issuer exposure semantics unavailable"},
+        json_schema_extra={"example": "none"},
     )
     calculation_supportability: RiskCalculationSupportability = Field(
         default_factory=lambda: RiskCalculationSupportability(
@@ -600,9 +591,10 @@ class HistoricalAttributionResponse(BaseModel):
                     "POSITION",
                     "SECTOR",
                     "ASSET_CLASS",
+                    "ISSUER",
                 ],
-                "stateful_active_risk_gated_grouping_dimensions": ["ISSUER"],
-                "stateful_active_risk_gate_reason": "benchmark issuer exposure semantics unavailable",
+                "stateful_active_risk_gated_grouping_dimensions": [],
+                "stateful_active_risk_gate_reason": "none",
             }
         },
     )
@@ -665,11 +657,10 @@ class HistoricalAttributionResponse(BaseModel):
                         "POSITION",
                         "SECTOR",
                         "ASSET_CLASS",
+                        "ISSUER",
                     ],
-                    "stateful_active_risk_gated_grouping_dimensions": ["ISSUER"],
-                    "stateful_active_risk_gate_reason": (
-                        "benchmark issuer exposure semantics unavailable"
-                    ),
+                    "stateful_active_risk_gated_grouping_dimensions": [],
+                    "stateful_active_risk_gate_reason": "none",
                 },
             }
         }

--- a/src/app/contracts/capabilities.py
+++ b/src/app/contracts/capabilities.py
@@ -67,8 +67,8 @@ class CapabilityWorkflow(BaseModel):
         description="Deterministic implementation notes or support boundaries for this workflow.",
         json_schema_extra={
             "example": [
-                "stateful active-risk supports POSITION, SECTOR, and ASSET_CLASS",
-                "stateful active-risk ISSUER remains gated",
+                "stateful active-risk supports POSITION, SECTOR, ASSET_CLASS, and ISSUER",
+                "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups",
             ]
         },
     )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -582,8 +582,8 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
                 support_status="partial",
                 notes=[
                     "simulation is intentionally unsupported",
-                    "stateful active-risk supports POSITION, SECTOR, and ASSET_CLASS",
-                    "stateful active-risk ISSUER remains gated",
+                    "stateful active-risk supports POSITION, SECTOR, ASSET_CLASS, and ISSUER",
+                    "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups",
                     "historical-attribution response metadata is the authoritative active-risk support contract",
                     "attribution residual and reconciled_sum must be preserved with contributors",
                 ],
@@ -688,8 +688,8 @@ async def analytics_risk_event_affected_cohort(
         "Calculates historical risk and active-risk attribution decompositions with contributor-level "
         "component, marginal, and percent contributions plus reconciliation diagnostics. Supports "
         "stateless execution and approved stateful execution. Stateful ACTIVE_RISK currently supports "
-        "POSITION, SECTOR, and ASSET_CLASS grouping dimensions; ISSUER is intentionally gated and "
-        "CUSTOM grouping is not supported in stateful mode."
+        "POSITION, SECTOR, ASSET_CLASS, and ISSUER grouping dimensions through lotus-performance "
+        "benchmark exposure context. CUSTOM grouping is not supported in stateful mode."
     ),
 )
 async def analytics_risk_historical_attribution(

--- a/src/app/services/benchmark_exposure_history.py
+++ b/src/app/services/benchmark_exposure_history.py
@@ -135,7 +135,7 @@ async def fetch_benchmark_exposure_history(
     correlation_id: str | None,
 ) -> list[ExposurePoint]:
     unsupported_groupings = sorted(
-        {dimension for dimension in grouping_dimensions if dimension in {"CUSTOM", "ISSUER"}}
+        {dimension for dimension in grouping_dimensions if dimension == "CUSTOM"}
     )
     if unsupported_groupings:
         raise ValueError(

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -5,6 +5,7 @@ from app.main import app
 from tests.support.app_runtime import override_app_runtime
 from tests.support.historical_attribution_fakes import (
     RecordingHistoricalAttributionCoreClient,
+    build_benchmark_exposure_context_response,
     build_stateful_attribution_returns_client,
 )
 from tests.support.lotus_core_fakes import SimulationLotusCoreClient
@@ -196,7 +197,7 @@ def test_integration_capabilities_endpoint_exposes_support_matrix() -> None:
     assert workflow_by_key["concentration_risk"]["support_status"] == "full"
     assert workflow_by_key["historical_risk_attribution"]["support_status"] == "partial"
     assert (
-        "stateful active-risk ISSUER remains gated"
+        "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups"
         in workflow_by_key["historical_risk_attribution"]["notes"]
     )
 
@@ -662,27 +663,49 @@ def test_e2e_historical_attribution_stateful_active_risk_mode() -> None:
     assert not hasattr(core_client, "get_benchmark_market_series")
 
 
-def test_e2e_historical_attribution_stateful_issuer_is_rejected_at_boundary() -> None:
-    client = TestClient(app)
-    response = client.post(
-        "/analytics/risk/historical-attribution",
-        json={
-            "input_mode": "stateful",
-            "stateful_input": {
-                "portfolio_id": "DEMO_DPM_EUR_001",
-                "as_of_date": "2026-01-06",
-                "periods": [{"type": "YTD", "name": "YTD"}],
-                "attribution_options": {
-                    "attribution_types": ["ACTIVE_RISK"],
-                    "metrics": ["TRACKING_ERROR"],
-                    "grouping_dimensions": ["ISSUER"],
-                },
-            },
-        },
+def test_e2e_historical_attribution_stateful_issuer_active_risk_mode() -> None:
+    performance_client = build_stateful_attribution_returns_client()
+    performance_client.benchmark_exposure_context_payload = (
+        build_benchmark_exposure_context_response(grouping_dimension="ISSUER")
     )
 
-    assert response.status_code == 422
+    class _IssuerCoreClient(RecordingHistoricalAttributionCoreClient):
+        async def get_instrument_enrichment(
+            self,
+            *,
+            security_ids: list[str],
+            correlation_id: str | None,  # noqa: ARG002
+        ) -> dict[str, object]:
+            return {
+                "records": [
+                    {"security_id": "SEC_A", "issuer_id": "ISSUER_A", "issuer_name": "Issuer A"},
+                    {"security_id": "SEC_B", "issuer_id": "ISSUER_B", "issuer_name": "Issuer B"},
+                ]
+            }
+
+    with override_app_runtime(
+        lotus_performance_client=performance_client,
+        lotus_core_client=_IssuerCoreClient(),
+    ):
+        client = TestClient(app)
+        response = client.post(
+            "/analytics/risk/historical-attribution",
+            json={
+                "input_mode": "stateful",
+                "stateful_input": {
+                    "portfolio_id": "DEMO_DPM_EUR_001",
+                    "as_of_date": "2026-01-06",
+                    "periods": [{"type": "YTD", "name": "YTD"}],
+                    "attribution_options": {
+                        "attribution_types": ["ACTIVE_RISK"],
+                        "metrics": ["TRACKING_ERROR"],
+                        "grouping_dimensions": ["ISSUER"],
+                    },
+                },
+            },
+        )
+
+    assert response.status_code == 200
     body = response.json()
-    assert body["error"]["code"] == "INVALID_REQUEST"
-    detail_messages = [detail["msg"] for detail in body["error"]["details"]]
-    assert any("grouping_dimension=ISSUER" in message for message in detail_messages)
+    assert body["metadata"]["requested_grouping_dimensions"] == ["ISSUER"]
+    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == []

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -80,7 +80,7 @@ def test_integration_capabilities_contract() -> None:
     )
     assert workflow_by_key["risk_event_affected_cohort"]["support_status"] == "partial"
     assert (
-        "stateful active-risk ISSUER remains gated"
+        "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups"
         in workflow_by_key["historical_risk_attribution"]["notes"]
     )
     assert (
@@ -449,7 +449,10 @@ def test_openapi_exposes_historical_attribution_support_metadata() -> None:
     assert "min_observations_policy" in serialized_spec
     assert "stateful_active_risk_supported_grouping_dimensions" in serialized_spec
     assert "stateful_active_risk_gated_grouping_dimensions" in serialized_spec
-    assert "benchmark issuer exposure semantics unavailable" in serialized_spec
+    assert (
+        "ISSUER is supported through lotus-performance benchmark exposure context issuer groups"
+        in serialized_spec
+    )
 
 
 def test_openapi_exposes_ops_dependency_diagnostics_schema() -> None:
@@ -568,7 +571,7 @@ def test_openapi_exposes_health_and_liveness_contracts() -> None:
     assert liveness_schema["properties"]["status"]["example"] == "live"
 
 
-def test_historical_attribution_openapi_examples_and_description_reflect_stateful_gate() -> None:
+def test_historical_attribution_openapi_examples_and_description_reflect_stateful_support() -> None:
     client = TestClient(app)
     spec = client.get("/openapi.json").json()
     operation = spec["paths"]["/analytics/risk/historical-attribution"]["post"]
@@ -576,8 +579,8 @@ def test_historical_attribution_openapi_examples_and_description_reflect_statefu
     request_schema = spec["components"]["schemas"]["HistoricalAttributionRequest"]
     response_schema = spec["components"]["schemas"]["HistoricalAttributionResponse"]
 
-    assert "POSITION, SECTOR, and ASSET_CLASS" in description
-    assert "ISSUER is intentionally gated" in description
+    assert "POSITION, SECTOR, ASSET_CLASS, and ISSUER" in description
+    assert "benchmark exposure context" in description
     assert "CUSTOM grouping is not supported in stateful mode" in description
     assert request_schema["example"]["input_mode"] == "stateful"
     assert request_schema["example"]["stateful_input"]["attribution_options"][

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -207,12 +207,10 @@ def test_historical_attribution_stateless_happy_path() -> None:
         "POSITION",
         "SECTOR",
         "ASSET_CLASS",
+        "ISSUER",
     ]
-    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == ["ISSUER"]
-    assert (
-        body["metadata"]["stateful_active_risk_gate_reason"]
-        == "benchmark issuer exposure semantics unavailable"
-    )
+    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == []
+    assert body["metadata"]["stateful_active_risk_gate_reason"] == "none"
     assert body["metadata"]["calculation_supportability"] == {
         "state": "ready",
         "reason": "calculation_complete",
@@ -489,9 +487,27 @@ def test_historical_attribution_stateful_active_risk_asset_class_contract() -> N
     assert not hasattr(core_client, "get_benchmark_market_series")
 
 
-def test_historical_attribution_stateful_active_risk_issuer_is_explicitly_gated() -> None:
+def test_historical_attribution_stateful_active_risk_issuer_uses_benchmark_context() -> None:
     performance_client = build_stateful_attribution_returns_client()
-    core_client = RecordingHistoricalAttributionCoreClient()
+    performance_client.benchmark_exposure_context_payload = (
+        build_benchmark_exposure_context_response(grouping_dimension="ISSUER")
+    )
+
+    class _IssuerCoreClient(RecordingHistoricalAttributionCoreClient):
+        async def get_instrument_enrichment(
+            self,
+            *,
+            security_ids: list[str],
+            correlation_id: str | None,  # noqa: ARG002
+        ) -> dict[str, object]:
+            return {
+                "records": [
+                    {"security_id": "SEC_A", "issuer_id": "ISSUER_A", "issuer_name": "Issuer A"},
+                    {"security_id": "SEC_B", "issuer_id": "ISSUER_B", "issuer_name": "Issuer B"},
+                ]
+            }
+
+    core_client = _IssuerCoreClient()
 
     with override_app_runtime(
         lotus_performance_client=performance_client,
@@ -516,12 +532,14 @@ def test_historical_attribution_stateful_active_risk_issuer_is_explicitly_gated(
             },
         )
 
-    assert response.status_code == 422
-    body = response.json()["error"]
-    assert body["code"] == "INVALID_REQUEST"
-    assert body["message"] == "Request validation failed"
-    assert any("grouping_dimension=ISSUER" in detail["msg"] for detail in body["details"])
-    assert body["correlation_id"] == "corr-attr-active-issuer"
+    assert response.status_code == 200
+    body = response.json()
+    assert body["input_mode"] == "stateful"
+    assert body["metadata"]["requested_grouping_dimensions"] == ["ISSUER"]
+    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == []
+    assert performance_client.benchmark_exposure_context_calls[0]["request_payload"][
+        "grouping_dimensions"
+    ] == ["ISSUER"]
 
 
 def test_historical_attribution_stateful_custom_grouping_is_explicitly_gated() -> None:

--- a/tests/integration/test_historical_attribution_live_characterization.py
+++ b/tests/integration/test_historical_attribution_live_characterization.py
@@ -184,8 +184,9 @@ def test_live_stateful_historical_attribution_supports_sector_active_risk() -> N
         "POSITION",
         "SECTOR",
         "ASSET_CLASS",
+        "ISSUER",
     ]
-    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == ["ISSUER"]
+    assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == []
 
     period = body["results"]["YTD"]
     assert period["error"] is None

--- a/tests/support/historical_attribution_fakes.py
+++ b/tests/support/historical_attribution_fakes.py
@@ -28,7 +28,58 @@ def build_benchmark_exposure_context_response(
     *,
     grouping_dimension: str = "SECTOR",
 ) -> dict[str, object]:
-    if grouping_dimension == "ASSET_CLASS":
+    if grouping_dimension == "ISSUER":
+        rows = [
+            {
+                "valuation_date": "2026-01-02",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_A",
+                "group_label": "Issuer A",
+                "weight": "0.55",
+            },
+            {
+                "valuation_date": "2026-01-02",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_B",
+                "group_label": "Issuer B",
+                "weight": "0.45",
+            },
+            {
+                "valuation_date": "2026-01-05",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_A",
+                "group_label": "Issuer A",
+                "weight": "0.56",
+            },
+            {
+                "valuation_date": "2026-01-05",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_B",
+                "group_label": "Issuer B",
+                "weight": "0.44",
+            },
+            {
+                "valuation_date": "2026-01-06",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_A",
+                "group_label": "Issuer A",
+                "weight": "0.54",
+            },
+            {
+                "valuation_date": "2026-01-06",
+                "component_id": None,
+                "grouping_dimension": "ISSUER",
+                "group_key": "ISSUER_B",
+                "group_label": "Issuer B",
+                "weight": "0.46",
+            },
+        ]
+    elif grouping_dimension == "ASSET_CLASS":
         rows = [
             {
                 "valuation_date": "2026-01-02",

--- a/tests/unit/test_attribution_contract.py
+++ b/tests/unit/test_attribution_contract.py
@@ -121,23 +121,25 @@ def test_attribution_contract_rejects_duplicate_period_names() -> None:
         HistoricalAttributionRequest.model_validate(payload)
 
 
-def test_stateful_attribution_contract_rejects_active_risk_issuer_grouping() -> None:
-    with pytest.raises(ValueError, match="grouping_dimension=ISSUER"):
-        HistoricalAttributionRequest.model_validate(
-            {
-                "input_mode": "stateful",
-                "stateful_input": {
-                    "portfolio_id": "DEMO_DPM_EUR_001",
-                    "as_of_date": "2026-01-04",
-                    "periods": [{"type": "YTD", "name": "YTD"}],
-                    "attribution_options": {
-                        "attribution_types": ["ACTIVE_RISK"],
-                        "metrics": ["TRACKING_ERROR"],
-                        "grouping_dimensions": ["ISSUER"],
-                    },
+def test_stateful_attribution_contract_accepts_active_risk_issuer_grouping() -> None:
+    request = HistoricalAttributionRequest.model_validate(
+        {
+            "input_mode": "stateful",
+            "stateful_input": {
+                "portfolio_id": "DEMO_DPM_EUR_001",
+                "as_of_date": "2026-01-04",
+                "periods": [{"type": "YTD", "name": "YTD"}],
+                "attribution_options": {
+                    "attribution_types": ["ACTIVE_RISK"],
+                    "metrics": ["TRACKING_ERROR"],
+                    "grouping_dimensions": ["ISSUER"],
                 },
-            }
-        )
+            },
+        }
+    )
+
+    assert request.stateful_input is not None
+    assert request.stateful_input.attribution_options.grouping_dimensions == ["ISSUER"]
 
 
 def test_stateful_attribution_contract_rejects_custom_grouping() -> None:

--- a/tests/unit/test_attribution_mode_adapter.py
+++ b/tests/unit/test_attribution_mode_adapter.py
@@ -311,22 +311,49 @@ def test_stateful_attribution_rejects_active_risk_when_benchmark_returns_missing
         )
 
 
-def test_stateful_attribution_rejects_active_risk_issuer_grouping_until_benchmark_mapping_exists() -> (
-    None
-):
-    with pytest.raises(ValueError, match="grouping_dimension=ISSUER"):
-        asyncio.run(
-            calculate_historical_attribution_stateful(
-                _stateful_input(
-                    grouping_dimensions=["ISSUER"],
-                    attribution_types=["ACTIVE_RISK"],
-                    metrics=["TRACKING_ERROR"],
-                ),
-                performance_client=_StubPerformanceClient(),
-                core_client=_StubCoreClient(),
-                correlation_id="corr-attr",
+def test_stateful_attribution_supports_active_risk_issuer_grouping() -> None:
+    class _IssuerBenchmarkPerformanceClient(_StubPerformanceClient):
+        async def get_benchmark_exposure_context(
+            self,
+            *,
+            request_payload: dict[str, object],
+            correlation_id: str | None,
+        ) -> dict[str, object]:
+            self._client.benchmark_exposure_context_calls.append(
+                {"request_payload": request_payload, "correlation_id": correlation_id}
             )
+            return build_benchmark_exposure_context_response(grouping_dimension="ISSUER")
+
+    performance_client = _IssuerBenchmarkPerformanceClient()
+    core_client = _StubCoreClient()
+
+    response = asyncio.run(
+        calculate_historical_attribution_stateful(
+            _stateful_input(
+                grouping_dimensions=["ISSUER"],
+                attribution_types=["ACTIVE_RISK"],
+                metrics=["TRACKING_ERROR"],
+            ),
+            performance_client=performance_client,
+            core_client=core_client,
+            correlation_id="corr-attr",
         )
+    )
+
+    assert response.metadata.requested_grouping_dimensions == ["ISSUER"]
+    assert response.metadata.stateful_active_risk_supported_grouping_dimensions == [
+        "POSITION",
+        "SECTOR",
+        "ASSET_CLASS",
+        "ISSUER",
+    ]
+    assert response.metadata.stateful_active_risk_gated_grouping_dimensions == []
+    assert core_client.enrichment_calls == [["SEC_A", "SEC_B"]]
+    benchmark_context_request = performance_client.benchmark_exposure_context_calls[0][
+        "request_payload"
+    ]
+    assert isinstance(benchmark_context_request, dict)
+    assert benchmark_context_request["grouping_dimensions"] == ["ISSUER"]
 
 
 def test_stateful_attribution_rejects_benchmark_exposure_date_misalignment() -> None:

--- a/tests/unit/test_benchmark_exposure_history.py
+++ b/tests/unit/test_benchmark_exposure_history.py
@@ -143,19 +143,28 @@ def test_fetch_benchmark_exposure_history_follows_performance_pagination() -> No
     assert points
 
 
-def test_fetch_benchmark_exposure_history_rejects_issuer_grouping_until_semantics_exist() -> None:
-    with pytest.raises(ValueError, match="cannot source benchmark exposure history"):
-        asyncio.run(
-            fetch_benchmark_exposure_history(
-                performance_client=_performance_client(),
-                portfolio_id="DEMO_DPM_EUR_001",
-                as_of_date=date(2026, 1, 4),
-                start_date=date(2026, 1, 2),
-                reporting_currency=None,
-                grouping_dimensions=["ISSUER"],
-                correlation_id=None,
-            )
+def test_fetch_benchmark_exposure_history_accepts_issuer_grouping() -> None:
+    performance = _performance_client(
+        build_benchmark_exposure_context_response(grouping_dimension="ISSUER")
+    )
+
+    points = asyncio.run(
+        fetch_benchmark_exposure_history(
+            performance_client=performance,
+            portfolio_id="DEMO_DPM_EUR_001",
+            as_of_date=date(2026, 1, 4),
+            start_date=date(2026, 1, 2),
+            reporting_currency=None,
+            grouping_dimensions=["ISSUER"],
+            correlation_id=None,
         )
+    )
+
+    assert points
+    assert {point.grouping_dimension for point in points} == {"ISSUER"}
+    assert performance.benchmark_exposure_context_calls[0]["request_payload"][
+        "grouping_dimensions"
+    ] == ["ISSUER"]
 
 
 def test_fetch_benchmark_exposure_history_rejects_empty_performance_payload() -> None:

--- a/tests/unit/test_product_surface_alignment_contract.py
+++ b/tests/unit/test_product_surface_alignment_contract.py
@@ -46,13 +46,19 @@ def test_product_surface_contract_keeps_simulation_concentration_only() -> None:
         assert any("simulation is intentionally unsupported" == note for note in workflow["notes"])
 
 
-def test_product_surface_contract_keeps_issuer_active_risk_gated() -> None:
+def test_product_surface_contract_supports_issuer_active_risk() -> None:
     workflows = _capability_workflows()
     attribution = workflows["historical_risk_attribution"]
 
     assert attribution["support_status"] == "partial"
-    assert "stateful active-risk supports POSITION, SECTOR, and ASSET_CLASS" in attribution["notes"]
-    assert "stateful active-risk ISSUER remains gated" in attribution["notes"]
+    assert (
+        "stateful active-risk supports POSITION, SECTOR, ASSET_CLASS, and ISSUER"
+        in attribution["notes"]
+    )
+    assert (
+        "issuer active-risk consumes lotus-performance benchmark exposure context issuer groups"
+        in attribution["notes"]
+    )
     assert (
         "historical-attribution response metadata is the authoritative active-risk support contract"
         in attribution["notes"]

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -72,7 +72,7 @@ The important rule is that support is workflow-specific, not service-wide:
 
 1. concentration supports all three,
 2. risk/calculate, drawdown, and rolling support stateless and stateful only,
-3. historical attribution supports stateless and stateful, but stateful active-risk remains partially gated.
+3. historical attribution supports stateless and stateful active-risk, including issuer grouping.
 
 ## Upstream Dependency Model
 
@@ -91,7 +91,7 @@ semantic preservation:
 
 1. signed VaR must stay signed,
 2. attribution residual and reconciled sum must stay attached to contributors,
-3. unsupported issuer active-risk must remain visibly gated,
+3. issuer active-risk must remain backed by lotus-performance benchmark exposure context issuer groups,
 4. simulation must remain concentration-only,
 5. lineage and upstream fingerprint metadata must survive downstream shaping.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -28,7 +28,7 @@ small but important:
 The most important current limits are:
 
 1. simulation is supported only for concentration,
-2. stateful historical attribution remains `partial` because `ACTIVE_RISK + ISSUER` is gated,
+2. stateful historical attribution supports `ACTIVE_RISK + ISSUER` through lotus-performance benchmark exposure context issuer groups,
 3. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
 4. broader enterprise claims require more seeded archetypes and evidence.
 

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -39,7 +39,7 @@ This matters because:
 5. regime scenario-pack evaluation is stateless and source-owned by `lotus-risk`,
 6. per-security regime scenario contribution rows are available when callers supply reconciled
    exposure components,
-7. one remaining functional gap inside the approved analytics surface is stateful `ACTIVE_RISK + ISSUER`.
+7. stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups.
 
 ## Downstream Preservation Rules
 
@@ -47,7 +47,7 @@ Gateway, Workbench, reporting, and AI consumers must preserve:
 
 1. signed VaR semantics,
 2. attribution `total_value`, `reconciled_sum`, `residual`, and contributor fields,
-3. issuer active-risk gating,
+3. issuer active-risk support metadata,
 4. concentration-only simulation support,
 5. regime scenario-pack evaluation reason codes and threshold-breach posture,
 6. regime scenario-pack per-security contribution rows when present,

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -26,7 +26,7 @@ That is why this repo cares so much about:
 1. explicit mode support,
 2. signed VaR semantics,
 3. attribution reconciliation fields,
-4. issuer active-risk gating,
+4. issuer active-risk support metadata,
 5. lineage and upstream fingerprint metadata.
 
 One practical consequence follows from that:
@@ -74,7 +74,7 @@ Those boundaries are governed and should stay explicit.
 
 The only material gap inside the current approved API surface is:
 
-1. stateful `ACTIVE_RISK + ISSUER` for historical attribution.
+1. broader live portfolio-archetype proof for stateful `ACTIVE_RISK + ISSUER` beyond the canonical baseline.
 
 That gap is intentionally exposed rather than hidden:
 

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -27,7 +27,7 @@ The current runtime and contract already provide:
 
 Important current limits:
 
-1. stateful `ACTIVE_RISK + ISSUER` remains intentionally gated,
+1. broaden live portfolio-archetype validation for stateful `ACTIVE_RISK + ISSUER`,
 2. simulation remains concentration-only,
 3. enterprise live-validation breadth remains limited to the canonical portfolio baseline unless more seeded archetypes are registered with evidence,
 4. downstream consumers still need more cross-repo proof that they preserve the risk contract correctly.

--- a/wiki/Security-and-Governance.md
+++ b/wiki/Security-and-Governance.md
@@ -18,7 +18,7 @@ The highest-value rules for this repo are:
 
 1. signed VaR and expected shortfall semantics must be preserved,
 2. attribution reconciliation fields must stay attached to contributor outputs,
-3. stateful issuer active-risk must remain visibly gated,
+3. stateful issuer active-risk must remain backed by lotus-performance benchmark exposure context issuer groups,
 4. simulation must remain concentration-only,
 5. lineage and upstream request-fingerprint metadata must survive downstream shaping.
 
@@ -48,7 +48,7 @@ A feature being implemented is not the same as a feature being broadly supportab
 
 Current examples:
 
-1. historical attribution exists, but one important stateful active-risk path is still intentionally partial,
+1. historical attribution exists with issuer active-risk support; broader live archetype evidence remains intentionally scoped,
 2. live validation exists, but enterprise archetype breadth is still limited,
 3. concentration simulation is real, but simulation support does not generalize to the rest of the service.
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -36,11 +36,11 @@ Use the canonical local URL runbook before changing more code.
 Symptoms:
 
 1. stateful historical attribution works for some dimensions but not others,
-2. issuer active-risk appears missing or rejected.
+2. issuer active-risk appears missing, degraded, or rejected.
 
 Interpretation:
 
-1. this may be the intentional `ACTIVE_RISK + ISSUER` gate,
+1. verify the request is not using unsupported `CUSTOM` stateful grouping,
 2. check `/integration/capabilities`,
 3. check the endpoint matrix and product-surface alignment docs.
 


### PR DESCRIPTION
## Summary
- enables stateful `ACTIVE_RISK + ISSUER` historical attribution in lotus-risk
- consumes lotus-performance benchmark exposure context issuer rows instead of locally recomputing benchmark issuer facts
- updates active-risk support metadata, capabilities, OpenAPI/API vocabulary, domain docs, RFC notes, repository context, tests, and wiki source

## Upstream prerequisite
- lotus-performance PR #165 is merged on `main` at merge commit `191a405`, with wiki published at `46a9124`

## Validation
- `python -m pytest tests\unit\test_benchmark_exposure_history.py tests\unit\test_attribution_contract.py tests\unit\test_attribution_mode_adapter.py tests\integration\test_historical_attribution_endpoint.py tests\integration\test_health.py tests\e2e\test_smoke.py tests\unit\test_product_surface_alignment_contract.py tests\unit\test_rfc0008_context_contract.py -q` -> 110 passed
- `make lint`
- `make no-alias-gate`
- `make typecheck`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make domain-data-product-gate`
- `make test-unit` -> 358 passed
- `make test-integration` -> 80 passed, 14 skipped
- `make test-e2e` -> 24 passed
- `make test-pyramid-gate`
- `pwsh -NoProfile -File ..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` -> expected drift in repo-authored wiki pages pending post-merge publication

## Wiki
Repo-local wiki source changed; publish after merge.