### PR TITLE
Document regime scenario methodology

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -43,7 +43,8 @@ Current repository posture:
    `POST /analytics/risk/regime-scenario-pack/evaluate`; it evaluates caller-supplied exposure
    weights against governed CIO scenario-pack definitions and returns source-owned worst-case loss,
    optional reconciled per-security contribution rows, threshold breach posture, lineage,
-   supportability, and bounded reason codes.
+   supportability, and bounded reason codes; the v3 methodology truth now lives in
+   `docs/methodologies/metrics/regime-scenario-pack-evaluation.md`.
 10. `RiskEventAffectedCohort:v1` is a repo-native domain data product exposed through
     `POST /analytics/risk/risk-event-cohorts/evaluate`; it evaluates candidate portfolios and
     source-supplied exposure weights against governed risk-event definitions and returns affected

--- a/docs/domain-apis/regime-scenario-pack-evaluation.md
+++ b/docs/domain-apis/regime-scenario-pack-evaluation.md
@@ -45,6 +45,9 @@ When `exposure_components` is supplied:
 
 ## Calculation Method
 
+The full auditable methodology is pinned in
+[`docs/methodologies/metrics/regime-scenario-pack-evaluation.md`](../methodologies/metrics/regime-scenario-pack-evaluation.md).
+
 For each governed scenario in the pack:
 
 1. normalize each requested exposure bucket to uppercase,

--- a/docs/methodologies/metrics-index.md
+++ b/docs/methodologies/metrics-index.md
@@ -65,6 +65,9 @@ This index provides one methodology document per Lotus-Risk metric with formulas
 - [ATTRIBUTION_VOLATILITY](./metrics/attribution-volatility.md)
 - [ATTRIBUTION_TRACKING_ERROR](./metrics/attribution-tracking-error.md)
 
+## Regime Scenario Pack Evaluation (`/analytics/risk/regime-scenario-pack/evaluate`)
+- [RegimeScenarioPackEvaluation](./metrics/regime-scenario-pack-evaluation.md)
+
 ## Notes
 - Stateful active tracking-error attribution is currently partial/pending benchmark exposure-history upstream contract.
 - All docs are aligned to current implementation in `main`.

