### PR TITLE
Add mandate risk health context

### DIFF
--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -51,7 +51,13 @@ Current repository posture:
     source-supplied exposure weights against governed risk-event definitions and returns affected
     membership, exclusions, impact scores, source refs, supportability, and bounded reason codes
     for future manage wave-trigger consumption without creating waves or campaign approvals.
-11. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
+11. `MandateRiskHealthContext:v1` is a repo-native domain data product exposed through
+    `POST /analytics/risk/mandate-health-context`; it derives bounded mandate risk health posture
+    from source-owned tracking-error methodology, returns threshold breach state, methodology
+    posture, lineage fingerprints, and bounded reason codes for future `lotus-manage`
+    consumption, and explicitly does not create mandate actions, rebalance waves, client
+    communications, orders, or execution.
+12. `RiskMetricsReport:v1` now has implementation-backed methodology truth for `VOLATILITY`,
     `DRAWDOWN`, `SHARPE`, `SORTINO`, `VAR`, `BETA`, `TRACKING_ERROR`, and
     `INFORMATION_RATIO`: the docs and tests pin
     percentage-point input conventions, optional
@@ -79,7 +85,7 @@ Current repository posture:
     zero-benchmark-variance fail-closed posture for beta, zero-tracking-error fail-closed posture
     for information ratio, constant-active-return zero tracking-error posture, and
     insufficient-data / insufficient-aligned-observation failure behavior.
-12. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
+13. `RollingRiskMetricsReport:v1` now has implementation-backed methodology truth for
     `ROLLING_VOLATILITY`, `ROLLING_SHARPE`, `ROLLING_BETA`, `ROLLING_TRACKING_ERROR`,
     `ROLLING_INFORMATION_RATIO`, and `ROLLING_MAX_DRAWDOWN`: the docs and tests pin
     percentage-point to decimal conversion, `ddof=1` sample standard deviation/covariance/variance
@@ -89,7 +95,7 @@ Current repository posture:
     warm-up/null behavior, source-owned risk-free/benchmark alignment posture, no-aligned
     dependency supportability posture, zero-excess-volatility Sharpe flagging,
     zero-benchmark-variance beta flagging, and zero-tracking-error information-ratio flagging.
-13. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
+14. `DrawdownAnalyticsReport:v1` now has implementation-backed methodology truth for
     `MAX_DRAWDOWN`, `AVERAGE_DRAWDOWN`, `ULCER_INDEX`, and `TIME_UNDER_WATER_DAYS`: the docs and
     tests pin percentage-point input conventions, decimal cumulative-wealth/running-peak drawdown
     behavior, decimal `summary.max_drawdown`, `summary.average_drawdown`, non-negative
@@ -99,7 +105,7 @@ Current repository posture:
     under water, empty-period insufficient-data posture, never-underwater zero-drawdown posture,
     duration-unit day counter behavior, and episode-list filter isolation from the summary
     maximum, average, ulcer-index, and time-under-water drawdown values.
-14. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
+15. `ConcentrationRiskReport:v1` now has implementation-backed methodology truth for
     `POSITION_HHI`, `TOP_POSITION_WEIGHT`, `TOP_N_CUMULATIVE_WEIGHT`, `ISSUER_HHI`, and
     `TOP_ISSUER_WEIGHT`: the docs and tests pin
     stateless, stateful, and simulation source resolution, positive numeric position-value

