### PR TITLE
Improve lotus-risk documentation and wiki knowledge base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: architecture-gate complexity-gate source-size-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-coverage test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate domain-data-product-gate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate openapi-artifact-gate api-vocabulary-gate live-api-validate live-api-validate-core format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down test-pyramid-gate quality-baseline
+.PHONY: architecture-gate complexity-gate source-size-gate dead-code-gate dependency-hygiene-gate install install-ci check check-all test test-unit test-integration test-e2e test-all test-coverage test-fast test-all-fast test-all-no-cov test-all-parallel ci ci-local ci-local-docker ci-local-docker-down typecheck typecheck-tests-critical lint monetary-float-guard domain-product-validate domain-data-product-gate trust-telemetry-validate observability-contract-validate mesh-contract-validate no-alias-gate openapi-gate openapi-artifact-gate api-vocabulary-gate format clean run check-deps security-audit migration-smoke migration-apply pre-commit docker-build docker-up docker-down test-pyramid-gate quality-baseline
 
 COVERAGE_FAIL_UNDER ?= 98
 SOURCE_FILE_MAX_LINES ?= 450
@@ -95,12 +95,6 @@ no-alias-gate:
 
 api-vocabulary-gate:
 	python scripts/api_vocabulary_inventory.py --validate-only
