### PR TITLE
Improve risk runtime request observability logs

### DIFF
--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 import re
 import time
@@ -17,11 +18,21 @@ _SAFE_TRACEPARENT = re.compile(
 )
 
 
+def _ensure_request_event_logger(logger: logging.Logger) -> None:
+    logger.setLevel(logging.INFO)
+    if logger.handlers or logging.getLogger().handlers:
+        return
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+
+
 class CorrelationIdMiddleware(BaseHTTPMiddleware):
     def __init__(self, app: ASGIApp, service_name: str) -> None:
         super().__init__(app)
         self._service_name = service_name
         self._event_logger = logging.getLogger("lotus_risk.request")
+        _ensure_request_event_logger(self._event_logger)
 
     @staticmethod
     def _resolve_trace_id(inbound_trace_id: str | None, traceparent: str | None) -> str:
@@ -71,19 +82,22 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
         response.headers["traceparent"] = traceparent
         response.headers["X-Service-Name"] = self._service_name
         response.headers["X-Request-Duration-Ms"] = f"{duration_ms:.3f}"
+        request_observation = {
+            "service": self._service_name,
+            "method": request.method,
+            "path": request.url.path,
+            "status_code": response.status_code,
+            "correlation_id": correlation_id,
+            "trace_id": trace_id,
+            "latency_ms": round(duration_ms, 3),
+            "risk": True,
+        }
         self._event_logger.info(
-            "request_observed",
-            extra={
-                "request_observation": {
-                    "service": self._service_name,
-                    "method": request.method,
-                    "path": request.url.path,
-                    "status_code": response.status_code,
-                    "correlation_id": correlation_id,
-                    "trace_id": trace_id,
-                    "latency_ms": round(duration_ms, 3),
-                    "risk": True,
-                }
-            },
+            json.dumps(
+                {"message": "request_observed", **request_observation},
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+            extra={"request_observation": request_observation},
         )
         return response

--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -19,7 +19,7 @@ _SAFE_TRACEPARENT = re.compile(
 
 
 def _ensure_request_event_logger(logger: logging.Logger) -> None:
-    if logger.handlers or logging.getLogger().handlers:
+    if logger.hasHandlers():
         return
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()

--- a/src/app/middleware/correlation.py
+++ b/src/app/middleware/correlation.py
@@ -19,9 +19,9 @@ _SAFE_TRACEPARENT = re.compile(
 
 
 def _ensure_request_event_logger(logger: logging.Logger) -> None:
-    logger.setLevel(logging.INFO)
     if logger.handlers or logging.getLogger().handlers:
         return
+    logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter("%(message)s"))
     logger.addHandler(handler)

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import Any, cast
 from unittest.mock import patch
@@ -6,7 +7,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from app.middleware.correlation import CorrelationIdMiddleware
+from app.middleware.correlation import CorrelationIdMiddleware, _ensure_request_event_logger
 
 
 def _correlation_app() -> FastAPI:
@@ -103,6 +104,21 @@ def test_correlation_middleware_does_not_reflect_unsafe_context_headers() -> Non
     assert response.headers["traceparent"] != "malformed"
 
 
+def test_request_event_logger_adds_runtime_handler_without_root_logging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = logging.getLogger("lotus_risk.request.test_runtime_handler")
+    logger.handlers.clear()
+    monkeypatch.setattr(logging.getLogger(), "handlers", [])
+
+    _ensure_request_event_logger(logger)
+
+    try:
+        assert any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers)
+    finally:
+        logger.handlers.clear()
+
+
 def test_correlation_middleware_emits_bounded_structured_request_event(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -116,11 +132,18 @@ def test_correlation_middleware_emits_bounded_structured_request_event(
 
     assert response.status_code == 200
     event = cast(dict[str, Any], getattr(caplog.records[-1], "request_observation"))
+    log_payload = json.loads(caplog.records[-1].getMessage())
     assert event["service"] == "lotus-risk"
     assert event["method"] == "GET"
     assert event["path"] == "/ping"
     assert event["status_code"] == 200
     assert event["correlation_id"] == "corr-structured"
     assert event["risk"] is True
+    assert log_payload["message"] == "request_observed"
+    assert log_payload["service"] == "lotus-risk"
+    assert log_payload["correlation_id"] == "corr-structured"
+    assert log_payload["risk"] is True
     assert "client_secret" not in str(event)
     assert "do-not-log" not in str(event)
+    assert "client_secret" not in caplog.records[-1].getMessage()
+    assert "do-not-log" not in caplog.records[-1].getMessage()

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -107,7 +107,7 @@ def test_correlation_middleware_does_not_reflect_unsafe_context_headers() -> Non
 def test_request_event_logger_adds_runtime_handler_without_root_logging(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    logger = logging.getLogger("lotus_risk.request.test_runtime_handler")
+    logger = logging.getLogger("lotus_risk_unconfigured.request.test_runtime_handler")
     logger.handlers.clear()
     monkeypatch.setattr(logging.getLogger(), "handlers", [])
 
@@ -119,8 +119,8 @@ def test_request_event_logger_adds_runtime_handler_without_root_logging(
         logger.handlers.clear()
 
 
-def test_request_event_logger_preserves_configured_level_when_logging_exists() -> None:
-    logger = logging.getLogger("lotus_risk.request.test_configured_level")
+def test_request_event_logger_preserves_configured_level_when_root_logging_exists() -> None:
+    logger = logging.getLogger("lotus_risk.request.test_configured_root_level")
     root_logger = logging.getLogger()
     root_handler = logging.NullHandler()
     logger.handlers.clear()
@@ -135,6 +135,28 @@ def test_request_event_logger_preserves_configured_level_when_logging_exists() -
         assert logger.handlers == []
     finally:
         root_logger.removeHandler(root_handler)
+        logger.setLevel(original_level)
+
+
+def test_request_event_logger_honors_parent_logger_handlers() -> None:
+    parent_logger = logging.getLogger("lotus_risk.request_parent_configured")
+    logger = logging.getLogger("lotus_risk.request_parent_configured.child")
+    parent_handler = logging.NullHandler()
+    parent_logger.handlers.clear()
+    logger.handlers.clear()
+    original_parent_level = parent_logger.level
+    original_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    parent_logger.addHandler(parent_handler)
+
+    _ensure_request_event_logger(logger)
+
+    try:
+        assert logger.level == logging.DEBUG
+        assert logger.handlers == []
+    finally:
+        parent_logger.removeHandler(parent_handler)
+        parent_logger.setLevel(original_parent_level)
         logger.setLevel(original_level)
 
 

--- a/tests/unit/test_correlation_middleware.py
+++ b/tests/unit/test_correlation_middleware.py
@@ -119,6 +119,25 @@ def test_request_event_logger_adds_runtime_handler_without_root_logging(
         logger.handlers.clear()
 
 
+def test_request_event_logger_preserves_configured_level_when_logging_exists() -> None:
+    logger = logging.getLogger("lotus_risk.request.test_configured_level")
+    root_logger = logging.getLogger()
+    root_handler = logging.NullHandler()
+    logger.handlers.clear()
+    original_level = logger.level
+    logger.setLevel(logging.WARNING)
+    root_logger.addHandler(root_handler)
+
+    _ensure_request_event_logger(logger)
+
+    try:
+        assert logger.level == logging.WARNING
+        assert logger.handlers == []
+    finally:
+        root_logger.removeHandler(root_handler)
+        logger.setLevel(original_level)
+
+
 def test_correlation_middleware_emits_bounded_structured_request_event(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary
- Emit bounded JSON request-observation events from the risk correlation middleware so Docker/runtime logs expose correlation, trace, service, latency, and risk markers.
- Add a runtime logging bridge only when no process-level handler exists, preserving existing configured logging behavior.
- Extend middleware tests for JSON payload shape, redaction safety, and runtime handler wiring.

## Evidence
- `make check` passed: ruff, format check, monetary float guard, no-alias guard, mypy, OpenAPI quality/export, API vocabulary, domain data product, trust telemetry, observability contract, source-size gate, and `555 passed` unit tests.
- Rebuilt runtime: `docker compose up -d --build lotus-risk`.
- Live log proof: `docker logs lotus-risk-lotus-risk-1` contains `request_observed` JSON with `correlation_id`, `service: lotus-risk`, and `risk: true`.
- Platform QA rerun from lotus-platform passed with 0 findings: `output/qa/20260618-demo-readiness-platform-qa-green-candidate/20260618-045802/qa-summary.md`.

## Risk
- Behavior-preserving for API responses; changes runtime log formatting for the request-observation event from plain message plus extra fields to bounded JSON message plus retained extra fields.