### PR TITLE
Degrade flagged historical attribution supportability

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -152,7 +152,10 @@ Boundary rules:
    `lotus_risk_calculation_supportability_total` labels. The supportability contract publishes
    explicit `metric_labels`, and tests prove the Prometheus labels remain bounded to `operation`,
    `supportability_state`, `reason`, and `freshness_bucket` without portfolio, client,
-   correlation, trace, security, request-body, or response-body label fields.
+   correlation, trace, security, request-body, or response-body label fields. Historical
+   attribution now degrades response-level calculation supportability whenever any source-owned
+   attribution set emits quality flags, so downstream consumers do not treat missing grouping data,
+   empty active-risk alignment, or unsupported attribution combinations as fully ready analytics.
 
 Canonical direct local validation ports:
 

--- a/docs/methodologies/metrics/attribution-tracking-error.md
+++ b/docs/methodologies/metrics/attribution-tracking-error.md
@@ -44,6 +44,10 @@
 - Missing benchmark exposure history blocks active-risk attribution.
 - Alignment-empty joins emit quality flags with no contributors.
 - Near-zero denominators result in diagnostic/unsupported flags.
+- Any emitted attribution-set quality flag degrades
+  `metadata.calculation_supportability` with reason `calculation_quality_issue`; downstream
+  services must preserve the source-owned supportability posture instead of treating flagged
+  active-risk attribution as fully ready.
 
 ## Configuration Options
 - `attribution_options.grouping_dimensions`

--- a/docs/methodologies/metrics/attribution-volatility.md
+++ b/docs/methodologies/metrics/attribution-volatility.md
@@ -43,6 +43,10 @@
 - Insufficient observations produce empty contributors and diagnostics.
 - Weight-sum deviations add quality flags.
 - Unsupported attribution combinations return quality flags.
+- Any emitted attribution-set quality flag degrades
+  `metadata.calculation_supportability` with reason `calculation_quality_issue`; downstream
+  services must preserve the source-owned supportability posture instead of treating flagged
+  attribution as fully ready.
 
 ## Configuration Options
 - `attribution_options.grouping_dimensions`