--- a/contracts/domain-data-products/lotus-risk-products.v1.json
+++ b/contracts/domain-data-products/lotus-risk-products.v1.json
@@ -290,6 +290,62 @@
       "temporal_semantics_ref": "as_of_date"
     },
     {
+      "product_name": "MandateRiskHealthContext",
+      "product_version": "v1",
+      "owner_repository": "lotus-risk",
+      "product_family": "analytics_output",
+      "authoritative_domain": "risk_analytics",
+      "lifecycle_status": "active",
+      "request_scope": {
+        "scope_level": "portfolio",
+        "supports_bulk": false
+      },
+      "temporal_scope": {
+        "primary_time_field": "as_of_date",
+        "freshness_basis": "as_of_date",
+        "supports_restatement": true
+      },
+      "required_trust_metadata": [
+        "product_name",
+        "product_version",
+        "as_of_date",
+        "lineage_version",
+        "request_fingerprint",
+        "source_services",
+        "upstream_request_fingerprints",
+        "benchmark_context"
+      ],
+      "current_routes": [
+        "/analytics/risk/mandate-health-context"
+      ],
+      "freshness_policy": {
+        "freshness_class": "daily",
+        "max_allowed_age_description": "Mandate risk health context must reflect source-owned tracking-error methodology, the requested as-of date, and the supplied portfolio and benchmark return observations."
+      },
+      "completeness_policy": {
+        "default_status": "partial",
+        "partial_allowed": true
+      },
+      "lineage_policy": {
+        "lineage_required": true,
+        "evidence_bundle_required": false,
+        "evidence_access_class_ref": "customer_consumable"
+      },
+      "security_profile_ref": "business_consumer_access:client_confidential:retain_for_client_record:audit_read_and_export",
+      "approved_consumers": [
+        "lotus-gateway",
+        "lotus-manage"
+      ],
+      "deprecation_policy": {
+        "state": "not_deprecated",
+        "successor_product": null
+      },
+      "identifier_refs": [
+        "portfolio_id"
+      ],
+      "temporal_semantics_ref": "as_of_date"
+    },
+    {
       "product_name": "RegimeScenarioPackEvaluation",
       "product_version": "v1",
       "owner_repository": "lotus-risk",

--- a/docs/domain-apis/endpoint-matrix.md
+++ b/docs/domain-apis/endpoint-matrix.md
@@ -24,6 +24,7 @@ Status meanings:
 | `POST /analytics/risk/rolling-metrics` | Domain analytics | rolling historical risk diagnostics | `stateless`, `stateful` | full | lotus-performance for portfolio/benchmark returns; lotus-core for risk-free series and reporting-currency resolution | simulation is intentionally unsupported; broader enterprise archetype coverage still requires additional seeded live portfolios beyond the canonical baseline |
 | `POST /analytics/risk/historical-attribution` | Domain analytics | historical risk and active-risk attribution decomposition | `stateless`, `stateful` | partial | stateless caller-supplied returns/exposures; stateful sourcing uses lotus-performance for portfolio/benchmark returns and benchmark exposure context, and lotus-core for portfolio exposure history and instrument enrichment | stateful `ACTIVE_RISK` supports `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`; simulation is intentionally unsupported |
 | `POST /analytics/risk/concentration` | Domain analytics | concentration analytics and HHI metrics | `stateless`, `stateful`, `simulation` | full | lotus-core snapshot and simulation session contracts | none |
+| `POST /analytics/risk/mandate-health-context` | Domain analytics | source-owned mandate risk health context derived from tracking-error methodology | `stateless` | partial | caller-supplied portfolio and benchmark return observations | bounded first-wave context only; does not create mandate actions, rebalance waves, client communication, or execution |
 | `POST /analytics/risk/regime-scenario-pack/evaluate` | Domain analytics | governed CIO regime scenario-pack evaluation with optional per-security contribution evidence | `stateless` | full | caller-supplied exposure weights, optional reconciled exposure components, and risk-owned scenario-pack definitions | does not forecast market states, perform full repricing, or accept browser-owned scenario methodology |
 
 ## Mode Support Detail
@@ -35,6 +36,7 @@ Status meanings:
 | `POST /analytics/risk/rolling-metrics` | full | full | unsupported by contract |
 | `POST /analytics/risk/historical-attribution` | full | partial | unsupported by contract |
 | `POST /analytics/risk/concentration` | full | full | full |
+| `POST /analytics/risk/mandate-health-context` | partial | unsupported by contract | unsupported by contract |
 | `POST /analytics/risk/regime-scenario-pack/evaluate` | full | unsupported by contract | unsupported by contract |
 
 ## Highest-Value Remaining Gap
@@ -97,4 +99,5 @@ See `docs/domain-apis/risk-product-surface-alignment.md`.
 - [risk-rolling-metrics.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-rolling-metrics.md)
 - [risk-historical-attribution.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-historical-attribution.md)
 - [risk-concentration.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-concentration.md)
+- [risk-mandate-health-context.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-mandate-health-context.md)
 - [risk-product-surface-alignment.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-product-surface-alignment.md)

--- a/docs/domain-apis/integration-capabilities.md
+++ b/docs/domain-apis/integration-capabilities.md
@@ -35,6 +35,7 @@
   - `risk.analytics.concentration`
   - `risk.analytics.rolling_metrics`
   - `risk.analytics.historical_attribution`
+  - `risk.analytics.mandate_risk_health_context`
   - `risk.analytics.regime_scenario_pack`
   - `risk.analytics.risk_event_affected_cohort`
   - `risk.analytics.metrics`
@@ -45,6 +46,7 @@
   - `concentration_risk`
   - `rolling_risk_analytics`
   - `historical_risk_attribution`
+  - `mandate_risk_health_context`
   - `regime_scenario_pack_evaluation`
   - `risk_event_affected_cohort`
 
@@ -63,6 +65,9 @@ This allows consumers to discover that:
 - historical-attribution response metadata is the authoritative active-risk support contract
 - risk snapshot VaR and expected shortfall are signed return-threshold metrics
 - historical attribution residual and `reconciled_sum` must be preserved with contributors
+- mandate risk health context is a stateless source-owned workflow that derives bounded
+  tracking-error health posture from lotus-risk methodology and returns threshold posture,
+  lineage, and non-claim reason codes for Manage consumption
 - regime scenario-pack evaluation is a stateless source-owned workflow that returns worst-case loss,
   optional per-security contribution rows when reconciled exposure components are supplied,
   policy-threshold breach posture, lineage, and bounded reason codes from risk-owned CIO scenario
@@ -82,7 +87,8 @@ This allows consumers to discover that:
 - Downstream consumers:
   - `lotus-gateway` capability aggregation (`/api/v1/platform/capabilities`).
   - `lotus-manage` future RFC40 scenario proof-pack and RFC41 wave trigger consumption for
-    source-owned scenario and risk-event evidence.
+    source-owned scenario and risk-event evidence, plus RFC38 mandate-health risk context
+    consumption.
   - downstream cleanup for undeclared risk capability query params is tracked in
     `sgajbi/lotus-gateway#113`.
 - Upstream dependencies:

--- a/docs/domain-apis/risk-mandate-health-context.md
+++ b/docs/domain-apis/risk-mandate-health-context.md
@@ -1,0 +1,52 @@
+# Mandate Risk Health Context
+
+## Endpoint
+
+- `POST /analytics/risk/mandate-health-context`
+
+## Purpose
+
+`MandateRiskHealthContext:v1` gives downstream DPM consumers a bounded source-owned risk health
+signal for mandate supportability. The first-wave implementation derives health posture from the
+existing lotus-risk tracking-error methodology and preserves source ownership, threshold posture,
+lineage fingerprints, and reason codes.
+
+The endpoint does not create mandate actions, rebalance waves, approvals, client communications, OMS
+orders, or execution instructions.
+
+## Inputs
+
+- `portfolio_id`
+- `scope.as_of_date`
+- one `period`
+- `portfolio_open_date`
+- portfolio `returns`
+- `benchmark_returns`
+- optional `tracking_error_attention_threshold` as an annualized decimal ratio
+
+Return observations use the same percentage-point convention as `POST /analytics/risk/calculate`.
+
+## Output Contract
+
+The response publishes:
+
+- `product_name: "MandateRiskHealthContext"`
+- `product_version: "v1"`
+- `health_state`: `ready`, `attention`, or `unavailable`
+- `threshold_breached`
+- `source_metric.annualized_tracking_error` as a decimal ratio
+- `methodology_posture.source_metrics_product: "RiskMetricsReport:v1"`
+- `methodology_posture.source_route: "/analytics/risk/calculate"`
+- request and source-request fingerprints
+- bounded reason codes, including `RISK_METHODOLOGY_SOURCE_OWNED`
+
+## Supportability Boundary
+
+This is intentionally a partial first-wave source product:
+
+- supported: supplied-return stateless tracking-error health context
+- unsupported: stateful mandate universe discovery
+- unsupported: mandate action creation
+- unsupported: wave orchestration
+- unsupported: client communication or execution
+

--- a/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
+++ b/docs/standards/api-vocabulary/lotus-risk-api-vocabulary.v1.json
@@ -8,7 +8,7 @@
       "openApiVersion": "3.1.0"
     }
   ],