--- a/docs/methodologies/metrics/regime-scenario-pack-evaluation.md
+++ b/docs/methodologies/metrics/regime-scenario-pack-evaluation.md
@@ -1,0 +1,209 @@
+# Regime Scenario Pack Evaluation Methodology
+
+## Metric
+
+- product_name: RegimeScenarioPackEvaluation
+- product_version: v1
+- methodology_version: risk-regime-scenario-pack-evaluation.v1
+- metric family: governed CIO regime scenario-pack evaluation
+- owner: lotus-risk
+
+This product evaluates caller-supplied portfolio exposure weights against a risk-owned CIO
+scenario pack. It returns scenario-level expected loss, worst-case loss, policy-threshold posture,
+source-owned supportability, deterministic lineage, and optional per-security contribution rows.
+
+## Endpoint and Mode Coverage
+
+- endpoint: `POST /analytics/risk/regime-scenario-pack/evaluate`
+- mode: stateless
+- supported pack in current implementation: `CIO_REGIME_2026_Q2`
+- response contract: `RegimeScenarioPackResponse`
+- downstream consumers must preserve the returned `scenario_results` and
+  `scenario_results[].position_contributions` instead of recalculating scenario methodology.
+
+The endpoint is not a market forecast, full instrument repricing model, client suitability engine,
+CIO approval workflow validator, mandate-applicability calculator, or execution/OMS product.
+
+## Inputs
+
+| Field | Required | Meaning |
+|---|---:|---|
+| `scenario_pack_id` | yes | Governed scenario-pack identifier. |
+| `portfolio_id` | no | Optional portfolio identifier retained for lineage. |
+| `as_of_date` | yes | Business date for the source-owned evaluation. |
+| `exposures[]` | yes | Caller-supplied portfolio weights by scenario bucket. |
+| `exposure_components[]` | no | Optional position-level rows that reconcile exactly to `exposures[]` by bucket. |
+| `maximum_allowed_loss_pct` | yes | Consumer policy threshold for worst-case loss breach posture. |
+
+## Upstream Data Sources
+
+- The caller supplies exposure weights and optional reconciled position components.
+- `lotus-risk` owns the scenario pack definitions, scenario identifiers, display names, and
+  scenario shocks by bucket.
+- The current implementation does not fetch holdings, market prices, factor models, CIO approval
+  workflow state, mandate-applicability evidence, OMS acknowledgements, fills, or settlement data.
+
+## Unit Conventions
+
+- `weight` is a decimal portfolio weight. `0.55` means 55% of portfolio value.
+- `shock_pct` is a decimal shock ratio. `-0.12` means a 12% loss shock.
+- `expected_loss_pct`, `worst_case_loss_pct`, and `contribution_loss_pct` are decimal loss ratios.
+  `0.106` means 10.6% expected loss.
+- Loss outputs are non-negative and rounded to six decimal places.
+- Bucket identifiers are normalized to uppercase before calculation.
+
+## Variable Dictionary
+
+| Symbol | API field | Meaning |
+|---|---|---|
+| `P` | `scenario_pack_id` | Governed scenario pack. |
+| `S` | `scenario_results[].scenario_id` | One scenario inside pack `P`. |
+| `b` | `exposures[].bucket` | Scenario exposure bucket, normalized to uppercase. |
+| `w_b` | `exposures[].weight` | Portfolio weight for bucket `b`. |
+| `q_{i,b}` | `exposure_components[].weight` | Position-level weight for component `i` assigned to bucket `b`. |
+| `shock_{S,b}` | `scenario_results[].shock_by_bucket[b]` | Scenario shock for bucket `b` under scenario `S`. |
+| `loss_{S,b}` | intermediate | Non-negative bucket loss under scenario `S`. |
+| `contribution_{S,i}` | `position_contributions[].contribution_loss_pct` | Non-negative component loss contribution under scenario `S`. |
+| `L_S` | `scenario_results[].expected_loss_pct` | Total expected loss under scenario `S`. |
+| `L_worst` | `worst_case_loss_pct` | Maximum expected loss across scenarios. |
+| `T` | `maximum_allowed_loss_pct` | Consumer policy threshold. |
+
+## Methodology and Formulas
+
+For each scenario `S` in the governed pack:
+
+```text
+loss_{S,b} = max(-(w_b * shock_{S,b}), 0.0)
+L_S = sum(loss_{S,b} for each requested exposure bucket b)
+```
+
+If a requested bucket does not exist in the scenario definition, the implementation uses
+`shock_{S,b} = 0.0` for that bucket and marks the evaluation degraded with
+`REGIME_SCENARIO_UNSUPPORTED_EXPOSURE_BUCKET`.
+
+Worst-case and threshold posture:
+
+```text
+L_worst = max(L_S for each scenario S)
+breach = L_worst > T
+```
+
+When `exposure_components[]` is supplied, every component receives the same bucket shock used by the
+scenario-level calculation:
+
+```text
+contribution_{S,i} = max(-(q_{i,b} * shock_{S,b}), 0.0)
+```
+
+Contribution rows are sorted deterministically by descending `contribution_loss_pct`, then `bucket`,
+then `security_id`.
+
+## Step-by-Step Computation
+
+1. Look up `scenario_pack_id` in the risk-owned `SCENARIO_PACKS` registry.
+2. Normalize `exposures[].bucket` to uppercase and build `exposure_by_bucket`.
+3. Compare requested buckets with `SUPPORTED_BUCKETS`.
+4. Validate optional `exposure_components[]` at request-model level:
+   - every component bucket must be present in `exposures[]`,
+   - component weights must reconcile to the matching exposure bucket within `0.000001`.
+5. For each scenario in the pack:
+   - get `shock_by_bucket[b]`, defaulting to `0.0` for unsupported requested buckets,
+   - compute bucket losses,
+   - sum bucket losses into `expected_loss_pct`,
+   - compute optional position contribution rows from component weights and bucket shocks.
+6. Set `worst_case_loss_pct` to the maximum scenario `expected_loss_pct`.
+7. Set `breach` when `worst_case_loss_pct > maximum_allowed_loss_pct`.
+8. Emit sorted bounded `reason_codes`.
+9. Emit `metadata.request_fingerprint` as a deterministic SHA-256 hash of the canonical request.
+
+## Validation and Failure Behavior
+
+- Unknown `scenario_pack_id` raises `Unsupported scenario_pack_id`.
+- Empty `exposures[]` is rejected by request validation.
+- Negative exposure or component weights are rejected by request validation.
+- `maximum_allowed_loss_pct` must be between `0.0` and `1.0`.
+- Component buckets absent from `exposures[]` are rejected.
+- Component weights that do not reconcile to exposure bucket weights within `0.000001` are rejected.
+- Unsupported exposure buckets do not fail the request; they produce
+  `metadata.calculation_supportability = degraded` and
+  `REGIME_SCENARIO_UNSUPPORTED_EXPOSURE_BUCKET`.
+- Threshold breaches produce `REGIME_SCENARIO_POLICY_THRESHOLD_BREACH`; when no other degraded
+  posture exists, supportability becomes `pending_review`.
+- Bucket-only requests return empty `position_contributions[]`.
+
+## Configuration Options
+
+The current source-owned scenario pack registry is code-defined:
+
+| Pack | Scenarios |
+|---|---|
+| `CIO_REGIME_2026_Q2` | `growth_slowdown`, `rates_up_inflation`, `risk_off_liquidity` |
+
+Current supported buckets are `EQUITY`, `FIXED_INCOME`, `ALTERNATIVES`, and `CASH`.
+
+No runtime caller option can override shocks, scenario ids, contribution formula, supportability
+classification, sorting, or request fingerprinting.
+
+## Outputs
+
+| Output field | Meaning |
+|---|---|
+| `scenario_results[].expected_loss_pct` | Scenario-level decimal expected loss after six-decimal rounding. |
+| `scenario_results[].shock_by_bucket` | Risk-owned shock definitions for the scenario. |
+| `scenario_results[].position_contributions[]` | Optional source-owned component contribution rows. |
+| `worst_case_loss_pct` | Maximum scenario expected loss after six-decimal rounding. |
+| `breach` | Whether `worst_case_loss_pct > maximum_allowed_loss_pct`. |
+| `reason_codes[]` | Bounded calculation and policy posture reason codes. |
+| `metadata.calculation_supportability` | `ready`, `degraded`, or `pending_review` for current implementation paths. |
+| `metadata.request_fingerprint` | Deterministic request hash for replay and audit. |
+
+## Worked Example
+
+Input:
+
+| Bucket | `w_b` |
+|---|---:|
+| `EQUITY` | 0.55 |
+| `FIXED_INCOME` | 0.35 |
+| `CASH` | 0.10 |
+
+For `growth_slowdown`, the code-defined shocks are:
+
+| Bucket | `shock_{S,b}` | Formula | Bucket loss |
+|---|---:|---|---:|
+| `EQUITY` | -0.12 | `max(-(0.55 * -0.12), 0.0)` | 0.0660 |
+| `FIXED_INCOME` | -0.03 | `max(-(0.35 * -0.03), 0.0)` | 0.0105 |
+| `CASH` | 0.00 | `max(-(0.10 * 0.00), 0.0)` | 0.0000 |
+
+Final scenario loss:
+
+```text
+scenario_results[].expected_loss_pct = 0.0660 + 0.0105 + 0.0000 = 0.0765
+```
+
+With `maximum_allowed_loss_pct = 0.12`, the three current pack scenarios produce:
+
+| Scenario | `expected_loss_pct` |
+|---|---:|
+| `growth_slowdown` | 0.0765 |
+| `rates_up_inflation` | 0.0685 |
+| `risk_off_liquidity` | 0.1060 |
+
+Final pack outputs:
+
+```text
+worst_case_loss_pct = 0.1060
+breach = false
+metadata.calculation_supportability = ready
+reason_codes = ["REGIME_SCENARIO_PACK_READY"]
+```
+
+When the equity exposure is split into `FO_EQ_AAPL_US = 0.30` and `FO_EQ_MSFT_US = 0.25`, the
+`growth_slowdown` contribution rows include:
+
+| Security | Bucket | Component weight | Shock | `contribution_loss_pct` |
+|---|---|---:|---:|---:|
+| `FO_EQ_AAPL_US` | `EQUITY` | 0.30 | -0.12 | 0.0360 |
+| `FO_EQ_MSFT_US` | `EQUITY` | 0.25 | -0.12 | 0.0300 |
+| `FO_BOND_UST_2030` | `FIXED_INCOME` | 0.35 | -0.03 | 0.0105 |
+| `CASH_USD_BOOK_OPERATING` | `CASH` | 0.10 | 0.00 | 0.0000 |

