### PR TITLE
Record lotus-risk wiki publication truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,5 +261,5 @@ Platform governance:
 
 The canonical authored source for the repository wiki lives under `wiki/` in this repository.
 
-If a GitHub wiki is published later, treat `wiki/` as the authored source and any separate
-`*.wiki.git` clone only as publication plumbing.
+The published GitHub wiki is synchronized from this repo-local source. Treat any separate
+`*.wiki.git` clone only as publication plumbing, not as an authored source.

--- a/REPOSITORY-ENGINEERING-CONTEXT.md
+++ b/REPOSITORY-ENGINEERING-CONTEXT.md
@@ -242,7 +242,10 @@ Most relevant current governance:
 5. live validation defaults to `PB_SG_GLOBAL_BAL_001`; do not claim broader enterprise portfolio-archetype coverage until `docs/operations/live-risk-validation-matrix.md` has real seeded portfolio IDs and evidence,
 6. stateful historical attribution `ACTIVE_RISK + ISSUER` is supported through lotus-performance benchmark exposure context issuer groups introduced in lotus-performance PR #165,
 7. transport optimization across upstream services should start with contract and retrieval-shape evidence before any gRPC proposal,
-8. `wiki/` inside the repository is the authored documentation source if a GitHub wiki is published later,
+8. `wiki/` inside the repository is the authored documentation source for the published GitHub
+   wiki; use `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk`
+   before merge and `../lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository
+   lotus-risk` after merge when repo-local wiki truth changes,
 9. RFC-0087 preparation should reuse repo-owned readiness, observability, and lineage signals before introducing any new trust publication surface.
 
 ## Context Maintenance Rule

--- a/docs/documentation-gap-ledger.md
+++ b/docs/documentation-gap-ledger.md
@@ -31,4 +31,6 @@ for each item. Keep it current when docs, wiki, or repo truth materially change.
 | `make mesh-contract-validate` | Passed |
 | `make openapi-gate` | Passed |
 | `make check` | Passed; includes lint, no-alias, typecheck, OpenAPI artifact, API vocabulary, mesh contracts, source-size, and 554 unit tests |
-| `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` | Ran; reported expected publication drift for repo-authored wiki source changes: `_Sidebar.md`, `Architecture.md`, `Development-Workflow.md`, `Home.md`, `Integrations.md`, `Overview.md`, `Roadmap.md`, `Supported-Features.md`, and `Validation-and-CI.md` |
+| `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` before merge | Ran; reported expected publication drift for repo-authored wiki source changes: `_Sidebar.md`, `Architecture.md`, `Development-Workflow.md`, `Home.md`, `Integrations.md`, `Overview.md`, `Roadmap.md`, `Supported-Features.md`, and `Validation-and-CI.md` |
+| `../lotus-platform/automation/Sync-RepoWikis.ps1 -Publish -Repository lotus-risk` after merge | Passed; published wiki commit `955d4ca` from repo source |
+| `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` after publish | Passed; `DiffCount 0` |


### PR DESCRIPTION
## Summary
- Record post-merge wiki publication truth in the documentation gap ledger.
- Update README wiki wording now that the GitHub wiki is published and synchronized from repo-local `wiki/`.
- Update `REPOSITORY-ENGINEERING-CONTEXT.md` with the current wiki publication workflow for future agents.

## Why
PR #151 published the `lotus-risk` wiki after merge, but a few durable docs still described the wiki as future-state or only recorded pre-merge publication drift. This keeps agent context and docs aligned with current repo truth.

## Validation
- Markdown/context local link sanity passed across 115 files.
- `../lotus-platform/automation/Sync-RepoWikis.ps1 -CheckOnly -Repository lotus-risk` passed with `DiffCount 0`.
- `python -m pytest tests/unit/test_final_pr_readiness_evidence.py tests/unit/test_configuration_docs.py -q` passed, 7 tests.

## Risk
Docs-only cleanup. No runtime, API, contract, or wiki source content changes.