-  "generatedAt": "2026-05-19T12:42:33.039494+00:00",
+  "generatedAt": "2026-05-22T01:08:18.409991+00:00",
   "attributeCatalog": [
     {
       "semanticId": "lotus.affected_portfolios",
@@ -39,6 +39,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.aligned_observation_count",
+      "canonicalTerm": "aligned_observation_count",
+      "preferredName": "aligned_observation_count",
+      "description": "Aligned portfolio and benchmark observations used by the source metric.",
+      "example": 64,
+      "type": "integer",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "integer"
       ]
     },
     {
@@ -97,6 +111,20 @@
       ],
       "observedTypes": [
         "integer"
+      ]
+    },
+    {
+      "semanticId": "lotus.annualized_tracking_error",
+      "canonicalTerm": "annualized_tracking_error",
+      "preferredName": "annualized_tracking_error",
+      "description": "Annualized tracking error as a decimal ratio when source-ready.",
+      "example": "0.0425",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -191,8 +219,8 @@
       "semanticId": "lotus.as_of_date",
       "canonicalTerm": "as_of_date",
       "preferredName": "as_of_date",
-      "description": "Business date for the scenario-pack evaluation.",
-      "example": "2026-05-03",
+      "description": "As-of date used for risk metric evaluation.",
+      "example": "2025-03-31",
       "type": "string",
       "locations": [
         "body"
@@ -260,6 +288,25 @@
       ],
       "observedTypes": [
         "BenchmarkDrawdownPolicy"
+      ]
+    },
+    {
+      "semanticId": "lotus.benchmark_returns",
+      "canonicalTerm": "benchmark_returns",
+      "preferredName": "benchmark_returns",
+      "description": "Benchmark return observations in percentage points.",
+      "example": [
+        {
+          "date": "2026-01-02",
+          "value": 0.18
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -577,6 +624,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.date",
+      "canonicalTerm": "date",
+      "preferredName": "date",
+      "description": "Date of return observation.",
+      "example": "2025-01-02",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1124,6 +1185,20 @@
       ]
     },
     {
+      "semanticId": "lotus.from_date",
+      "canonicalTerm": "from_date",
+      "preferredName": "from_date",
+      "description": "Explicit period start date (required when type=EXPLICIT).",
+      "example": "2025-01-01",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.governance_evidence",
       "canonicalTerm": "governance_evidence",
       "preferredName": "governance_evidence",
@@ -1137,6 +1212,20 @@
       ],
       "observedTypes": [
         "ScenarioPackGovernanceEvidence"
+      ]
+    },
+    {
+      "semanticId": "lotus.health_state",
+      "canonicalTerm": "health_state",
+      "preferredName": "health_state",
+      "description": "Bounded risk health posture derived from source-owned tracking error.",
+      "example": "attention",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1482,6 +1571,22 @@
       ]
     },
     {
+      "semanticId": "lotus.methodology_posture",
+      "canonicalTerm": "methodology_posture",
+      "preferredName": "methodology_posture",
+      "description": "Canonical methodology posture used by lotus-risk APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "MandateRiskHealthMethodologyPosture",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "MandateRiskHealthMethodologyPosture"
+      ]
+    },
+    {
       "semanticId": "lotus.methodology_ref",
       "canonicalTerm": "methodology_ref",
       "preferredName": "methodology_ref",
@@ -1499,8 +1604,8 @@
       "semanticId": "lotus.methodology_version",
       "canonicalTerm": "methodology_version",
       "preferredName": "methodology_version",
-      "description": "Methodology version used for historical attribution formulas.",
-      "example": "historical_attribution.v1",
+      "description": "Risk methodology version used by the source calculation.",
+      "example": "risk.v1",
       "type": "string",
       "locations": [
         "body"
@@ -1526,6 +1631,20 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.metric_name",
+      "canonicalTerm": "metric_name",
+      "preferredName": "metric_name",
+      "description": "Source-owned risk metric used for mandate health posture.",
+      "example": "TRACKING_ERROR",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1614,6 +1733,20 @@
       ]
     },
     {
+      "semanticId": "lotus.name",
+      "canonicalTerm": "name",
+      "preferredName": "name",
+      "description": "Optional display label for this period.",
+      "example": "explicit_q1_2025",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
       "semanticId": "lotus.net_or_gross",
       "canonicalTerm": "net_or_gross",
       "preferredName": "net_or_gross",
@@ -1673,6 +1806,36 @@
       ]
     },
     {
+      "semanticId": "lotus.period",
+      "canonicalTerm": "period",
+      "preferredName": "period",
+      "description": "Canonical period used by lotus-risk APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "RiskRequestPeriod",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "RiskRequestPeriod"
+      ]
+    },
+    {
+      "semanticId": "lotus.period_name",
+      "canonicalTerm": "period_name",
+      "preferredName": "period_name",
+      "description": "Resolved period key evaluated by the source product.",
+      "example": "YTD",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.periodic_rate",
       "canonicalTerm": "periodic_rate",
       "preferredName": "periodic_rate",
@@ -1718,15 +1881,15 @@
       "semanticId": "lotus.portfolio_id",
       "canonicalTerm": "portfolio_id",
       "preferredName": "portfolio_id",
-      "description": "Optional portfolio identifier used for lineage and diagnostics.",
+      "description": "Portfolio identifier for the mandate health risk context.",
       "example": "PB_SG_GLOBAL_BAL_001",
-      "type": "object",
+      "type": "string",
       "locations": [
         "body"
       ],
       "observedTypes": [
-        "object",
-        "string"
+        "string",
+        "object"
       ]
     },
     {
@@ -1741,6 +1904,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.portfolio_open_date",
+      "canonicalTerm": "portfolio_open_date",
+      "preferredName": "portfolio_open_date",
+      "description": "Portfolio inception date used for SI period handling.",
+      "example": "2024-01-01",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
       ]
     },
     {
@@ -1950,9 +2127,10 @@
       "semanticId": "lotus.reason_codes",
       "canonicalTerm": "reason_codes",
       "preferredName": "reason_codes",
-      "description": "Bounded reason codes explaining scenario evaluation posture.",
+      "description": "Bounded reason codes safe for downstream supportability and audit use.",
       "example": [
-        "REGIME_SCENARIO_PACK_READY"
+        "MANDATE_RISK_HEALTH_TRACKING_ERROR_SOURCE_READY",
+        "RISK_METHODOLOGY_SOURCE_OWNED"
       ],
       "type": "array",
       "locations": [
@@ -2106,6 +2284,25 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.returns",
+      "canonicalTerm": "returns",
+      "preferredName": "returns",
+      "description": "Portfolio return observations in percentage points.",
+      "example": [
+        {
+          "date": "2026-01-02",
+          "value": 0.25
+        }
+      ],
+      "type": "array",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "array"
       ]
     },
     {
@@ -2448,11 +2645,97 @@
       ]
     },
     {
+      "semanticId": "lotus.source_metric",
+      "canonicalTerm": "source_metric",
+      "preferredName": "source_metric",
+      "description": "Canonical source metric used by lotus-risk APIs.",
+      "example": {
+        "key": "value"
+      },
+      "type": "MandateRiskHealthSourceMetric",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "MandateRiskHealthSourceMetric"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_metrics_product",
+      "canonicalTerm": "source_metrics_product",
+      "preferredName": "source_metrics_product",
+      "description": "Underlying source-owned risk metrics product used for this context.",
+      "example": "RiskMetricsReport:v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_product_name",
+      "canonicalTerm": "source_product_name",
+      "preferredName": "source_product_name",
+      "description": "Source-owned mandate health risk product name.",
+      "example": "MandateRiskHealthContext",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_product_version",
+      "canonicalTerm": "source_product_version",
+      "preferredName": "source_product_version",
+      "description": "Source-owned mandate health risk product version.",
+      "example": "v1",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.source_ref",
       "canonicalTerm": "source_ref",
       "preferredName": "source_ref",
       "description": "Stable source reference for downstream wave lineage.",
       "example": "risk-event-cohort:RISK_EVENT_2026_Q2_RATES_UP:PB_SG_GLOBAL_BAL_001",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_request_fingerprint",
+      "canonicalTerm": "source_request_fingerprint",
+      "preferredName": "source_request_fingerprint",
+      "description": "Fingerprint of the underlying RiskMetricsReport request.",
+      "example": "sha256:...",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.source_route",
+      "canonicalTerm": "source_route",
+      "preferredName": "source_route",
+      "description": "Underlying source route used for risk metric calculation.",
+      "example": "/analytics/risk/calculate",
       "type": "string",
       "locations": [
         "body"
@@ -2691,6 +2974,34 @@
       ],
       "observedTypes": [
         "array"
+      ]
+    },
+    {
+      "semanticId": "lotus.threshold_breached",
+      "canonicalTerm": "threshold_breached",
+      "preferredName": "threshold_breached",
+      "description": "Whether source-owned tracking error breached the supplied attention threshold.",
+      "example": true,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.to_date",
+      "canonicalTerm": "to_date",
+      "preferredName": "to_date",
+      "description": "Explicit period end date (required when type=EXPLICIT).",
+      "example": "2025-03-31",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     },
     {
@@ -2940,6 +3251,35 @@
       ]
     },
     {
+      "semanticId": "lotus.tracking_error_attention_threshold",
+      "canonicalTerm": "tracking_error_attention_threshold",
+      "preferredName": "tracking_error_attention_threshold",
+      "description": "Annualized tracking-error attention threshold as a decimal ratio. For example, 0.05 represents 5 percent annualized tracking error.",
+      "example": "0.05",
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object",
+        "string"
+      ]
+    },
+    {
+      "semanticId": "lotus.type",
+      "canonicalTerm": "type",
+      "preferredName": "type",
+      "description": "Period type used for metric aggregation. Prefer canonical values EXPLICIT, YEAR, MTD, QTD, YTD, 1Y, 3Y, 5Y, and SI. Legacy aliases ONE_YEAR, THREE_YEAR, FIVE_YEAR, and ITD are accepted and normalized.",
+      "example": "3Y",
+      "type": "string",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "string"
+      ]
+    },
+    {
       "semanticId": "lotus.unavailable_dependency_count",
       "canonicalTerm": "unavailable_dependency_count",
       "preferredName": "unavailable_dependency_count",
@@ -3059,6 +3399,20 @@
       ],
       "observedTypes": [
         "object"
+      ]
+    },
+    {
+      "semanticId": "lotus.value",
+      "canonicalTerm": "value",
+      "preferredName": "value",
+      "description": "Return value in percentage points.",
+      "example": 0.85,
+      "type": "number",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "number"
       ]
     },
     {
@@ -3217,6 +3571,20 @@
       ],
       "observedTypes": [
         "number"
+      ]
+    },
+    {
+      "semanticId": "lotus.year",
+      "canonicalTerm": "year",
+      "preferredName": "year",
+      "description": "Calendar year (required when type=YEAR).",
+      "example": 2025,
+      "type": "object",
+      "locations": [
+        "body"
+      ],
+      "observedTypes": [
+        "object"
       ]
     }
   ],
