### PR TITLE
Fix canonical risk environment file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
     ports:
       - "8130:8130"
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-control.dev.lotus:8202}
       LOTUS_PERFORMANCE_BASE_URL: ${LOTUS_PERFORMANCE_BASE_URL:-http://performance.dev.lotus:8002}

--- a/tests/unit/test_local_docker_runtime_contract.py
+++ b/tests/unit/test_local_docker_runtime_contract.py
@@ -4,6 +4,8 @@ from pathlib import Path
 def test_local_docker_compose_sets_explicit_upstream_urls() -> None:
     compose_text = Path("docker-compose.yml").read_text(encoding="utf-8")
 
+    assert "path: .env" in compose_text
+    assert "required: false" in compose_text
     assert (
         "LOTUS_CORE_BASE_URL: ${LOTUS_CORE_BASE_URL:-http://core-control.dev.lotus:8202}"
         in compose_text


### PR DESCRIPTION
## Summary
- align lotus-risk canonical local environment file behavior for governed demo stack bring-up

## Evidence
- Remote Feature Lane: https://github.com/sgajbi/lotus-risk/actions/runs/27684580265
- Quality Baseline: https://github.com/sgajbi/lotus-risk/actions/runs/27684580255
- Live canonical Workbench validation passed for PB_SG_GLOBAL_BAL_001 after the platform demo stack fixes

## Risk
- Scoped to environment-file correctness for canonical local validation.