-
-live-api-validate:
-	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://127.0.0.1:8001}
-
-live-api-validate-core:
-	python scripts/validate_live_api.py --base-url $${LOTUS_MANAGE_BASE_URL:-http://manage.dev.lotus} --skip-demo-pack --core-base-url $${LOTUS_CORE_CONTROL_BASE_URL:-http://core-control.dev.lotus} --core-base-url $${LOTUS_CORE_QUERY_BASE_URL:-http://core-query.dev.lotus} --expect-core-dpm-route $${LOTUS_MANAGE_EXPECT_CORE_DPM_ROUTE:-absent} --expect-stateful-core-sourcing $${LOTUS_MANAGE_EXPECT_STATEFUL_CORE_SOURCING:-available} --portfolio-id $${LOTUS_MANAGE_CANONICAL_PORTFOLIO_ID:-PB_SG_GLOBAL_BAL_001} --as-of $${LOTUS_MANAGE_CANONICAL_AS_OF:-2026-04-10}
 
 MIGRATION_SMOKE_TESTS := $(wildcard tests/unit/shared/dependencies/test_postgres_migrations.py tests/unit/shared/dependencies/test_production_cutover_contract.py)
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Current primary workflows:
 5. `POST /analytics/risk/concentration`
 6. `POST /analytics/risk/regime-scenario-pack/evaluate`
 7. `POST /analytics/risk/risk-event-cohorts/evaluate`
-8. `GET /integration/capabilities`
-9. `GET /ops`
+8. `POST /analytics/risk/mandate-health-context`
+9. `GET /integration/capabilities`
+10. `GET /ops`
 
 Important posture limits:
 
@@ -54,9 +55,12 @@ Important posture limits:
 3. risk-event affected-cohort evaluation is stateless and consumes caller-supplied candidate
    portfolios and source-supplied exposure weights against risk-owned event definitions; it does
    not create rebalance waves or own campaign approval workflow,
-4. stateful historical attribution supports `ACTIVE_RISK + ISSUER` through lotus-performance benchmark exposure context issuer groups,
-5. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
-6. broader enterprise-bank claims require more seeded archetypes and attached evidence.
+4. mandate risk health context is stateless and returns source-owned tracking-error posture for
+   downstream manage consumption; it does not create actions, rebalance waves, orders, execution,
+   or client communications,
+5. stateful historical attribution supports `ACTIVE_RISK + ISSUER` through lotus-performance benchmark exposure context issuer groups,
+6. live validation defaults to canonical portfolio `PB_SG_GLOBAL_BAL_001`,
+7. broader enterprise-bank claims require more seeded archetypes and attached evidence.
 
 ## Architectural Shape
 
@@ -71,14 +75,16 @@ Core areas:
    analytics engines, mode adapters, lineage helpers, and domain calculations.
 3. `src/app/integrations/`
    upstream clients for `lotus-core` and `lotus-performance`.
-4. `src/app/main.py`
-   public API surface and endpoint grouping.
+4. `src/app/app_factory.py` and `src/app/routers/`
+   application assembly and public API endpoint grouping.
 5. `docs/domain-apis/`
    endpoint-by-endpoint contract and product-surface alignment guidance.
 6. `docs/methodologies/`
    metric methodology definitions.
 7. `docs/operations/` and `docs/runbooks/`
    local runtime, CI, and live validation guidance.
+8. `docs/index.md`
+   navigable docs map for agents, developers, BAs, ops/support, and business/product readers.
 
 Execution model:
 
@@ -94,6 +100,7 @@ Execution model:
 - `docs/domain-apis/` API contracts and downstream alignment rules
 - `docs/methodologies/` metric methodology definitions
 - `docs/operations/` and `docs/runbooks/` runtime and validation guidance
+- `docs/index.md` audience-oriented documentation map
 - `docs/rfcs/` local RFC inventory
 - `docs/standards/` repo-local standards
 - `wiki/` canonical source pages for the repository wiki
@@ -134,6 +141,8 @@ Canonical direct local upstream URLs for live characterization and operator chec
 - `make test-unit` - unit suite
 - `make test-integration` - integration suite
 - `make test-e2e` - e2e suite
+- `make domain-data-product-gate` - repo-native domain data product validation
+- `make mesh-contract-validate` - domain product, trust telemetry, and observability contract validation
 - `make migration-apply` - governed migration contract check
 - `make docker-build` - Docker build validation
 
@@ -230,9 +239,12 @@ Key references:
 
 Best starting points:
 
+- audience-oriented docs index: `docs/index.md`
 - service-wide endpoint posture: `docs/domain-apis/endpoint-matrix.md`
 - capability publication: `docs/domain-apis/integration-capabilities.md`
 - product-surface alignment: `docs/domain-apis/risk-product-surface-alignment.md`
+- supported features and limits: `docs/supported-features.md`
+- documentation gap ledger: `docs/documentation-gap-ledger.md`
 - service operations: `docs/runbooks/service-operations.md`
 - runtime configuration: `docs/configuration.md`
 - development workflow: `docs/operations/development-workflow-and-ci-strategy.md`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,10 +11,38 @@ live under `src/app/contracts`, business calculations and orchestration helpers 
 `src/app/services`, downstream adapters live under `src/app/integrations`, and cross-cutting
 middleware/observability/error helpers live under dedicated app modules.
 
+The application is assembled by `src/app/app_factory.py`, which registers correlation middleware,
+enterprise audit/readiness controls, HTTP observation middleware, standard error handlers, and the
+router modules under `src/app/routers/`.
+
+## Runtime Surfaces
+
+| Surface | Router or module | Purpose |
+| --- | --- | --- |
+| Operational endpoints | `src/app/routers/operational.py` | health, liveness, readiness, metadata, ops diagnostics, trust telemetry, capabilities, and Prometheus metrics |
+| Risk calculation | `src/app/routers/risk_calculation.py` | portfolio risk metrics for stateless and stateful inputs |
+| Drawdown | `src/app/routers/drawdown.py` | realized drawdown analytics |
+| Rolling metrics | `src/app/routers/rolling.py` | rolling volatility, Sharpe, beta, tracking error, information ratio, and max drawdown |
+| Concentration | `src/app/routers/concentration.py` | stateless, stateful, and simulation concentration analytics |
+| Historical attribution | `src/app/routers/historical_attribution.py` | historical risk and active-risk attribution decomposition |
+| Source-owned products | `src/app/routers/source_products.py` | mandate risk health context, regime scenario-pack evaluation, and risk-event affected cohort evaluation |
+
+## Domain Boundaries
+
+`lotus-risk` owns risk meaning, methodology, supportability posture, lineage, and the repo-native
+domain data product declarations under `contracts/domain-data-products/`. It does not own
+portfolio holdings, transactions, benchmark returns, or UI composition. Stateful calls use
+`lotus-performance` for returns and benchmark exposure context and `lotus-core` for snapshots,
+simulation inputs, enrichment, and risk-free reference data.
+
+The service publishes raw local trust telemetry through `/ops/trust-telemetry` and static
+repo-native fixtures under `contracts/trust-telemetry/`. Platform-certified mesh posture remains
+owned by `lotus-platform` generated certification artifacts, not by this endpoint alone.
+
 ## Refactor Direction
 
 1. Keep calculation logic in services and pure helpers.
-2. Move route declarations out of `src/app/main.py` into focused routers.
+2. Keep route declarations in focused router modules rather than the ASGI export file.
 3. Keep downstream HTTP clients behind service-facing protocols.
 4. Keep middleware limited to correlation, audit, payload, policy, and telemetry concerns.
 5. Preserve existing risk methodology behavior unless a change is explicitly documented and tested.

--- a/docs/documentation-gap-ledger.md
+++ b/docs/documentation-gap-ledger.md
@@ -1,0 +1,34 @@
+# Documentation Gap Ledger
+
+This ledger records documentation issues found during the knowledge-base refresh and the disposition
+for each item. Keep it current when docs, wiki, or repo truth materially change.
+
+| ID | Area | Finding | Disposition |
+| --- | --- | --- | --- |
+| RISK-DOC-001 | Command surface | `Makefile` exposed stale `live-api-validate*` targets copied from `lotus-manage` and pointing at a missing `scripts/validate_live_api.py`. | Removed from the supported command surface in this slice. Do not document live validation as a make target until a real repo-native script exists. |
+| RISK-DOC-002 | Navigation | README and wiki routed to useful pages, but there was no audience-oriented docs index for agents, developers, BAs, ops/support, sales/marketing, and business/product users. | Added `docs/index.md` and linked it from README/wiki. |
+| RISK-DOC-003 | Supported features | `docs/supported-features.md` listed product names but did not separate implemented, partial, planned, and backlog posture. | Expanded into an implementation-backed matrix with limits and planned/backlog boundaries. |
+| RISK-DOC-004 | API docs | `docs/domain-apis/endpoint-matrix.md` used absolute Windows links and omitted the risk-event cohort row from the endpoint/mode tables. | Replaced absolute links with relative links and added risk-event affected-cohort posture. |
+| RISK-DOC-005 | Wiki business/product coverage | Wiki pages were operator/developer useful but did not expose a dedicated supported-features page for non-developer readers. | Added `wiki/Supported-Features.md` and sidebar navigation. |
+| RISK-DOC-006 | Operations | Runbook guidance existed but was terse for escalation, observability, and enterprise deployment failure modes. | Expanded `docs/runbooks/service-operations.md` with operator checks and escalation paths. |
+| RISK-DOC-007 | Migration docs | `docs/migrations/README.md` had a Markdown link target with raw parentheses that broke automated local link sanity parsing. | URL-encoded the parentheses in the link target and reran link/path sanity successfully. |
+
+## Open Follow-Ups
+
+1. Add a real repo-native live validation script before restoring any `live-api-validate` make
+   target.
+2. Add seeded portfolio IDs and evidence for pending live-validation archetypes before broadening
+   enterprise-bank claims.
+3. Attach cross-repo gateway and Workbench consumer proof whenever downstream risk semantics are
+   promoted.
+
+## Validation Evidence
+
+| Check | Result |
+| --- | --- |
+| Markdown local link/path sanity over `README.md`, `docs/**/*.md`, and `wiki/**/*.md` | Passed; checked 114 Markdown files |
+| Focused documentation and contract tests: `python -m pytest tests/unit/test_product_surface_alignment_contract.py tests/unit/test_observability_operations_contract.py tests/unit/test_configuration_docs.py tests/unit/test_final_pr_readiness_evidence.py tests/unit/test_capabilities_contract.py tests/unit/test_risk_event_cohort_api.py tests/unit/test_mandate_health_context.py -q` | Passed; 29 tests |
+| `make mesh-contract-validate` | Passed |
+| `make openapi-gate` | Passed |
+| `make check` | Passed; includes lint, no-alias, typecheck, OpenAPI artifact, API vocabulary, mesh contracts, source-size, and 554 unit tests |
+| `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` | Ran; reported expected publication drift for repo-authored wiki source changes: `_Sidebar.md`, `Architecture.md`, `Development-Workflow.md`, `Home.md`, `Integrations.md`, `Overview.md`, `Roadmap.md`, `Supported-Features.md`, and `Validation-and-CI.md` |

--- a/docs/domain-apis/README.md
+++ b/docs/domain-apis/README.md
@@ -41,6 +41,7 @@ This package documents the current `lotus-risk` API surface and evaluates it aga
 - `POST /analytics/risk/regime-scenario-pack/evaluate` (stateless governed CIO scenario-pack
   evaluation with optional reconciled per-security contribution rows)
 - `POST /analytics/risk/risk-event-cohorts/evaluate`
+- `POST /analytics/risk/mandate-health-context`
 
 ## Current Dependency Summary
 
@@ -79,6 +80,8 @@ See per-endpoint detail:
 - `docs/domain-apis/risk-rolling-metrics.md`
 - `docs/domain-apis/risk-historical-attribution.md`
 - `docs/domain-apis/regime-scenario-pack-evaluation.md`
+- `docs/domain-apis/risk-event-cohorts.md`
+- `docs/domain-apis/risk-mandate-health-context.md`
 - `docs/domain-apis/risk-upstream-failure-behavior.md`
 - `docs/domain-apis/risk-audit-lineage.md`
 - `docs/domain-apis/risk-observability.md`

--- a/docs/domain-apis/endpoint-matrix.md
+++ b/docs/domain-apis/endpoint-matrix.md
@@ -26,6 +26,7 @@ Status meanings:
 | `POST /analytics/risk/concentration` | Domain analytics | concentration analytics and HHI metrics | `stateless`, `stateful`, `simulation` | full | lotus-core snapshot and simulation session contracts | none |
 | `POST /analytics/risk/mandate-health-context` | Domain analytics | source-owned mandate risk health context derived from tracking-error methodology | `stateless` | partial | caller-supplied portfolio and benchmark return observations | bounded first-wave context only; does not create mandate actions, rebalance waves, client communication, or execution |
 | `POST /analytics/risk/regime-scenario-pack/evaluate` | Domain analytics | governed CIO regime scenario-pack evaluation with optional per-security contribution evidence | `stateless` | full | caller-supplied exposure weights, optional reconciled exposure components, and risk-owned scenario-pack definitions | does not forecast market states, perform full repricing, or accept browser-owned scenario methodology |
+| `POST /analytics/risk/risk-event-cohorts/evaluate` | Domain analytics | source-owned affected-cohort membership for governed risk events | `stateless` | partial | caller-supplied candidate portfolios, exposure weights, and risk-owned event definitions | does not create rebalance waves, approvals, campaign workflow, or client communications |
 
 ## Mode Support Detail
 
@@ -38,6 +39,7 @@ Status meanings:
 | `POST /analytics/risk/concentration` | full | full | full |
 | `POST /analytics/risk/mandate-health-context` | partial | unsupported by contract | unsupported by contract |
 | `POST /analytics/risk/regime-scenario-pack/evaluate` | full | unsupported by contract | unsupported by contract |
+| `POST /analytics/risk/risk-event-cohorts/evaluate` | partial | unsupported by contract | unsupported by contract |
 
 ## Highest-Value Remaining Gap
 
@@ -93,11 +95,12 @@ See `docs/domain-apis/risk-product-surface-alignment.md`.
 
 ## Related Detail Docs
 
-- [integration-capabilities.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\integration-capabilities.md)
-- [risk-calculate.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-calculate.md)
-- [risk-drawdown.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-drawdown.md)
-- [risk-rolling-metrics.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-rolling-metrics.md)
-- [risk-historical-attribution.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-historical-attribution.md)
-- [risk-concentration.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-concentration.md)
-- [risk-mandate-health-context.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-mandate-health-context.md)
-- [risk-product-surface-alignment.md](C:\Users\Sandeep\projects\lotus-risk\docs\domain-apis\risk-product-surface-alignment.md)
+- [integration-capabilities.md](./integration-capabilities.md)
+- [risk-calculate.md](./risk-calculate.md)
+- [risk-drawdown.md](./risk-drawdown.md)
+- [risk-rolling-metrics.md](./risk-rolling-metrics.md)
+- [risk-historical-attribution.md](./risk-historical-attribution.md)
+- [risk-concentration.md](./risk-concentration.md)
+- [risk-mandate-health-context.md](./risk-mandate-health-context.md)
+- [regime-scenario-pack-evaluation.md](./regime-scenario-pack-evaluation.md)
+- [risk-product-surface-alignment.md](./risk-product-surface-alignment.md)

--- a/docs/domain-apis/risk-event-cohorts.md
+++ b/docs/domain-apis/risk-event-cohorts.md
@@ -1,0 +1,64 @@
+# Risk Event Affected Cohorts
+
+## Endpoint
+
+`POST /analytics/risk/risk-event-cohorts/evaluate`
+
+## Business Purpose
+
+This endpoint evaluates candidate portfolios against governed risk-event definitions and returns a
+source-owned affected cohort. It is intended for downstream consumers that need risk-owned evidence
+for event-driven monitoring or future manage-wave trigger inputs.
+
+## Current Support
+
+| Item | Status |
+| --- | --- |
+| Input mode | `stateless` only |
+| Support status | partial first-wave product |
+| Product declaration | `RiskEventAffectedCohort:v1` |
+| Runtime owner | `lotus-risk` |
+| Primary tests | `tests/unit/test_risk_event_cohort_engine.py`, `tests/unit/test_risk_event_cohort_api.py` |
+
+## Inputs
+
+The caller supplies:
+
+1. a governed `risk_event_id`,
+2. candidate portfolios,
+3. source-owned exposure weights for each candidate,
+4. optional threshold and source-reference context as modeled by `src/app/contracts/risk_event_cohort_inputs.py`.
+
+The service evaluates those inputs against risk-owned event definitions in
+`src/app/services/risk_event_cohort_engine.py`.
+
+## Outputs
+
+The response returns:
+
+1. affected portfolio membership,
+2. excluded portfolios and exclusion reasons,
+3. source-owned impact scores,
+4. lineage source refs,
+5. supportability posture,
+6. bounded reason codes.
+
+## Explicit Non-Ownership
+
+This endpoint does not create:
+
+1. rebalance waves,
+2. approvals,
+3. campaign workflows,
+4. client communications,
+5. orders or execution.
+
+Downstream consumers must preserve source refs, impact scores, supportability, and lineage metadata
+when using the response as evidence.
+
+## Where To Look Next
+
+1. Service-wide posture: `docs/domain-apis/endpoint-matrix.md`.
+2. Capability publication: `docs/domain-apis/integration-capabilities.md`.
+3. Consumer preservation rules: `docs/domain-apis/risk-product-surface-alignment.md`.
+

--- a/docs/domain-apis/risk-product-surface-alignment.md
+++ b/docs/domain-apis/risk-product-surface-alignment.md
@@ -131,7 +131,8 @@ Workbench panels must:
 
 - label VaR as a signed return-threshold metric,
 - show attribution residuals with contributor totals or preserve them in a detail surface,
-- disable or omit stateful issuer active-risk affordances,
+- expose stateful issuer active-risk only when consuming the current lotus-risk capability and
+  historical-attribution metadata that marks `ACTIVE_RISK + ISSUER` as supported,
 - expose simulation controls only for concentration,
 - show coverage warnings when concentration issuer enrichment is partial or missing,
 - keep correlation/request identifiers available for support escalation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,60 @@
+# Lotus Risk Documentation Index
+
+This index routes agents, developers, BAs, ops/support, sales/marketing, and business/product users
+to implementation-backed `lotus-risk` documentation.
+
+## Start Here
+
+| Audience | Read first | Then use |
+| --- | --- | --- |
+| Agents | `README.md`, `REPOSITORY-ENGINEERING-CONTEXT.md`, this index | `docs/documentation-gap-ledger.md`, `docs/domain-apis/endpoint-matrix.md`, `docs/rfcs/README.md` |
+| Developers | `docs/architecture.md`, `docs/operations/development-workflow-and-ci-strategy.md` | `Makefile`, `tests/`, `scripts/`, `docs/configuration.md` |
+| BAs and product | `docs/supported-features.md`, `docs/domain-apis/endpoint-matrix.md` | `docs/domain-apis/integration-capabilities.md`, `wiki/Overview.md`, `wiki/Roadmap.md` |
+| Ops and support | `docs/runbooks/service-operations.md`, `wiki/Operations-Runbook.md` | `docs/observability.md`, `docs/security-deployment-policy.md`, `docs/operations/live-risk-validation-matrix.md` |
+| Sales and marketing | `wiki/Overview.md`, `docs/supported-features.md` | `wiki/Roadmap.md`, `docs/rfcs/RFC-0008-enterprise-bank-readiness-and-live-risk-validation-baseline.md` |
+| Business users | `wiki/Overview.md`, `wiki/Supported-Features.md` | `docs/domain-apis/risk-product-surface-alignment.md`, `wiki/Integrations.md` |
+
+## Documentation Layers
+
+1. `README.md` is the fast repo entry point.
+2. `wiki/` is the authored source for onboarding, operator, business, and product wiki pages.
+3. `docs/` holds detailed architecture, API, methodology, standards, operations, security, RFC, and
+   quality evidence.
+4. `quality/` holds generated or curated quality reports and PR-readiness evidence.
+5. `contracts/` holds repo-native machine-readable domain data product, trust telemetry, and
+   observability contracts.
+
+## Implementation Truth Sources
+
+Use code and executable checks when documentation is uncertain:
+
+1. router layout: `src/app/app_factory.py` and `src/app/routers/`,
+2. API contracts: `src/app/contracts/`,
+3. analytics behavior: `src/app/services/`,
+4. upstream integration: `src/app/integrations/`,
+5. command surface: `Makefile`,
+6. CI lanes: `.github/workflows/`,
+7. contract and methodology tests: `tests/unit/` and `tests/integration/`.
+
+## Where To Change What
+
+| Change type | Primary files |
+| --- | --- |
+| API behavior or request/response shape | `src/app/routers/`, `src/app/contracts/`, `docs/domain-apis/`, OpenAPI gates, integration tests |
+| Methodology behavior | `src/app/services/`, `docs/methodologies/`, methodology tests |
+| Upstream dependency behavior | `src/app/integrations/`, `docs/domain-apis/RFC-0082-upstream-contract-family-map.md`, integration tests |
+| Runtime configuration | `docs/configuration.md`, `.env.example`, `src/app/integrations/downstream_profile_env.py`, configuration tests |
+| Observability or supportability | `src/app/observability.py`, `contracts/observability/`, `docs/observability.md`, `docs/runbooks/service-operations.md` |
+| Security posture | `src/app/enterprise_readiness.py`, `docs/security-deployment-policy.md`, `docs/security.md`, security tests |
+| Business/product support claims | `docs/supported-features.md`, `docs/domain-apis/endpoint-matrix.md`, `wiki/Supported-Features.md`, capability tests |
+| Wiki truth | `wiki/`, then `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` |
+
+## Validation Entry Points
+
+1. Fast local gate: `make check`.
+2. PR-grade local gate: `make ci`.
+3. Domain product and mesh contracts: `make mesh-contract-validate`.
+4. OpenAPI and vocabulary gates: `make openapi-gate`, `make openapi-artifact-gate`,
+   `make api-vocabulary-gate`.
+5. Wiki source check: `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk`.
+

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -10,7 +10,7 @@ Authoritative risk documentation has moved to lotus-risk.
 - [04_Operations_Troubleshooting_Guide.md](from-lotus-core/04_Operations_Troubleshooting_Guide.md)
 - [05_Developer_Guide.md](from-lotus-core/05_Developer_Guide.md)
 - [06_ADR_Risk_Analytics_Design.md](from-lotus-core/06_ADR_Risk_Analytics_Design.md)
-- [RFC 007 - Risk Analytics APIs (Volatility, Drawdown, Sharpe, Sortino, Beta, VaR).md](from-lotus-core/RFC 007 - Risk Analytics APIs (Volatility, Drawdown, Sharpe, Sortino, Beta, VaR).md)
+- [RFC 007 - Risk Analytics APIs (Volatility, Drawdown, Sharpe, Sortino, Beta, VaR).md](from-lotus-core/RFC 007 - Risk Analytics APIs %28Volatility, Drawdown, Sharpe, Sortino, Beta, VaR%29.md)
 - [RFC 031 - Risk Service Correctness Hardening.md](from-lotus-core/RFC 031 - Risk Service Correctness Hardening.md)
 
 ## Migrated from lotus-performance

--- a/docs/runbooks/service-operations.md
+++ b/docs/runbooks/service-operations.md
@@ -2,10 +2,12 @@
 
 ## Standard Commands
 
-- make lint
-- make typecheck
-- make ci
-- docker compose up --build
+- `make check` for the fast local gate.
+- `make ci` for the PR-grade local gate.
+- `make mesh-contract-validate` for domain product, trust telemetry, and observability contract
+  validation.
+- `docker compose up --build` for prod-shaped local runtime.
+- `docker compose down` to stop the local runtime.
 
 ## Health and Readiness
 
@@ -20,6 +22,9 @@
 1. Check container logs for request failures and stack traces.
 2. Verify /health/ready, /ops, and metrics endpoint.
 3. Run local parity check (make ci) before hotfix PR.
+4. Check `/integration/capabilities` before treating an unsupported mode as an outage.
+5. For stateful-only failures, validate `LOTUS_CORE_BASE_URL` and `LOTUS_PERFORMANCE_BASE_URL`
+   before changing analytics code.
 
 ## Enterprise Deployment Security Checks
 
@@ -75,6 +80,24 @@ Alert id: `lotus-risk-calculation-supportability-degraded`
    exposing portfolio or client identifiers in metrics.
 3. For `stale_source_observations`, validate source freshness from upstream dependency diagnostics.
 4. For `permission_blocked`, verify caller capability and deployment authorization policy.
+
+## Escalation Paths
+
+Escalate by ownership boundary:
+
+1. `lotus-risk` owner: calculation defects, supportability metadata, risk methodology, OpenAPI,
+   capability publication, and bounded risk error mapping.
+2. `lotus-performance` owner: returns, benchmark returns, benchmark exposure context, and
+   performance-aligned attribution inputs.
+3. `lotus-core` owner: portfolio snapshots, simulation sessions, instrument enrichment, issuer
+   authority, and risk-free reference series.
+4. `lotus-gateway` owner: client-facing composition, entitlement propagation, and downstream
+   contract preservation.
+5. `lotus-platform` owner: ingress, CI governance, mesh certification, wiki sync automation, and
+   shared observability contracts.
+
+Do not reclassify an unsupported workflow as degraded. Unsupported modes should remain deterministic
+request-validation or capability-publication outcomes.
 
 ## HTTP 5xx Alert
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -1,5 +1,9 @@
 # Lotus Risk Supported Features
 
+This page separates current implementation-backed support from bounded, planned, and backlog
+posture. Treat `/integration/capabilities` and `docs/domain-apis/endpoint-matrix.md` as the
+runtime-facing support contract.
+
 ## Implementation-Backed Risk Products
 
 1. `RiskMetricsReport:v1`
@@ -10,8 +14,31 @@
 6. `RiskEventAffectedCohort:v1`
 7. `MandateRiskHealthContext:v1`
 
-## Supported Posture
+## Current Support Matrix
+
+| Product or workflow | Endpoint | Current support | Important limits |
+| --- | --- | --- | --- |
+| `RiskMetricsReport:v1` | `POST /analytics/risk/calculate` | full for stateless and stateful modes | simulation is intentionally unsupported |
+| `DrawdownAnalyticsReport:v1` | `POST /analytics/risk/drawdown` | full for stateless and stateful modes | simulation is intentionally unsupported |
+| `RollingRiskMetricsReport:v1` | `POST /analytics/risk/rolling-metrics` | full for stateless and stateful modes | broader portfolio-archetype proof remains limited to the live validation matrix |
+| `ConcentrationRiskReport:v1` | `POST /analytics/risk/concentration` | full for stateless, stateful, and simulation modes | simulation support must not be generalized to other risk workflows |
+| Historical attribution | `POST /analytics/risk/historical-attribution` | partial | stateful `ACTIVE_RISK` supports `POSITION`, `SECTOR`, `ASSET_CLASS`, and `ISSUER`; `CUSTOM` grouping and simulation remain unsupported |
+| `RegimeScenarioPackEvaluation:v1` | `POST /analytics/risk/regime-scenario-pack/evaluate` | full for stateless source-owned scenario-pack evaluation | does not forecast markets, perform full repricing, or accept UI-owned scenario methodology |
+| `RiskEventAffectedCohort:v1` | `POST /analytics/risk/risk-event-cohorts/evaluate` | partial stateless first-wave product | does not create rebalance waves, approvals, campaign workflows, or client communications |
+| `MandateRiskHealthContext:v1` | `POST /analytics/risk/mandate-health-context` | partial stateless first-wave product | does not create mandate actions, rebalance waves, orders, execution, or client communications |
+| Capability publication | `GET /integration/capabilities` | implemented | global capability publication only; no tenant- or consumer-shaped query controls |
+| Operations | `/health`, `/health/live`, `/health/ready`, `/metadata`, `/ops`, `/ops/trust-telemetry`, `/metrics` | implemented | `/ops/trust-telemetry` is repo-owned raw telemetry seed material, not platform-certified trust posture |
+
+## Current Evidence Boundary
 
 Supported features are bounded by the repository engineering context, domain API documentation,
 methodology documents, and repo-native tests. Broader enterprise-bank approval still requires the
 seeded portfolio archetype evidence described in `docs/operations/live-risk-validation-matrix.md`.
+
+## Planned Or Backlog
+
+1. Broader seeded live portfolio archetype coverage for enterprise-bank claims.
+2. Consumer-side proof that gateway, Workbench, reporting, and AI surfaces preserve signed VaR,
+   attribution reconciliation, concentration-only simulation, supportability, and lineage semantics.
+3. RFC-0009 Enterprise Risk Intelligence Operating Layer slices. These remain planned until each
+   slice is implemented, tested, documented, and validated.

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -8,7 +8,8 @@
 2. integration capability publication,
 3. domain risk analytics endpoints.
 
-That split is visible directly in `src/app/main.py`.
+That split is visible in `src/app/app_factory.py`, which assembles the FastAPI application and
+registers the router modules under `src/app/routers/`.
 
 ## Core Endpoint Groups
 
@@ -44,6 +45,9 @@ It is also the place downstream teams should discover that:
 3. `/analytics/risk/rolling-metrics`
 4. `/analytics/risk/historical-attribution`
 5. `/analytics/risk/concentration`
+6. `/analytics/risk/mandate-health-context`
+7. `/analytics/risk/regime-scenario-pack/evaluate`
+8. `/analytics/risk/risk-event-cohorts/evaluate`
 
 ## Code Map
 
@@ -59,6 +63,10 @@ Primary implementation areas:
    readiness and ops-status evaluation.
 5. `src/app/enterprise_readiness.py`
    enterprise-runtime validation and audit middleware setup.
+6. `contracts/domain-data-products/`
+   repo-native domain product and consumer declarations.
+7. `contracts/observability/`
+   dashboard, alert, and metric-label governance for risk supportability.
 
 ## Execution Modes
 
@@ -72,7 +80,9 @@ The important rule is that support is workflow-specific, not service-wide:
 
 1. concentration supports all three,
 2. risk/calculate, drawdown, and rolling support stateless and stateful only,
-3. historical attribution supports stateless and stateful active-risk, including issuer grouping.
+3. historical attribution supports stateless and stateful active-risk, including issuer grouping,
+4. mandate health, regime scenario-pack evaluation, and risk-event cohorts are stateless
+   source-owned products.
 
 ## Upstream Dependency Model
 

--- a/wiki/Development-Workflow.md
+++ b/wiki/Development-Workflow.md
@@ -18,6 +18,8 @@ Use a small, truthful backend loop:
 - `make test-unit`
 - `make test-integration`
 - `make test-e2e`
+- `make mesh-contract-validate`
+- `make openapi-gate`
 - `make migration-apply`
 - `make docker-build`
 
@@ -42,16 +44,18 @@ Use `make ci` when the change affects:
 
 For product and integration work, start from:
 
-1. `src/app/main.py`
-2. `src/app/contracts/`
-3. `src/app/services/`
-4. `src/app/integrations/`
+1. `src/app/app_factory.py`
+2. `src/app/routers/`
+3. `src/app/contracts/`
+4. `src/app/services/`
+5. `src/app/integrations/`
 
 Then confirm with:
 
 1. `docs/domain-apis/endpoint-matrix.md`
 2. `docs/domain-apis/risk-product-surface-alignment.md`
-3. `docs/operations/development-workflow-and-ci-strategy.md`
+3. `docs/index.md`
+4. `docs/operations/development-workflow-and-ci-strategy.md`
 
 ## Docs-With-Code Rule
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -22,8 +22,11 @@ small but important:
 3. rolling risk metrics,
 4. historical risk attribution,
 5. concentration analytics,
-6. capability publication,
-7. operational diagnostics.
+6. mandate risk health context,
+7. governed regime scenario-pack evaluation,
+8. risk-event affected-cohort evaluation,
+9. capability publication,
+10. operational diagnostics.
 
 The most important current limits are:
 
@@ -64,8 +67,9 @@ Use:
 4. [Operations Runbook](./Operations-Runbook.md) for health, readiness, and local upstreams,
 5. [Integrations](./Integrations.md) for gateway/downstream contract rules,
 6. [Security and Governance](./Security-and-Governance.md) for contract and supportability discipline,
-7. [RFC Index](./RFC-Index.md) for local decision history,
-8. [Roadmap](./Roadmap.md) for remaining gaps and rollout posture.
+7. [Supported Features](./Supported-Features.md) for implementation-backed support and limits,
+8. [RFC Index](./RFC-Index.md) for local decision history,
+9. [Roadmap](./Roadmap.md) for remaining gaps and rollout posture.
 
 ## Core Commands
 
@@ -81,6 +85,8 @@ docker compose up --build
 
 - `README.md`
 - `REPOSITORY-ENGINEERING-CONTEXT.md`
+- `docs/index.md`
+- `docs/supported-features.md`
 - `docs/domain-apis/endpoint-matrix.md`
 - `docs/domain-apis/risk-product-surface-alignment.md`
 - `docs/operations/live-risk-validation-matrix.md`

--- a/wiki/Integrations.md
+++ b/wiki/Integrations.md
@@ -20,6 +20,9 @@ The main executable risk workflows are:
 3. `POST /analytics/risk/rolling-metrics`
 4. `POST /analytics/risk/historical-attribution`
 5. `POST /analytics/risk/concentration`
+6. `POST /analytics/risk/mandate-health-context`
+7. `POST /analytics/risk/regime-scenario-pack/evaluate`
+8. `POST /analytics/risk/risk-event-cohorts/evaluate`
 
 The main discovery contract is:
 
@@ -39,7 +42,9 @@ This matters because:
 5. regime scenario-pack evaluation is stateless and source-owned by `lotus-risk`,
 6. per-security regime scenario contribution rows are available when callers supply reconciled
    exposure components,
-7. stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups.
+7. risk-event affected-cohort evaluation and mandate risk health context are stateless first-wave
+   products,
+8. stateful `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups.
 
 ## Downstream Preservation Rules
 
@@ -51,7 +56,9 @@ Gateway, Workbench, reporting, and AI consumers must preserve:
 4. concentration-only simulation support,
 5. regime scenario-pack evaluation reason codes and threshold-breach posture,
 6. regime scenario-pack per-security contribution rows when present,
-7. lineage and upstream request-fingerprint metadata.
+7. risk-event affected-cohort source refs and impact scores,
+8. mandate risk health threshold posture and non-claim reason codes,
+9. lineage and upstream request-fingerprint metadata.
 
 If those are dropped or flattened, a numerically correct response can still become product-wrong.
 

--- a/wiki/Overview.md
+++ b/wiki/Overview.md
@@ -10,7 +10,10 @@ It owns the analytics and contract meaning for:
 2. realized drawdown,
 3. rolling historical risk diagnostics,
 4. concentration analytics,
-5. historical risk attribution.
+5. historical risk attribution,
+6. mandate risk health context,
+7. governed regime scenario-pack evaluation,
+8. risk-event affected-cohort evaluation.
 
 ## What Makes This Repo Important
 
@@ -70,15 +73,18 @@ It depends on:
 
 Those boundaries are governed and should stay explicit.
 
-## Current Functional Gap
+## Current Functional Limits
 
-The only material gap inside the current approved API surface is:
+The current approved API surface is implementation-backed but intentionally bounded:
 
-1. broader live portfolio-archetype proof for stateful `ACTIVE_RISK + ISSUER` beyond the canonical baseline.
+1. simulation is concentration-only,
+2. historical attribution is partial even though stateful `ACTIVE_RISK + ISSUER` is supported,
+3. mandate risk health context and risk-event affected cohorts are stateless first-wave products,
+4. live portfolio-archetype proof remains broader-roadmap work beyond the canonical baseline.
 
-That gap is intentionally exposed rather than hidden:
+Those limits are intentionally exposed rather than hidden:
 
-1. request validation rejects it,
+1. request validation rejects unsupported modes and unsupported grouping shapes,
 2. `/integration/capabilities` marks historical attribution as `partial`,
 3. docs describe the gate,
 4. live evidence covers the supported stateful groupings.
@@ -93,4 +99,5 @@ That is the pattern this repo should keep following:
 
 1. use [Architecture](./Architecture.md) for code and endpoint shape,
 2. use [Integrations](./Integrations.md) for downstream contract rules,
-3. use [Roadmap](./Roadmap.md) for remaining rollout and evidence gaps.
+3. use [Supported Features](./Supported-Features.md) for current support and limitations,
+4. use [Roadmap](./Roadmap.md) for remaining rollout and evidence gaps.

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -20,8 +20,11 @@ The current runtime and contract already provide:
 3. full rolling-metrics support for stateless and stateful modes,
 4. full concentration support for stateless, stateful, and simulation modes,
 5. partial historical attribution support with explicit gating,
-6. typed capability publication through `/integration/capabilities`,
-7. readiness and ops diagnostics tied to real dependency posture.
+6. stateless regime scenario-pack evaluation,
+7. stateless risk-event affected-cohort evaluation,
+8. stateless mandate risk health context,
+9. typed capability publication through `/integration/capabilities`,
+10. readiness and ops diagnostics tied to real dependency posture.
 
 ## What Remains Intentionally Bounded
 
@@ -30,7 +33,9 @@ Important current limits:
 1. broaden live portfolio-archetype validation for stateful `ACTIVE_RISK + ISSUER`,
 2. simulation remains concentration-only,
 3. enterprise live-validation breadth remains limited to the canonical portfolio baseline unless more seeded archetypes are registered with evidence,
-4. downstream consumers still need more cross-repo proof that they preserve the risk contract correctly.
+4. mandate health and risk-event cohorts are bounded first-wave source-owned products, not workflow
+   orchestration engines,
+5. downstream consumers still need more cross-repo proof that they preserve the risk contract correctly.
 
 ## Near-Term Focus
 

--- a/wiki/Supported-Features.md
+++ b/wiki/Supported-Features.md
@@ -1,0 +1,47 @@
+# Supported Features
+
+## Current Implementation-Backed Capabilities
+
+| Capability | Primary endpoint | Current status | Business use |
+| --- | --- | --- | --- |
+| Risk metrics | `/analytics/risk/calculate` | full for stateless and stateful modes | Portfolio volatility, drawdown, Sharpe, Sortino, VaR, beta, tracking error, and information-ratio review. |
+| Drawdown analytics | `/analytics/risk/drawdown` | full for stateless and stateful modes | Realized drawdown, underwater period, and recovery analysis. |
+| Rolling risk metrics | `/analytics/risk/rolling-metrics` | full for stateless and stateful modes | Rolling historical risk diagnostics for front-office review. |
+| Concentration risk | `/analytics/risk/concentration` | full for stateless, stateful, and simulation modes | Position, issuer, and HHI concentration review, including what-if simulation support. |
+| Historical attribution | `/analytics/risk/historical-attribution` | partial | Historical total-risk and active-risk decomposition; stateful `ACTIVE_RISK + ISSUER` is supported. |
+| Regime scenario pack | `/analytics/risk/regime-scenario-pack/evaluate` | full stateless | CIO-governed scenario-pack evaluation with threshold posture and optional per-security contribution evidence. |
+| Risk-event affected cohort | `/analytics/risk/risk-event-cohorts/evaluate` | partial stateless first-wave product | Source-owned portfolio membership and impact scores for governed risk events. |
+| Mandate risk health | `/analytics/risk/mandate-health-context` | partial stateless first-wave product | Tracking-error health posture for downstream mandate-management consumption. |
+| Capability publication | `/integration/capabilities` | implemented | Downstream discovery of workflow support, mode support, and support notes. |
+| Operations and observability | `/health`, `/health/ready`, `/ops`, `/metrics` | implemented | Runtime readiness, dependency posture, and bounded Prometheus monitoring. |
+
+## Explicit Limits
+
+1. Simulation is supported only for concentration risk.
+2. `CUSTOM` stateful historical-attribution grouping remains unsupported.
+3. Mandate health context does not create mandate actions, rebalance waves, orders, execution, or
+   client communications.
+4. Risk-event affected cohorts do not create waves, approvals, campaigns, or client communications.
+5. `/ops/trust-telemetry` returns repo-owned raw telemetry seeds; platform certification is a
+   separate `lotus-platform` evidence flow.
+6. Broad enterprise-bank coverage requires seeded portfolio archetype evidence beyond
+   `PB_SG_GLOBAL_BAL_001`.
+
+## Implementation Evidence
+
+Use these sources when a support claim is questioned:
+
+1. `docs/supported-features.md`
+2. `docs/domain-apis/endpoint-matrix.md`
+3. `docs/domain-apis/integration-capabilities.md`
+4. `src/app/services/capability_workflows.py`
+5. `tests/unit/test_capabilities_contract.py`
+6. `tests/unit/test_product_surface_alignment_contract.py`
+7. `tests/unit/test_risk_event_cohort_api.py`
+8. `tests/unit/test_mandate_health_context.py`
+
+## Read Next
+
+1. [Integrations](./Integrations.md) for downstream preservation rules.
+2. [Operations Runbook](./Operations-Runbook.md) for support and readiness checks.
+3. [Roadmap](./Roadmap.md) for planned work and known evidence gaps.

--- a/wiki/Validation-and-CI.md
+++ b/wiki/Validation-and-CI.md
@@ -15,7 +15,11 @@ The repo-native commands are designed to map to those lanes directly.
 - `make check` - fast local gate
 - `make ci` - PR-grade local gate
 - `make quality-baseline` - report-only enterprise refactor baseline and quality scorecard
+- `make mesh-contract-validate` - domain product, trust telemetry, and observability contract validation
 - `make domain-data-product-gate` - repo-native domain product declaration validation
+- `make openapi-gate` - generated schema quality
+- `make openapi-artifact-gate` - generated artifact policy
+- `make api-vocabulary-gate` - API vocabulary inventory validation
 - `make test-unit` - unit suite
 - `make test-integration` - integration suite
 - `make test-e2e` - e2e suite
@@ -31,8 +35,9 @@ The repo-native commands are designed to map to those lanes directly.
 3. typecheck,
 4. OpenAPI quality,
 5. API vocabulary validation,
-6. repo-native domain product declaration validation,
-7. unit-focused default test execution.
+6. mesh contract validation,
+7. source-size regression protection,
+8. unit-focused default test execution.
 
 ## What `make ci` Adds
 
@@ -78,13 +83,13 @@ They protect:
 - `REPOSITORY-ENGINEERING-CONTEXT.md`
 - `quality/baseline_report.md`
 - `quality/quality_scorecard.md`
+- `docs/operations/development-workflow-and-ci-strategy.md`
+- `docs/domain-apis/endpoint-matrix.md`
+- `docs/domain-apis/risk-product-surface-alignment.md`
 
 The active `make source-size-gate` prevents new Python source monoliths above the governed
 450-line ceiling. It runs in local `make check`/`make ci` and the Feature, PR Merge, and Main
 Releasability lanes.
-- `docs/operations/development-workflow-and-ci-strategy.md`
-- `docs/domain-apis/endpoint-matrix.md`
-- `docs/domain-apis/risk-product-surface-alignment.md`
 
 ## Read Next
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -6,6 +6,7 @@
 * [Validation and CI](Validation-and-CI)
 * [Operations Runbook](Operations-Runbook)
 * [Integrations](Integrations)
+* [Supported Features](Supported-Features)
 * [Security and Governance](Security-and-Governance)
 * [RFC Index](RFC-Index)
 * [Roadmap](Roadmap)


### PR DESCRIPTION
## Summary
- Refresh `lotus-risk` README/navigation so the repo front door routes agents, developers, BAs, ops/support, sales/marketing, and business/product users to the right source of truth.
- Add `docs/index.md` and `docs/documentation-gap-ledger.md` for audience-based navigation, gap tracking, validation evidence, and follow-up backlog.
- Align architecture, API, supported-feature, and product-surface docs with the current FastAPI app factory/router layout, source-owned risk products, capability publication, and tests.
- Strengthen operations/runbook guidance for readiness, capability checks, supportability metrics, dependency ownership, and escalation paths.
- Update repo-local `wiki/` source, including a new Supported Features page, while leaving published GitHub wiki publication for the post-merge sync step.

## Why
The docs/wiki surface needed to be more navigable and implementation-backed for mixed audiences without broadening product claims. This PR makes current support, partial support, planned work, operational posture, and ownership boundaries easier to verify from code, tests, contracts, CI, and runbooks.

## Improvements
- Removed stale `live-api-validate*` Makefile targets copied from `lotus-manage`; no matching `lotus-risk` script exists.
- Added risk-event affected-cohort API documentation and fixed endpoint matrix coverage.
- Expanded `docs/supported-features.md` to separate full, partial, planned, backlog, and explicit non-ownership claims.
- Corrected stale Workbench issuer-active-risk guidance to match the current `ACTIVE_RISK + ISSUER` support contract.
- Replaced absolute local links and fixed a migration-doc Markdown link that used raw parentheses.
- Added wiki navigation for implementation-backed supported features and refreshed architecture/integration/roadmap pages.

## Validation
- `python -m pytest tests/unit/test_product_surface_alignment_contract.py tests/unit/test_observability_operations_contract.py tests/unit/test_configuration_docs.py tests/unit/test_final_pr_readiness_evidence.py tests/unit/test_capabilities_contract.py tests/unit/test_risk_event_cohort_api.py tests/unit/test_mandate_health_context.py -q` passed, 29 tests.
- `make mesh-contract-validate` passed.
- `make openapi-gate` passed.
- `make check` passed, including lint, no-alias, typecheck, OpenAPI artifact, API vocabulary, mesh contracts, source-size, and 554 unit tests.
- Markdown local link/path sanity passed across 114 Markdown files.
- `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` ran and reported expected publication drift for repo-authored wiki source changes: `_Sidebar.md`, `Architecture.md`, `Development-Workflow.md`, `Home.md`, `Integrations.md`, `Overview.md`, `Roadmap.md`, `Supported-Features.md`, and `Validation-and-CI.md`.

## Risks
- Published GitHub wiki remains intentionally unsynchronized until after merge, per Lotus wiki governance.
- Broader enterprise-bank support remains bounded by the live validation matrix; no new portfolio-archetype support is claimed.
- No runtime live-validation script was added; `live-api-validate*` targets were removed rather than replaced.

## Follow-up Backlog
- After merge to `main`, publish wiki source with `../lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-risk` and rerun `-CheckOnly`.
- Add a real repo-native live validation script before restoring any `live-api-validate` make target.
- Add seeded portfolio IDs and evidence for pending live-validation archetypes before broadening enterprise-bank claims.
- Attach cross-repo gateway and Workbench consumer proof whenever downstream risk semantics are promoted.