@@ -4059,6 +4427,349 @@
       },
       "response": {
         "fields": []
+      }
+    },
+    {
+      "domain": "risk_analytics",
+      "method": "POST",
+      "path": "/analytics/risk/mandate-health-context",
+      "operationId": "analytics_risk_mandate_health_context_analytics_risk_mandate_health_context_post",
+      "summary": "Evaluate source-owned mandate risk health context",
+      "request": {
+        "fields": [
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "scope",
+            "location": "body",
+            "required": true,
+            "type": "RiskRequestScope",
+            "semanticId": "lotus.scope",
+            "attributeRef": "#/attributeCatalog/lotus.scope"
+          },
+          {
+            "name": "scope.as_of_date",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "scope.reporting_currency",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.reporting_currency",
+            "attributeRef": "#/attributeCatalog/lotus.reporting_currency"
+          },
+          {
+            "name": "scope.net_or_gross",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.net_or_gross",
+            "attributeRef": "#/attributeCatalog/lotus.net_or_gross"
+          },
+          {
+            "name": "period",
+            "location": "body",
+            "required": true,
+            "type": "RiskRequestPeriod",
+            "semanticId": "lotus.period",
+            "attributeRef": "#/attributeCatalog/lotus.period"
+          },
+          {
+            "name": "period.type",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.type",
+            "attributeRef": "#/attributeCatalog/lotus.type"
+          },
+          {
+            "name": "period.name",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.name",
+            "attributeRef": "#/attributeCatalog/lotus.name"
+          },
+          {
+            "name": "period.from_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.from_date",
+            "attributeRef": "#/attributeCatalog/lotus.from_date"
+          },
+          {
+            "name": "period.to_date",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.to_date",
+            "attributeRef": "#/attributeCatalog/lotus.to_date"
+          },
+          {
+            "name": "period.year",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.year",
+            "attributeRef": "#/attributeCatalog/lotus.year"
+          },
+          {
+            "name": "portfolio_open_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_open_date",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_open_date"
+          },
+          {
+            "name": "returns",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.returns",
+            "attributeRef": "#/attributeCatalog/lotus.returns"
+          },
+          {
+            "name": "returns[].date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.date",
+            "attributeRef": "#/attributeCatalog/lotus.date"
+          },
+          {
+            "name": "returns[].value",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.value",
+            "attributeRef": "#/attributeCatalog/lotus.value"
+          },
+          {
+            "name": "benchmark_returns",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.benchmark_returns",
+            "attributeRef": "#/attributeCatalog/lotus.benchmark_returns"
+          },
+          {
+            "name": "benchmark_returns[].date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.date",
+            "attributeRef": "#/attributeCatalog/lotus.date"
+          },
+          {
+            "name": "benchmark_returns[].value",
+            "location": "body",
+            "required": true,
+            "type": "number",
+            "semanticId": "lotus.value",
+            "attributeRef": "#/attributeCatalog/lotus.value"
+          },
+          {
+            "name": "tracking_error_attention_threshold",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.tracking_error_attention_threshold",
+            "attributeRef": "#/attributeCatalog/lotus.tracking_error_attention_threshold"
+          }
+        ]
+      },
+      "response": {
+        "fields": [
+          {
+            "name": "product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_name",
+            "attributeRef": "#/attributeCatalog/lotus.product_name"
+          },
+          {
+            "name": "product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.product_version",
+            "attributeRef": "#/attributeCatalog/lotus.product_version"
+          },
+          {
+            "name": "portfolio_id",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.portfolio_id",
+            "attributeRef": "#/attributeCatalog/lotus.portfolio_id"
+          },
+          {
+            "name": "as_of_date",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.as_of_date",
+            "attributeRef": "#/attributeCatalog/lotus.as_of_date"
+          },
+          {
+            "name": "period_name",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.period_name",
+            "attributeRef": "#/attributeCatalog/lotus.period_name"
+          },
+          {
+            "name": "health_state",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.health_state",
+            "attributeRef": "#/attributeCatalog/lotus.health_state"
+          },
+          {
+            "name": "threshold_breached",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.threshold_breached",
+            "attributeRef": "#/attributeCatalog/lotus.threshold_breached"
+          },
+          {
+            "name": "tracking_error_attention_threshold",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.tracking_error_attention_threshold",
+            "attributeRef": "#/attributeCatalog/lotus.tracking_error_attention_threshold"
+          },
+          {
+            "name": "source_metric",
+            "location": "body",
+            "required": true,
+            "type": "MandateRiskHealthSourceMetric",
+            "semanticId": "lotus.source_metric",
+            "attributeRef": "#/attributeCatalog/lotus.source_metric"
+          },
+          {
+            "name": "source_metric.metric_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.metric_name",
+            "attributeRef": "#/attributeCatalog/lotus.metric_name"
+          },
+          {
+            "name": "source_metric.annualized_tracking_error",
+            "location": "body",
+            "required": false,
+            "type": "object",
+            "semanticId": "lotus.annualized_tracking_error",
+            "attributeRef": "#/attributeCatalog/lotus.annualized_tracking_error"
+          },
+          {
+            "name": "source_metric.aligned_observation_count",
+            "location": "body",
+            "required": false,
+            "type": "integer",
+            "semanticId": "lotus.aligned_observation_count",
+            "attributeRef": "#/attributeCatalog/lotus.aligned_observation_count"
+          },
+          {
+            "name": "methodology_posture",
+            "location": "body",
+            "required": false,
+            "type": "MandateRiskHealthMethodologyPosture",
+            "semanticId": "lotus.methodology_posture",
+            "attributeRef": "#/attributeCatalog/lotus.methodology_posture"
+          },
+          {
+            "name": "methodology_posture.source_product_name",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_product_name",
+            "attributeRef": "#/attributeCatalog/lotus.source_product_name"
+          },
+          {
+            "name": "methodology_posture.source_product_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_product_version",
+            "attributeRef": "#/attributeCatalog/lotus.source_product_version"
+          },
+          {
+            "name": "methodology_posture.source_service",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_service",
+            "attributeRef": "#/attributeCatalog/lotus.source_service"
+          },
+          {
+            "name": "methodology_posture.source_metrics_product",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_metrics_product",
+            "attributeRef": "#/attributeCatalog/lotus.source_metrics_product"
+          },
+          {
+            "name": "methodology_posture.methodology_version",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.methodology_version",
+            "attributeRef": "#/attributeCatalog/lotus.methodology_version"
+          },
+          {
+            "name": "methodology_posture.source_route",
+            "location": "body",
+            "required": false,
+            "type": "string",
+            "semanticId": "lotus.source_route",
+            "attributeRef": "#/attributeCatalog/lotus.source_route"
+          },
+          {
+            "name": "request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.request_fingerprint"
+          },
+          {
+            "name": "source_request_fingerprint",
+            "location": "body",
+            "required": true,
+            "type": "string",
+            "semanticId": "lotus.source_request_fingerprint",
+            "attributeRef": "#/attributeCatalog/lotus.source_request_fingerprint"
+          },
+          {
+            "name": "reason_codes",
+            "location": "body",
+            "required": true,
+            "type": "array",
+            "semanticId": "lotus.reason_codes",
+            "attributeRef": "#/attributeCatalog/lotus.reason_codes"
+          }
+        ]
       }
     },
     {

--- a/src/app/contracts/capabilities.py
+++ b/src/app/contracts/capabilities.py
@@ -10,6 +10,7 @@ CAPABILITY_FEATURE_KEYS: tuple[str, ...] = (
     "risk.analytics.drawdown",
     "risk.analytics.rolling_metrics",
     "risk.analytics.historical_attribution",
+    "risk.analytics.mandate_risk_health_context",
     "risk.analytics.regime_scenario_pack",
     "risk.analytics.risk_event_affected_cohort",
     "risk.analytics.metrics",
@@ -21,6 +22,7 @@ CAPABILITY_WORKFLOW_KEYS: tuple[str, ...] = (
     "drawdown_analytics",
     "rolling_risk_analytics",
     "historical_risk_attribution",
+    "mandate_risk_health_context",
     "regime_scenario_pack_evaluation",
     "risk_event_affected_cohort",
 )

--- a/src/app/contracts/mandate_health.py
+++ b/src/app/contracts/mandate_health.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.contracts.risk import ReturnPoint, RiskRequestPeriod, RiskRequestScope
+
+
+MandateRiskHealthState = Literal["ready", "attention", "unavailable"]
+
+
+class MandateRiskHealthContextRequest(BaseModel):
+    portfolio_id: str = Field(
+        description="Portfolio identifier for the mandate health risk context.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    scope: RiskRequestScope = Field(
+        description="Risk scope and as-of date used for source-owned mandate health evaluation.",
+        json_schema_extra={
+            "example": {
+                "as_of_date": "2026-02-27",
+                "reporting_currency": "USD",
+                "net_or_gross": "NET",
+            }
+        },
+    )
+    period: RiskRequestPeriod = Field(
+        description="Single risk period evaluated for mandate health context.",
+        json_schema_extra={"example": {"type": "YTD", "name": "YTD"}},
+    )
+    portfolio_open_date: dt.date = Field(
+        description="Portfolio inception date used for SI period handling.",
+        json_schema_extra={"example": "2024-01-01"},
+    )
+    returns: list[ReturnPoint] = Field(
+        description="Portfolio return observations in percentage points.",
+        json_schema_extra={"example": [{"date": "2026-01-02", "value": 0.25}]},
+    )
+    benchmark_returns: list[ReturnPoint] = Field(
+        description="Benchmark return observations in percentage points.",
+        json_schema_extra={"example": [{"date": "2026-01-02", "value": 0.18}]},
+    )
+    tracking_error_attention_threshold: Decimal = Field(
+        default=Decimal("0.05"),
+        ge=Decimal("0"),
+        description=(
+            "Annualized tracking-error attention threshold as a decimal ratio. "
+            "For example, 0.05 represents 5 percent annualized tracking error."
+        ),
+        json_schema_extra={"example": "0.05"},
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class MandateRiskHealthSourceMetric(BaseModel):
+    metric_name: Literal["TRACKING_ERROR"] = Field(
+        default="TRACKING_ERROR",
+        description="Source-owned risk metric used for mandate health posture.",
+        json_schema_extra={"example": "TRACKING_ERROR"},
+    )
+    annualized_tracking_error: Decimal | None = Field(
+        default=None,
+        description="Annualized tracking error as a decimal ratio when source-ready.",
+        json_schema_extra={"example": "0.0425"},
+    )
+    aligned_observation_count: int = Field(
+        default=0,
+        ge=0,
+        description="Aligned portfolio and benchmark observations used by the source metric.",
+        json_schema_extra={"example": 64},
+    )
+
+
+class MandateRiskHealthMethodologyPosture(BaseModel):
+    source_product_name: Literal["MandateRiskHealthContext"] = Field(
+        default="MandateRiskHealthContext",
+        description="Source-owned mandate health risk product name.",
+        json_schema_extra={"example": "MandateRiskHealthContext"},
+    )
+    source_product_version: Literal["v1"] = Field(
+        default="v1",
+        description="Source-owned mandate health risk product version.",
+        json_schema_extra={"example": "v1"},
+    )
+    source_service: Literal["lotus-risk"] = Field(
+        default="lotus-risk",
+        description="Authoritative source service for this risk context.",
+        json_schema_extra={"example": "lotus-risk"},
+    )
+    source_metrics_product: Literal["RiskMetricsReport:v1"] = Field(
+        default="RiskMetricsReport:v1",
+        description="Underlying source-owned risk metrics product used for this context.",
+        json_schema_extra={"example": "RiskMetricsReport:v1"},
+    )
+    methodology_version: Literal["risk.v1"] = Field(
+        default="risk.v1",
+        description="Risk methodology version used by the source calculation.",
+        json_schema_extra={"example": "risk.v1"},
+    )
+    source_route: Literal["/analytics/risk/calculate"] = Field(
+        default="/analytics/risk/calculate",
+        description="Underlying source route used for risk metric calculation.",
+        json_schema_extra={"example": "/analytics/risk/calculate"},
+    )
+
+
+class MandateRiskHealthContextResponse(BaseModel):
+    product_name: Literal["MandateRiskHealthContext"] = Field(
+        default="MandateRiskHealthContext",
+        description="Source-owned product emitted by lotus-risk for mandate health risk context.",
+        json_schema_extra={"example": "MandateRiskHealthContext"},
+    )
+    product_version: Literal["v1"] = Field(
+        default="v1",
+        description="Product contract version.",
+        json_schema_extra={"example": "v1"},
+    )
+    portfolio_id: str = Field(
+        description="Portfolio identifier evaluated by the source product.",
+        json_schema_extra={"example": "PB_SG_GLOBAL_BAL_001"},
+    )
+    as_of_date: dt.date = Field(
+        description="As-of date for the source-owned mandate health risk context.",
+        json_schema_extra={"example": "2026-02-27"},
+    )
+    period_name: str = Field(
+        description="Resolved period key evaluated by the source product.",
+        json_schema_extra={"example": "YTD"},
+    )
+    health_state: MandateRiskHealthState = Field(
+        description="Bounded risk health posture derived from source-owned tracking error.",
+        json_schema_extra={"example": "attention"},
+    )
+    threshold_breached: bool | None = Field(
+        default=None,
+        description="Whether source-owned tracking error breached the supplied attention threshold.",
+        json_schema_extra={"example": True},
+    )
+    tracking_error_attention_threshold: Decimal = Field(
+        description="Applied annualized tracking-error threshold as a decimal ratio.",
+        json_schema_extra={"example": "0.05"},
+    )
+    source_metric: MandateRiskHealthSourceMetric = Field(
+        description="Bounded source metric evidence used to derive health state.",
+        json_schema_extra={
+            "example": {
+                "metric_name": "TRACKING_ERROR",
+                "annualized_tracking_error": "0.0425",
+                "aligned_observation_count": 64,
+            }
+        },
+    )
+    methodology_posture: MandateRiskHealthMethodologyPosture = Field(
+        default_factory=MandateRiskHealthMethodologyPosture,
+        description="Source ownership and methodology posture for consumers.",
+        json_schema_extra={
+            "example": {
+                "source_product_name": "MandateRiskHealthContext",
+                "source_product_version": "v1",
+                "source_service": "lotus-risk",
+                "source_metrics_product": "RiskMetricsReport:v1",
+                "methodology_version": "risk.v1",
+                "source_route": "/analytics/risk/calculate",
+            }
+        },
+    )
+    request_fingerprint: str = Field(
+        description="Fingerprint of the mandate health context request.",
+        json_schema_extra={"example": "sha256:..."},
+    )
+    source_request_fingerprint: str = Field(
+        description="Fingerprint of the underlying RiskMetricsReport request.",
+        json_schema_extra={"example": "sha256:..."},
+    )
+    reason_codes: list[str] = Field(
+        description="Bounded reason codes safe for downstream supportability and audit use.",
+        json_schema_extra={
+            "example": [
+                "MANDATE_RISK_HEALTH_TRACKING_ERROR_SOURCE_READY",
+                "RISK_METHODOLOGY_SOURCE_OWNED",
+            ]
+        },
+    )

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -27,6 +27,10 @@ from app.contracts.drawdown import (
     DrawdownResponse,
 )
 from app.contracts.error import ErrorResponse
+from app.contracts.mandate_health import (
+    MandateRiskHealthContextRequest,
+    MandateRiskHealthContextResponse,
+)
 from app.contracts.ops import DependencyStatus, OpsChecks, OpsResponse
 from app.contracts.rolling import (
     RollingAnalyticsRequest,
@@ -54,6 +58,7 @@ from app.services.attribution_engine import calculate_historical_attribution
 from app.services.attribution_mode_adapter import calculate_historical_attribution_stateful
 from app.services.drawdown_engine import calculate_drawdown
 from app.services.drawdown_mode_adapter import calculate_drawdown_stateful
+from app.services.mandate_health_context import evaluate_mandate_risk_health_context
 from app.services.rolling_engine import calculate_rolling_metrics
 from app.services.rolling_mode_adapter import calculate_rolling_metrics_stateful
 from app.services.risk_engine import calculate_risk
@@ -589,6 +594,17 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
                 ],
             ),
             CapabilityWorkflow(
+                workflow_key="mandate_risk_health_context",
+                endpoint_path="/analytics/risk/mandate-health-context",
+                supported_input_modes=["stateless"],
+                support_status="partial",
+                notes=[
+                    "derives bounded mandate risk health from source-owned tracking-error methodology",
+                    "returns threshold posture, lineage, and non-claim reason codes for Manage consumption",
+                    "does not create mandate actions, rebalance waves, or client communication",
+                ],
+            ),
+            CapabilityWorkflow(
                 workflow_key="regime_scenario_pack_evaluation",
                 endpoint_path="/analytics/risk/regime-scenario-pack/evaluate",
                 supported_input_modes=["stateless"],
@@ -629,6 +645,29 @@ async def integration_capabilities() -> IntegrationCapabilitiesResponse:
 )
 async def metrics() -> Response:
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post(
+    "/analytics/risk/mandate-health-context",
+    response_model=MandateRiskHealthContextResponse,
+    responses=STANDARD_ERROR_RESPONSES,
+    summary="Evaluate source-owned mandate risk health context",
+    tags=["risk-analytics"],
+    description=(
+        "Evaluates a bounded mandate risk health context using lotus-risk source-owned "
+        "tracking-error methodology. The response preserves threshold posture, lineage, "
+        "methodology ownership, and reason codes for downstream consumers such as lotus-manage "
+        "without creating mandate actions, rebalance waves, client communications, or execution."
+    ),
+)
+async def analytics_risk_mandate_health_context(
+    request_payload: MandateRiskHealthContextRequest,
+) -> MandateRiskHealthContextResponse:
+    return await _observed_endpoint(
+        endpoint="mandate-risk-health-context",
+        input_mode="stateless",
+        operation=lambda: evaluate_mandate_risk_health_context(request_payload),
+    )
 
 
 @app.post(

--- a/src/app/services/mandate_health_context.py
+++ b/src/app/services/mandate_health_context.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from app.contracts.mandate_health import (
+    MandateRiskHealthContextRequest,
+    MandateRiskHealthContextResponse,
+    MandateRiskHealthSourceMetric,
+    MandateRiskHealthState,
+)
+from app.contracts.risk import StatelessRiskInput
+from app.services.audit_lineage import fingerprint_model
+from app.services.risk_engine import calculate_risk
+
+
+def _to_decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value))
+
+
+def evaluate_mandate_risk_health_context(
+    request: MandateRiskHealthContextRequest,
+) -> MandateRiskHealthContextResponse:
+    period_name = request.period.name or request.period.type
+    risk_request = StatelessRiskInput(
+        scope=request.scope,
+        periods=[request.period],
+        metrics=["TRACKING_ERROR"],
+        portfolio_open_date=request.portfolio_open_date,
+        returns=request.returns,
+        benchmark_returns=request.benchmark_returns,
+    )
+    risk_response = calculate_risk(risk_request)
+    period_result = risk_response.results[period_name]
+    metric = period_result.metrics["TRACKING_ERROR"]
+    details = metric.details or {}
+    annualized_tracking_error = _to_decimal(details.get("annualized_tracking_error"))
+    aligned_observation_count = int(details.get("aligned_observation_count") or 0)
+
+    reason_codes = ["RISK_METHODOLOGY_SOURCE_OWNED"]
+    if annualized_tracking_error is None:
+        health_state: MandateRiskHealthState = "unavailable"
+        threshold_breached = None
+        reason_codes.append("MANDATE_RISK_HEALTH_TRACKING_ERROR_UNAVAILABLE")
+    else:
+        threshold_breached = annualized_tracking_error > request.tracking_error_attention_threshold
+        health_state = "attention" if threshold_breached else "ready"
+        reason_codes.append("MANDATE_RISK_HEALTH_TRACKING_ERROR_SOURCE_READY")
+        if threshold_breached:
+            reason_codes.append("MANDATE_RISK_HEALTH_TRACKING_ERROR_THRESHOLD_BREACHED")
+
+    return MandateRiskHealthContextResponse(
+        portfolio_id=request.portfolio_id,
+        as_of_date=request.scope.as_of_date,
+        period_name=period_name,
+        health_state=health_state,
+        threshold_breached=threshold_breached,
+        tracking_error_attention_threshold=request.tracking_error_attention_threshold,
+        source_metric=MandateRiskHealthSourceMetric(
+            annualized_tracking_error=annualized_tracking_error,
+            aligned_observation_count=aligned_observation_count,
+        ),
+        request_fingerprint=fingerprint_model(request),
+        source_request_fingerprint=risk_response.metadata.request_fingerprint or "",
+        reason_codes=reason_codes,
+    )

--- a/tests/e2e/test_smoke.py
+++ b/tests/e2e/test_smoke.py
@@ -216,7 +216,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         body["consumer_declaration_source"]
         == "contracts/domain-data-products/lotus-risk-consumers.v1.json"
     )