--- a/docs/standards/monetary-float-allowlist.json
+++ b/docs/standards/monetary-float-allowlist.json
@@ -1,7 +1,7 @@
 {
   "description": "Approved baseline monetary-float findings. New findings fail CI.",
   "policy_version": "1.1.0",
-  "generated_at": "2026-05-16T00:56:02Z",
+  "generated_at": "2026-05-16T06:58:14Z",
   "allowlist": [
     {
       "finding": "src/app/contracts/attribution.py:400:total_value: float | None = Field(",
@@ -34,31 +34,31 @@
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:107:total_value: float,",
+      "finding": "src/app/services/attribution_engine.py:108:total_value: float,",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:128:percent = float(component / total_value) if not np.isclose(total_value, 0.0) else None",
+      "finding": "src/app/services/attribution_engine.py:129:percent = float(component / total_value) if not np.isclose(total_value, 0.0) else None",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:183:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
+      "finding": "src/app/services/attribution_engine.py:184:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:211:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
+      "finding": "src/app/services/attribution_engine.py:212:total_value = float(metric_series.std(ddof=1) * sqrt(annualization_basis))",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"
     },
     {
-      "finding": "src/app/services/attribution_engine.py:243:residual = float(total_value - reconciled_sum)",
+      "finding": "src/app/services/attribution_engine.py:244:residual = float(total_value - reconciled_sum)",
       "justification": "Temporary approved monetary float usage; migrate to Decimal.",
       "owner": "platform-governance",
       "review_by": "2026-10-27"

--- a/docs/standards/risk-analytics-contract.md
+++ b/docs/standards/risk-analytics-contract.md
@@ -70,8 +70,9 @@
 - Metrics and response metadata must not expose portfolio, client, account, position, transaction,
   security, trace, correlation, request-body, response-body, or raw request identifiers.
 - Endpoint-specific supportability must be source-backed: return-series endpoints derive freshness
-  and empty/degraded posture from period results, while concentration derives degraded posture from
-  issuer coverage and empty universe support.
+  and empty/degraded posture from period results, historical-attribution also degrades when any
+  attribution set emits quality flags, and concentration derives degraded posture from issuer
+  coverage and empty universe support.
 
 ## Risk Calculate Mode Support
 - `stateless`: caller supplies full return series.

--- a/src/app/services/attribution_engine.py
+++ b/src/app/services/attribution_engine.py
@@ -23,6 +23,7 @@ from app.contracts.risk import ReturnPoint, RiskRequestPeriod
 from app.services.audit_lineage import fingerprint_model
 from app.services.calculation_supportability import (
     record_operation_supportability,
+    supportability_from_attribution_results,
     supportability_from_period_results,
 )
 from app.services.risk_engine import _resolve_period
@@ -369,7 +370,7 @@ def calculate_historical_attribution(
             error=None,
         )
 
-    calculation_supportability = supportability_from_period_results(
+    calculation_supportability = supportability_from_attribution_results(
         returns=request.returns,
         as_of_date=request.scope.as_of_date,
         results=results,

--- a/src/app/services/calculation_supportability.py
+++ b/src/app/services/calculation_supportability.py
@@ -156,6 +156,44 @@ def supportability_from_period_results(
     )
 
 
+def supportability_from_attribution_results(
+    *,
+    returns: Sequence[ReturnPoint],
+    as_of_date: dt.date,
+    results: Mapping[str, Any],
+) -> RiskCalculationSupportability:
+    supportability = supportability_from_period_results(
+        returns=returns,
+        as_of_date=as_of_date,
+        results=results,
+    )
+    if supportability.state == "empty":
+        return supportability
+
+    degraded_set_count = 0
+    for period_result in results.values():
+        attribution_sets = getattr(period_result, "attribution_sets", ())
+        if not isinstance(attribution_sets, Sequence):
+            continue
+        for attribution_set in attribution_sets:
+            quality_flags = getattr(attribution_set, "quality_flags", ())
+            if isinstance(quality_flags, Sequence) and quality_flags:
+                degraded_set_count += 1
+
+    if degraded_set_count == 0:
+        return supportability
+
+    freshness_bucket = freshness_bucket_from_returns(returns, as_of_date=as_of_date)
+    return RiskCalculationSupportability(
+        state="degraded",
+        reason="calculation_quality_issue",
+        freshness_bucket=freshness_bucket,
+        degraded_metric_count=degraded_set_count,
+        empty_period_count=supportability.empty_period_count,
+        evaluated_period_count=len(results),
+    )
+
+
 def supportability_from_risk_metric_results(
     *,
     returns: Sequence[ReturnPoint],

--- a/tests/integration/test_historical_attribution_endpoint.py
+++ b/tests/integration/test_historical_attribution_endpoint.py
@@ -212,11 +212,11 @@ def test_historical_attribution_stateless_happy_path() -> None:
     assert body["metadata"]["stateful_active_risk_gated_grouping_dimensions"] == []
     assert body["metadata"]["stateful_active_risk_gate_reason"] == "none"
     assert body["metadata"]["calculation_supportability"] == {
-        "state": "ready",
-        "reason": "calculation_complete",
+        "state": "degraded",
+        "reason": "calculation_quality_issue",
         "freshness_bucket": "current",
         "metric_labels": _EXPECTED_SUPPORTABILITY_METRIC_LABELS,
-        "degraded_metric_count": 0,
+        "degraded_metric_count": 2,
         "empty_period_count": 0,
         "evaluated_period_count": 1,
     }

--- a/tests/unit/test_attribution_engine.py
+++ b/tests/unit/test_attribution_engine.py
@@ -257,3 +257,6 @@ def test_attribution_engine_sets_quality_flag_for_missing_grouping_data() -> Non
     response = calculate_historical_attribution(request, input_mode=AttributionInputMode.STATELESS)
     attribution_set = response.results["YTD"].attribution_sets[0]
     assert "grouping:SECTOR:no_exposure_data" in attribution_set.quality_flags
+    assert response.metadata.calculation_supportability.state == "degraded"
+    assert response.metadata.calculation_supportability.reason == "calculation_quality_issue"
+    assert response.metadata.calculation_supportability.degraded_metric_count == 1

--- a/tests/unit/test_calculation_supportability.py
+++ b/tests/unit/test_calculation_supportability.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from app.contracts.risk import ReturnPoint
 from app.services.calculation_supportability import (
+    supportability_from_attribution_results,
     supportability_from_concentration_response,
     supportability_from_period_results,
 )
@@ -13,6 +14,15 @@ from app.services.calculation_supportability import (
 
 class _PeriodResult(BaseModel):
     portfolio_observation_count: int
+    error: str | None = None
+
+
+class _AttributionSet(BaseModel):
+    quality_flags: list[str]
+
+
+class _AttributionPeriodResult(BaseModel):
+    attribution_sets: list[_AttributionSet]
     error: str | None = None
 
 
@@ -45,6 +55,27 @@ def test_period_supportability_prioritizes_benchmark_degradation() -> None:
     assert supportability.reason == "benchmark_unavailable"
     assert supportability.freshness_bucket == "current"
     assert supportability.degraded_metric_count == 1
+
+
+def test_attribution_supportability_degrades_when_sets_emit_quality_flags() -> None:
+    supportability = supportability_from_attribution_results(
+        returns=[ReturnPoint(date=dt.date(2026, 1, 5), value=1.2)],
+        as_of_date=dt.date(2026, 1, 5),
+        results={
+            "YTD": _AttributionPeriodResult(
+                attribution_sets=[
+                    _AttributionSet(quality_flags=[]),
+                    _AttributionSet(quality_flags=["grouping:SECTOR:no_exposure_data"]),
+                ],
+            )
+        },
+    )
+
+    assert supportability.state == "degraded"
+    assert supportability.reason == "calculation_quality_issue"
+    assert supportability.freshness_bucket == "current"
+    assert supportability.degraded_metric_count == 1
+    assert supportability.evaluated_period_count == 1
 
 
 def test_concentration_supportability_reports_uncovered_issuer_mapping() -> None:

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -53,6 +53,12 @@ RISK_TRACKING_ERROR_DOC = (
 RISK_INFORMATION_RATIO_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "risk-information-ratio.md"
 )
+ATTRIBUTION_VOLATILITY_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "attribution-volatility.md"
+)
+ATTRIBUTION_TRACKING_ERROR_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "attribution-tracking-error.md"
+)
 
 
 EXPECTED_V3_SECTIONS = [
@@ -74,6 +80,15 @@ EXPECTED_V3_SECTIONS = [
 def _assert_v3_section_order(text: str) -> None:
     section_positions = [text.index(section) for section in EXPECTED_V3_SECTIONS]
     assert section_positions == sorted(section_positions)
+
+
+def test_historical_attribution_methodologies_record_quality_flag_supportability() -> None:
+    for doc_path in (ATTRIBUTION_VOLATILITY_DOC, ATTRIBUTION_TRACKING_ERROR_DOC):
+        text = doc_path.read_text(encoding="utf-8")
+        _assert_v3_section_order(text)
+        assert "metadata.calculation_supportability" in text
+        assert "calculation_quality_issue" in text
+        assert "quality flag" in text
 
 
 def test_rolling_volatility_methodology_is_auditable_against_engine_contract() -> None:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -144,6 +144,9 @@ Audience notes:
 - Developers and downstream services must preserve `RiskMetricsReport:v1` volatility, drawdown,
   Sharpe, Sortino, VaR, beta, tracking-error, and information-ratio values and supportability metadata rather than
   recomputing period risk metrics locally.
+- Developers and downstream services must preserve `HistoricalRiskAttributionReport:v1`
+  attribution-set quality flags and response-level calculation supportability; flagged
+  attribution sets are degraded source-owned analytics, not ready values for local promotion.
 - Developers and downstream services must preserve `ConcentrationRiskReport:v1` position HHI,
   issuer HHI, top issuer weight, and related concentration outputs rather than recomputing
   concentration locally.

--- a/wiki/Operations-Runbook.md
+++ b/wiki/Operations-Runbook.md
@@ -75,6 +75,8 @@ For risk analytics responses, `metadata.calculation_supportability` is emitted b
 drawdown, rolling metrics, historical attribution, and concentration. Use it before inferring UI
 state from individual metric values, period errors, issuer coverage, or stale returns. It reports
 bounded `ready`, `stale`, `degraded`, or `empty` posture, a bounded reason, and a freshness bucket.
+Historical attribution responses are degraded when any attribution set emits quality flags such as
+missing grouping data, empty active-risk alignment, or unsupported attribution combinations.
 The matching Prometheus counter is
 `lotus_risk_calculation_supportability_total` with only bounded labels: `operation`,
 `supportability_state`, `reason`, and `freshness_bucket`.


### PR DESCRIPTION
## Summary
- degrade historical-attribution response supportability when any attribution set emits quality flags
- document the source-owned supportability posture in methodology, standards, repo context, and wiki source
- add reusable supportability tests plus endpoint/integration coverage for mixed supported/unsupported attribution requests
- refresh existing monetary-float allowlist line numbers for attribution_engine.py after line shifts, preserving review dates

## Validation
- python -m pytest tests/unit/test_calculation_supportability.py tests/unit/test_attribution_engine.py tests/unit/test_methodology_docs.py -q
- python -m pytest tests/integration/test_historical_attribution_endpoint.py::test_historical_attribution_stateless_happy_path tests/unit/test_attribution_engine.py tests/unit/test_calculation_supportability.py -q
- make lint
- make monetary-float-guard
- make check
- make ci
- python ..\\lotus-platform\\automation\\validate_engineering_context_system.py
- python ..\\lotus-platform\\automation\\validate_lotus_skill_alignment.py
- Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk (expected pre-merge drift: Mesh-Data-Products.md, Operations-Runbook.md)