--- a/tests/unit/test_methodology_docs.py
+++ b/tests/unit/test_methodology_docs.py
@@ -59,6 +59,9 @@ ATTRIBUTION_VOLATILITY_DOC = (
 ATTRIBUTION_TRACKING_ERROR_DOC = (
     REPO_ROOT / "docs" / "methodologies" / "metrics" / "attribution-tracking-error.md"
 )
+REGIME_SCENARIO_PACK_DOC = (
+    REPO_ROOT / "docs" / "methodologies" / "metrics" / "regime-scenario-pack-evaluation.md"
+)
 
 
 EXPECTED_V3_SECTIONS = [
@@ -89,6 +92,32 @@ def test_historical_attribution_methodologies_record_quality_flag_supportability
         assert "metadata.calculation_supportability" in text
         assert "calculation_quality_issue" in text
         assert "quality flag" in text
+
+
+def test_regime_scenario_pack_methodology_is_auditable_against_engine_contract() -> None:
+    text = REGIME_SCENARIO_PACK_DOC.read_text(encoding="utf-8")
+
+    _assert_v3_section_order(text)
+
+    required_truth = [
+        "product_name: RegimeScenarioPackEvaluation",
+        "methodology_version: risk-regime-scenario-pack-evaluation.v1",
+        "/analytics/risk/regime-scenario-pack/evaluate",
+        "CIO_REGIME_2026_Q2",
+        "contribution_{S,i} = max(-(q_{i,b} * shock_{S,b}), 0.0)",
+        "component weights must reconcile to the matching exposure bucket within `0.000001`",
+        "REGIME_SCENARIO_UNSUPPORTED_EXPOSURE_BUCKET",
+        "REGIME_SCENARIO_POLICY_THRESHOLD_BREACH",
+        "metadata.calculation_supportability = ready",
+        "scenario_results[].expected_loss_pct = 0.0660 + 0.0105 + 0.0000 = 0.0765",
+        "worst_case_loss_pct = 0.1060",
+        "FO_EQ_AAPL_US",
+        "0.0360",
+        "not a market forecast, full instrument repricing model",
+    ]
+
+    for phrase in required_truth:
+        assert phrase in text
 
 
 def test_rolling_volatility_methodology_is_auditable_against_engine_contract() -> None:

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -90,7 +90,9 @@ loss. When callers provide reconciled `exposure_components`, the product emits p
 scenario contribution rows alongside worst-case loss, threshold-breach posture, lineage, and
 bounded reason codes. The rows are contribution evidence for governed CIO shocks, not full
 instrument repricing, and downstream proof packs must preserve them instead of rebuilding scenario
-logic outside `lotus-risk`.
+logic outside `lotus-risk`. The auditable methodology is pinned in
+`docs/methodologies/metrics/regime-scenario-pack-evaluation.md`, including formulas, validation and
+failure behavior, deterministic ordering, and a worked contribution example.
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
## Summary
- add v3 methodology truth for `RegimeScenarioPackEvaluation:v1`, including formulas, validation/failure behavior, deterministic contribution ordering, and a worked contribution example
- link the methodology from the domain API docs, methodology index, repo context, and repo-authored wiki source
- add a methodology-doc contract test that pins the engine-aligned scenario/contribution evidence

## WTBD impact
- Advances source-owned realization for `RFC40-WTBD-009` and `RFC42-WTBD-006` by pinning richer scenario-pack methodology and contribution calculation evidence in `lotus-risk`.
- Does not claim closure of the remaining CIO approval workflow, effective-period exception, portfolio/mandate applicability, OMS, or execution-methodology gaps.

## Validation
- `python -m pytest tests\unit\test_methodology_docs.py tests\unit\test_scenario_engine.py tests\unit\test_scenario_api.py -q` -> 34 passed
- `make lint`
- `make typecheck`
- `make no-alias-gate`
- `make openapi-gate`
- `make api-vocabulary-gate`
- `make domain-data-product-gate`
- `make test-unit` -> 361 passed
- `make test-integration` -> 80 passed, 14 skipped
- `make test-e2e` -> 24 passed
- `python ..\lotus-platform\automation\validate_engineering_context_system.py`
- `python ..\lotus-platform\automation\validate_lotus_skill_alignment.py`
- `git diff --check`

## Wiki
- `..\lotus-platform\automation\Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` reports expected pre-merge drift in `Mesh-Data-Products.md` because repo-authored wiki source changed.