-    assert body["summary"]["declared_product_count"] == 7
+    assert body["summary"]["declared_product_count"] == 8
     assert body["summary"]["declared_dependency_count"] == 6
     assert [product["product_name"] for product in body["products"]] == [
         "RiskMetricsReport",
@@ -224,6 +224,7 @@ def test_e2e_ops_trust_telemetry_exposes_declared_products_and_summary() -> None
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "MandateRiskHealthContext",
         "RegimeScenarioPackEvaluation",
         "RiskEventAffectedCohort",
     ]

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -43,6 +43,7 @@ def test_integration_capabilities_contract() -> None:
         "risk.analytics.drawdown",
         "risk.analytics.rolling_metrics",
         "risk.analytics.historical_attribution",
+        "risk.analytics.mandate_risk_health_context",
         "risk.analytics.regime_scenario_pack",
         "risk.analytics.risk_event_affected_cohort",
         "risk.analytics.metrics",
@@ -55,6 +56,7 @@ def test_integration_capabilities_contract() -> None:
         "drawdown_analytics",
         "rolling_risk_analytics",
         "historical_risk_attribution",
+        "mandate_risk_health_context",
         "regime_scenario_pack_evaluation",
         "risk_event_affected_cohort",
     }
@@ -69,6 +71,11 @@ def test_integration_capabilities_contract() -> None:
         "simulation",
     ]
     assert workflow_by_key["historical_risk_attribution"]["support_status"] == "partial"
+    assert workflow_by_key["mandate_risk_health_context"]["endpoint_path"] == (
+        "/analytics/risk/mandate-health-context"
+    )
+    assert workflow_by_key["mandate_risk_health_context"]["supported_input_modes"] == ["stateless"]
+    assert workflow_by_key["mandate_risk_health_context"]["support_status"] == "partial"
     assert workflow_by_key["regime_scenario_pack_evaluation"]["endpoint_path"] == (
         "/analytics/risk/regime-scenario-pack/evaluate"
     )
@@ -218,7 +225,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         == "lotus-performance"
     )
     assert trust_telemetry_body["declared_dependencies"][0]["runtime_status"] == "ok"
-    assert trust_telemetry_body["summary"]["declared_product_count"] == 7
+    assert trust_telemetry_body["summary"]["declared_product_count"] == 8
     assert trust_telemetry_body["summary"]["declared_dependency_count"] == 6
     assert trust_telemetry_body["summary"]["degraded_dependency_count"] == 0
     assert trust_telemetry_body["summary"]["unavailable_dependency_count"] == 0
@@ -229,6 +236,7 @@ def test_metadata_and_ops_contract_shape() -> None:
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "MandateRiskHealthContext",
         "RegimeScenarioPackEvaluation",
         "RiskEventAffectedCohort",
     ]

--- a/tests/unit/test_domain_data_products.py
+++ b/tests/unit/test_domain_data_products.py
@@ -24,6 +24,7 @@ def test_list_declared_products_matches_expected_wave() -> None:
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "MandateRiskHealthContext",
         "RegimeScenarioPackEvaluation",
         "RiskEventAffectedCohort",
     ]
@@ -47,6 +48,20 @@ def test_regime_scenario_pack_declaration_tracks_position_identifiers() -> None:
 
     assert product["approved_consumers"] == ["lotus-gateway", "lotus-manage"]
     assert product["identifier_refs"] == ["portfolio_id", "instrument_id"]
+
+
+def test_mandate_risk_health_context_declaration_is_manage_consumable() -> None:
+    product = get_declared_product(
+        product_name="MandateRiskHealthContext",
+        product_version="v1",
+    )
+
+    assert product["current_routes"] == ["/analytics/risk/mandate-health-context"]
+    assert product["approved_consumers"] == ["lotus-gateway", "lotus-manage"]
+    assert product["completeness_policy"] == {
+        "default_status": "partial",
+        "partial_allowed": True,
+    }
 
 
 def test_get_declared_product_rejects_unknown_product() -> None:

--- a/tests/unit/test_mandate_health_context.py
+++ b/tests/unit/test_mandate_health_context.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from fastapi.testclient import TestClient
+
+from app.contracts.mandate_health import MandateRiskHealthContextRequest
+from app.main import app
+from app.services.mandate_health_context import evaluate_mandate_risk_health_context
+
+
+def _request_payload() -> dict[str, object]:
+    return {
+        "portfolio_id": "PB_SG_GLOBAL_BAL_001",
+        "scope": {
+            "as_of_date": "2026-02-27",
+            "reporting_currency": "USD",
+            "net_or_gross": "NET",
+        },
+        "period": {"type": "YTD", "name": "YTD"},
+        "portfolio_open_date": "2024-01-01",
+        "returns": [
+            {"date": "2026-01-02", "value": 0.25},
+            {"date": "2026-01-03", "value": -0.10},
+            {"date": "2026-01-04", "value": 0.40},
+        ],
+        "benchmark_returns": [
+            {"date": "2026-01-02", "value": 0.10},
+            {"date": "2026-01-03", "value": 0.05},
+            {"date": "2026-01-04", "value": 0.12},
+        ],
+        "tracking_error_attention_threshold": "0.01",
+    }
+
+
+def test_mandate_risk_health_context_uses_source_tracking_error_methodology() -> None:
+    response = evaluate_mandate_risk_health_context(
+        MandateRiskHealthContextRequest.model_validate(_request_payload())
+    )
+
+    assert response.product_name == "MandateRiskHealthContext"
+    assert response.product_version == "v1"
+    assert response.portfolio_id == "PB_SG_GLOBAL_BAL_001"
+    assert response.period_name == "YTD"
+    assert response.health_state == "attention"
+    assert response.threshold_breached is True
+    assert response.tracking_error_attention_threshold == Decimal("0.01")
+    assert response.source_metric.metric_name == "TRACKING_ERROR"
+    assert response.source_metric.annualized_tracking_error is not None
+    assert response.source_metric.annualized_tracking_error > Decimal("0.01")
+    assert response.source_metric.aligned_observation_count == 3
+    assert response.methodology_posture.source_service == "lotus-risk"
+    assert response.methodology_posture.source_metrics_product == "RiskMetricsReport:v1"
+    assert response.methodology_posture.source_route == "/analytics/risk/calculate"
+    assert response.request_fingerprint.startswith("sha256:")
+    assert response.source_request_fingerprint.startswith("sha256:")
+    assert "RISK_METHODOLOGY_SOURCE_OWNED" in response.reason_codes
+    assert "MANDATE_RISK_HEALTH_TRACKING_ERROR_SOURCE_READY" in response.reason_codes
+    assert "MANDATE_RISK_HEALTH_TRACKING_ERROR_THRESHOLD_BREACHED" in response.reason_codes
+
+
+def test_mandate_risk_health_context_endpoint_returns_source_product() -> None:
+    client = TestClient(app)
+
+    response = client.post("/analytics/risk/mandate-health-context", json=_request_payload())
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["product_name"] == "MandateRiskHealthContext"
+    assert body["methodology_posture"]["source_service"] == "lotus-risk"
+    assert body["methodology_posture"]["source_metrics_product"] == "RiskMetricsReport:v1"
+    assert body["health_state"] == "attention"
+    assert body["threshold_breached"] is True
+
+
+def test_capabilities_include_mandate_risk_health_context_workflow() -> None:
+    client = TestClient(app)
+
+    response = client.get("/integration/capabilities")
+
+    assert response.status_code == 200
+    workflows = {workflow["workflow_key"]: workflow for workflow in response.json()["workflows"]}
+    workflow = workflows["mandate_risk_health_context"]
+    assert workflow["endpoint_path"] == "/analytics/risk/mandate-health-context"
+    assert workflow["support_status"] == "partial"
+    assert workflow["supported_input_modes"] == ["stateless"]

--- a/tests/unit/test_trust_telemetry.py
+++ b/tests/unit/test_trust_telemetry.py
@@ -205,7 +205,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
     assert snapshot.declared_dependencies[2].runtime_status == "degraded"
     assert snapshot.declared_dependencies[2].runtime_category == "data_gap"
     assert snapshot.declared_dependencies[2].runtime_issue_code == "RISK_FREE_SERIES_STALE"
-    assert snapshot.summary.declared_product_count == 7
+    assert snapshot.summary.declared_product_count == 8
     assert snapshot.summary.declared_dependency_count == 6
     assert snapshot.summary.degraded_dependency_count == 4
     assert snapshot.summary.unavailable_dependency_count == 0
@@ -224,6 +224,7 @@ def test_build_declared_product_trust_telemetry_snapshot_uses_repo_native_catalo
         "RollingRiskMetricsReport",
         "HistoricalRiskAttributionReport",
         "ConcentrationRiskReport",
+        "MandateRiskHealthContext",
         "RegimeScenarioPackEvaluation",
         "RiskEventAffectedCohort",
     ]

--- a/wiki/Mesh-Data-Products.md
+++ b/wiki/Mesh-Data-Products.md
@@ -12,11 +12,13 @@
   - `lotus-risk:RollingRiskMetricsReport:v1`
   - `lotus-risk:HistoricalRiskAttributionReport:v1`
   - `lotus-risk:ConcentrationRiskReport:v1`
+  - `lotus-risk:MandateRiskHealthContext:v1`
   - `lotus-risk:RegimeScenarioPackEvaluation:v1`
   - `lotus-risk:RiskEventAffectedCohort:v1`
-- Product role: governed risk analytics reports, scenario-pack evaluation outputs, and risk-event
-  affected-cohort membership for advisory, reporting, gateway, Workbench discovery, manage
-  construction-supportability, and future rebalance-wave trigger flows
+- Product role: governed risk analytics reports, mandate risk health context, scenario-pack
+  evaluation outputs, and risk-event affected-cohort membership for advisory, reporting, gateway,
+  Workbench discovery, manage construction-supportability, mandate supportability, and future
+  rebalance-wave trigger flows
 - Source declaration: `contracts/domain-data-products/`
 - Trust telemetry: `contracts/trust-telemetry/`
 
@@ -96,6 +98,13 @@ downstream proof packs must preserve them instead of rebuilding scenario logic o
 `docs/methodologies/metrics/regime-scenario-pack-evaluation.md`, including formulas, validation and
 failure behavior, deterministic ordering, governance posture, and a worked contribution example.
 
+`MandateRiskHealthContext:v1` is a bounded first-wave source product for DPM mandate health
+consumption. It derives `ready`, `attention`, or `unavailable` posture from source-owned
+tracking-error methodology, returns the applied annualized tracking-error threshold, preserves the
+underlying `RiskMetricsReport:v1` source route and request fingerprints, and emits bounded reason
+codes. It does not create mandate actions, rebalance waves, client communications, orders, or
+execution instructions.
+
 ```mermaid
 flowchart LR
     PERF[lotus-performance<br/>portfolio + benchmark returns]
@@ -104,12 +113,14 @@ flowchart LR
     WB[lotus-workbench<br/>risk workspace]
     MANAGE[lotus-manage<br/>realized outcome source adapter]
     COHORT[lotus-risk<br/>RiskEventAffectedCohort:v1]
+    HEALTH[lotus-risk<br/>MandateRiskHealthContext:v1]
 
     PERF -->|dated return series| RISK
     RISK -->|rolling active-risk metrics + lineage| GW
     GW --> WB
     RISK -->|source-owned scalar + scenario contribution evidence| MANAGE
     COHORT -->|affected portfolios + source refs| MANAGE
+    HEALTH -->|tracking-error health posture + lineage| MANAGE
 ```
 
 Audience notes:
@@ -157,6 +168,9 @@ Audience notes:
 - Developers and downstream services must preserve `RiskEventAffectedCohort:v1` membership,
   exclusions, source refs, and impact scores rather than reconstructing risk-event cohort
   membership locally.
+- Developers and downstream services must preserve `MandateRiskHealthContext:v1` threshold posture,
+  source metric evidence, methodology posture, fingerprints, and reason codes rather than
+  recomputing mandate risk health locally.
 - Developers and downstream services must preserve `RegimeScenarioPackEvaluation:v1` scenario
   results, per-security contribution rows, reason codes, and lineage rather than applying local
   scenario methodology in gateway, Workbench, reporting, or manage proof packs.


### PR DESCRIPTION
## Summary
- add source-owned MandateRiskHealthContext:v1 over existing TRACKING_ERROR methodology
- expose POST /analytics/risk/mandate-health-context with bounded health posture, threshold state, lineage fingerprints, and non-claim reason codes
- declare the risk product for lotus-gateway and lotus-manage consumption and update API vocabulary, docs, context, tests, and wiki source

## Validation
- python -m pytest tests/unit/test_mandate_health_context.py tests/unit/test_domain_data_products.py tests/unit/test_capabilities_contract.py -q
- make check
- make test-integration
- make test-e2e
- make test-pyramid-gate
- make migration-smoke
- make security-audit
- python ../lotus-platform/automation/validate_engineering_context_system.py
- python ../lotus-platform/automation/validate_lotus_skill_alignment.py

Wiki source changed: Mesh-Data-Products.md has expected drift until post-merge publication.

Platform mirror note: the matching lotus-platform domain-product mirror is prepared on branch feat/risk-mandate-health-product-mirror and should merge after this PR so platform federated checks see the risk route on main.